### PR TITLE
Add strict databuilder export bridge

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,3 +40,7 @@ DATASET_OUTPUT_DIR=./exports/short-finnish-responses/v1
 # Optional override. Leave empty to derive from local storage or S3 config.
 DATASET_AUDIO_ROOT=
 DATASET_SPEAKER_HASH_SALT=change-me-before-real-export
+
+# Compatibility export for audio-classifier databuilder.
+DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v1/databuilder
+DATABUILDER_MANIFEST_VERSION=20260501001

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ volunteer browser
      - AWS S3 in production-like mode
   -> exportDataset.js
   -> metadata/dataset.json + metadata/samples.jsonl
-  -> audio-classifier loader
+  -> exportDatabuilderDataset.js
+  -> databuilder/manifest.json + databuilder/<sample_id>.wav + databuilder/<sample_id>.json
+  -> audio-classifier databuilder
 ```
 
 ## What Changed In This Fork
@@ -97,6 +99,9 @@ DATASET_TASK=short_response_classification
 DATASET_OUTPUT_DIR=./exports/short-finnish-responses/v1
 DATASET_AUDIO_ROOT=
 DATASET_SPEAKER_HASH_SALT=change-me-before-real-export
+
+DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v1/databuilder
+DATABUILDER_MANIFEST_VERSION=20260501001
 ```
 
 Notes:
@@ -107,6 +112,8 @@ Notes:
 - In S3 mode it is used only as a temporary processing area.
 - `COLLECTION_AUDIO_PREFIX` defines the permanent object-key prefix in S3.
 - `DATASET_AUDIO_ROOT` is optional. If empty, export derives the correct storage root from local mode or AWS S3 settings.
+- `DATABUILDER_OUTPUT_DIR` is the optional output directory for the audio-classifier databuilder compatibility package.
+- `DATABUILDER_MANIFEST_VERSION` controls the flat databuilder `manifest.json` version field.
 - `VITE_MAX_RECORDING_SECONDS` controls the frontend auto-stop timer. `MAX_RECORDING_SECONDS` plus `MAX_RECORDING_DURATION_TOLERANCE_SECONDS` is the backend duration limit.
 - `MAX_UPLOAD_BYTES` limits multipart audio upload size before storage.
 - Leave `VITE_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` empty for local development. Configure both for public collection.
@@ -271,7 +278,7 @@ This keeps `dataset.json.audio_root` and every sample `audio_path` loader-compat
 
 ## Export Dataset
 
-After recordings exist, export manifests with:
+After recordings exist, export the normal collector dataset manifests with:
 
 ```bash
 pnpm run aina:export
@@ -298,7 +305,42 @@ Export behavior:
 - hashes the anonymous browser `device_id` into stable `speaker_id`
 - references permanent storage directly
 
+This export remains the collector-native contract. It does not copy audio into the export folder.
+
+## Export Databuilder Package
+
+The current `audio-classifier` `feature/databuilder` branch expects a flat cache package, so the collector also provides a compatibility bridge:
+
+```bash
+pnpm run aina:export:databuilder
+```
+
+Default output:
+
+```text
+exports/short-finnish-responses/v1/databuilder/
+  manifest.json
+  <sample_id>.wav
+  <sample_id>.json
+```
+
+Databuilder export behavior:
+
+- keeps `pnpm run aina:export` unchanged
+- filters rows to the active `STORAGE` backend, like the normal exporter
+- exports only classifier-ready recordings with `processed_audio` set to WAV PCM 16-bit, 16 kHz, mono
+- skips legacy recordings where `processed_audio` is missing, null, or different from the classifier-ready format
+- fails clearly when no classifier-ready recordings remain
+- uses `recordings.id` as `sample_id`, the file basename, and the manifest key
+- copies local audio or downloads S3 audio into `<sample_id>.wav`
+- writes root-level sidecar JSON because databuilder filters use paths such as `demographics.native_language`
+- writes MD5 hashes for the exact WAV and JSON bytes in `manifest.json`
+
+Generated exports and audio files are ignored by Git and should not be committed.
+
 ## Validate Against audio-classifier
+
+For the databuilder package, see [docs/databuilder-export.md](docs/databuilder-export.md).
 
 ```bash
 cd D:\ass_vscode\AIN\packages\audio-classifier
@@ -338,6 +380,7 @@ If you only need more test sessions and want to keep the existing prompt copies,
 - [docs/aina-refactor-plan.md](docs/aina-refactor-plan.md)
 - [docs/aina-s3-integration.md](docs/aina-s3-integration.md)
 - [docs/aina-data-contract.md](docs/aina-data-contract.md)
+- [docs/databuilder-export.md](docs/databuilder-export.md)
 - [docs/database-structure.md](docs/database-structure.md)
 - [docs/database-setup.md](docs/database-setup.md)
 - [docs/dev-reset-session-data.sql](docs/dev-reset-session-data.sql)

--- a/backend/src/fileStorage.js
+++ b/backend/src/fileStorage.js
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3';
+import { pipeline } from 'stream/promises';
+import { S3Client, PutObjectCommand, GetObjectCommand } from '@aws-sdk/client-s3';
 import ffmpeg from 'fluent-ffmpeg';
 import ffmpegPath from 'ffmpeg-static';
 import ffprobe from 'ffprobe-static';
@@ -173,6 +174,32 @@ export class FileStorage {
     );
 
     return response;
+  }
+
+  async downloadObject(objectKey, destinationPath, options = {}) {
+    if (!this.s3Client) {
+      throw new Error('Remote download is only available for S3-compatible storage.');
+    }
+
+    const bucketName = options.bucketName || this.bucketName;
+    if (!bucketName) {
+      throw new Error('Bucket name is required to download a storage object.');
+    }
+
+    ensureDirectory(path.dirname(destinationPath));
+    const response = await this.s3Client.send(
+      new GetObjectCommand({
+        Bucket: bucketName,
+        Key: objectKey,
+      })
+    );
+
+    if (!response.Body) {
+      throw new Error(`Storage object ${objectKey} did not include a response body.`);
+    }
+
+    await pipeline(response.Body, fs.createWriteStream(destinationPath));
+    return destinationPath;
   }
 
   async saveRecording(file, { sessionId, taskId }) {

--- a/docs/aina-data-contract.md
+++ b/docs/aina-data-contract.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-`schema_version = "v1"` is the first stable contract between the browser collector, backend storage, and the audio-classifier dataset loader. The collector stores live data safely as PostgreSQL rows plus audio files in local storage or S3-compatible storage. The final classifier handoff is produced later by `scripts/aina/exportDataset.js`.
+`schema_version = "v1"` is the first stable contract between the browser collector, backend storage, and downstream dataset tooling. The collector stores live data safely as PostgreSQL rows plus audio files in local storage or S3-compatible storage. The normal collector export is produced by `scripts/aina/exportDataset.js`. The current audio-classifier databuilder receives a separate compatibility bridge from `scripts/aina/exportDatabuilderDataset.js`.
 
-The frontend must not append directly to a shared `samples.jsonl` file. Public volunteers can upload at the same time, and concurrent appends to one shared manifest can corrupt data. Each upload is stored as one database recording row plus one audio object/file, then the exporter creates `metadata/dataset.json` and `metadata/samples.jsonl`.
+The frontend must not append directly to a shared `samples.jsonl` file. Public volunteers can upload at the same time, and concurrent appends to one shared manifest can corrupt data. Each upload is stored as one database recording row plus one audio object/file, then exporters create derived handoff files.
 
 ## Live Storage Model
 
@@ -116,7 +116,7 @@ The frontend auto-stops recordings after `VITE_MAX_RECORDING_SECONDS`, defaultin
 
 Turnstile is a session-start gate only. When `TURNSTILE_SECRET_KEY` is configured, `/api/start-session` requires and verifies a Turnstile token before creating or resuming a session. When the secret is empty, local development bypasses Turnstile.
 
-## Export Output
+## Collector Export Output
 
 `scripts/aina/exportDataset.js` writes:
 
@@ -195,6 +195,96 @@ Example exported row:
 
 `label` remains an alias of `normalized_label` for the current audio-classifier loader. `speaker_id` is stable for the same browser `device_id` and is hashed with `DATASET_SPEAKER_HASH_SALT` during export.
 
+## Databuilder Compatibility Export
+
+`scripts/aina/exportDatabuilderDataset.js` is an additional bridge for the current `audio-classifier` `feature/databuilder` package layout. It does not replace the collector export above.
+
+It writes:
+
+```text
+exports/short-finnish-responses/v1/databuilder/
+  manifest.json
+  <sample_id>.wav
+  <sample_id>.json
+```
+
+The output directory and manifest version can be configured with:
+
+```env
+DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v1/databuilder
+DATABUILDER_MANIFEST_VERSION=20260501001
+```
+
+`sample_id` is always `recordings.id`, and the same value is used as:
+
+- the manifest key
+- the WAV basename
+- the sidecar JSON basename
+- the sidecar `sample_id` field
+
+The manifest format is:
+
+```json
+{
+  "version": "20260501001",
+  "hash_algorithm": "md5",
+  "samples": {
+    "recording-uuid": {
+      "wav_hash": "md5-of-written-wav",
+      "json_hash": "md5-of-written-json"
+    }
+  }
+}
+```
+
+The MD5 hashes are computed from the exact files written into the databuilder output directory.
+
+Each `<sample_id>.json` sidecar is root-level for fields used by classifier filters:
+
+```json
+{
+  "sample_id": "recording-uuid",
+  "timestamp": "2026-05-03T12:00:00.000Z",
+  "prompted_word": "Kyll??",
+  "normalized_label": "kylla",
+  "literal_transcript": null,
+  "label_source": "prompt_assumed",
+  "language": "fi",
+  "category": "affirmative",
+  "augmentation_strategy": null,
+  "augmentations": [],
+  "device_id": "dev_ab12cd34ef56",
+  "speaker_id": "spk_ab12cd34ef56",
+  "duration_sec": 0.82,
+  "demographics": {},
+  "environment": {},
+  "technical": {},
+  "processed_audio": {
+    "sample_rate_hz": 16000,
+    "channel_count": 1,
+    "encoding": "pcm_s16le"
+  },
+  "collection": {},
+  "storage": {}
+}
+```
+
+The sidecar keeps `demographics`, `environment`, `technical`, `processed_audio`, and `category` at the root because audio-classifier filters use dotted paths such as `demographics.native_language` and `technical.sample_rate_hz`, not `metadata.demographics.native_language`.
+
+In local storage mode, the bridge copies the stored audio file to `<sample_id>.wav`. In S3 mode, it downloads the stored object and writes it as `<sample_id>.wav`. Live collection still uses PostgreSQL plus local/S3 audio storage; the databuilder package is a generated handoff artifact and should not be committed.
+
+The databuilder export is strict by default. It exports only classifier-ready recordings whose `recording.metadata.processed_audio` is exactly:
+
+```json
+{
+  "sample_rate_hz": 16000,
+  "channel_count": 1,
+  "encoding": "pcm_s16le"
+}
+```
+
+Old recordings collected before the processed-audio fix may not contain `processed_audio` or may point to 48 kHz audio. Those recordings are skipped by the databuilder bridge so they cannot enter the classifier cache by accident. If no classifier-ready recordings remain, the databuilder export fails and asks for fresh samples or explicit legacy reprocessing.
+
 ## Classifier Handoff Notes
 
 - Train on `normalized_label` or its compatibility alias `label`.
@@ -202,3 +292,5 @@ Example exported row:
 - Treat `literal_transcript` as optional metadata, not the default target label.
 - `sample_id` is the UUID from `recordings.id`.
 - Export filters recordings by the active `STORAGE` setting so one manifest does not mix local and S3 audio roots.
+- Use `scripts/aina/exportDataset.js` for the collector-native `dataset.json + samples.jsonl` export.
+- Use `scripts/aina/exportDatabuilderDataset.js` when the current audio-classifier databuilder needs `manifest.json + <sample_id>.wav + <sample_id>.json`.

--- a/docs/databuilder-export.md
+++ b/docs/databuilder-export.md
@@ -1,0 +1,132 @@
+# Databuilder Export Bridge
+
+## Purpose
+
+The normal Speech Collector export remains:
+
+```text
+exports/short-finnish-responses/v1/
+  metadata/
+    dataset.json
+    samples.jsonl
+```
+
+The current `audio-classifier` `feature/databuilder` branch expects a different flat package, so Speech Collector adds a separate compatibility export:
+
+```text
+exports/short-finnish-responses/v1/databuilder/
+  manifest.json
+  <sample_id>.wav
+  <sample_id>.json
+```
+
+This bridge is generated from PostgreSQL metadata plus local/S3 audio storage. The frontend still never appends to a shared JSONL file.
+
+## Command
+
+```bash
+pnpm run aina:export:databuilder
+```
+
+Optional settings:
+
+```env
+DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v1/databuilder
+DATABUILDER_MANIFEST_VERSION=20260501001
+```
+
+Generated databuilder outputs contain audio and should not be committed.
+
+## Storage Behavior
+
+The bridge filters rows by the active `STORAGE` value, matching `scripts/aina/exportDataset.js`.
+
+It also filters out recordings that are not classifier-ready. A row is exported only when `recording.metadata.processed_audio` is exactly:
+
+```json
+{
+  "sample_rate_hz": 16000,
+  "channel_count": 1,
+  "encoding": "pcm_s16le"
+}
+```
+
+Rows with missing, null, or different `processed_audio` values are treated as legacy recordings and skipped. If no classifier-ready rows remain, the export fails with:
+
+```text
+No classifier-ready recordings found. Record fresh samples after the 16 kHz processed-audio fix or reprocess legacy audio.
+```
+
+In `STORAGE=local`, it copies the existing stored audio from `SOUND_RECORDINGS_PATH` and writes it as `<sample_id>.wav`.
+
+In `STORAGE=aws-s3`, it downloads the stored object using row metadata such as `metadata.storage.object_key`, `metadata.storage.bucket_name`, `storage_key`, `AWS_BUCKET_NAME`, and `COLLECTION_AUDIO_PREFIX`, then writes it as `<sample_id>.wav`.
+
+No AWS credentials are exposed to the frontend.
+
+## Sidecar Shape
+
+Each `<sample_id>.json` sidecar is root-level:
+
+```json
+{
+  "sample_id": "recording-uuid",
+  "timestamp": "submitted_at",
+  "prompted_word": "Kylla",
+  "normalized_label": "kylla",
+  "literal_transcript": null,
+  "label_source": "prompt_assumed",
+  "language": "fi",
+  "category": "affirmative",
+  "augmentation_strategy": null,
+  "augmentations": [],
+  "device_id": "dev_...",
+  "speaker_id": "spk_...",
+  "duration_sec": 0.82,
+  "demographics": {},
+  "environment": {},
+  "technical": {},
+  "processed_audio": {
+    "sample_rate_hz": 16000,
+    "channel_count": 1,
+    "encoding": "pcm_s16le"
+  },
+  "collection": {},
+  "storage": {}
+}
+```
+
+It is flat because audio-classifier filters use dotted paths like `demographics.native_language`, `environment.noise_level`, and `technical.sample_rate_hz`.
+
+`literal_transcript`, `augmentation_strategy`, and `augmentations` always exist. Original recordings use `augmentation_strategy: null` and `augmentations: []`.
+
+Older recordings collected before the processed-audio fix may not contain `processed_audio`; those sidecars keep the root-level key with `null`.
+
+## Manifest
+
+`manifest.json` uses:
+
+```json
+{
+  "version": "20260501001",
+  "hash_algorithm": "md5",
+  "samples": {
+    "recording-uuid": {
+      "wav_hash": "...",
+      "json_hash": "..."
+    }
+  }
+}
+```
+
+Hashes are computed from the exact WAV and JSON bytes written into the databuilder output directory.
+
+## Local Databuilder Smoke Test
+
+The current databuilder can be smoke-tested directly against the generated directory as a local cache:
+
+```powershell
+cd D:\ass_vscode\AIN\tmp\audio-classifier-audit
+python -c "import sys; sys.path.insert(0, 'src'); from pathlib import Path; from databuilder.builder import build_dataset; from databuilder.config import Config, SourceConfig, CacheDirConfig, DatasetConfig, FiltersConfig, AugmentationsConfig; cache=Path(r'D:\ass_vscode\AIN\apps\speech-collector\exports\short-finnish-responses\v1\databuilder'); out=cache.parent / 'databuilder-smoke-dataset'; cfg=Config(source=SourceConfig(endpoint_url='local', bucket='local', prefix='local'), cache_dir=CacheDirConfig(path=cache), dataset=DatasetConfig(path=out, clear=True), filters=FiltersConfig(include={}, exclude={}), augmentations=AugmentationsConfig()); print(build_dataset(cfg))"
+```
+
+That check verifies that the classifier can read `manifest.json`, find each `<sample_id>.wav` and `<sample_id>.json`, validate that sidecar `sample_id` equals the manifest key, and write its local dataset output.

--- a/package.json
+++ b/package.json
@@ -8,10 +8,11 @@
     "dev:frontend": "dotenv -e ./.env -- pnpm --filter sound-collector-frontend dev",
     "dev": "concurrently \"pnpm run dev:backend\" \"pnpm run dev:frontend\"",
     "build": "dotenv -e ./.env -- pnpm --filter sound-collector-frontend build",
-    "test:backend": "dotenv -e ./.env -- node --test backend/src/config.test.js backend/src/taskProvider.test.js backend/src/fileStorage.test.js backend/src/index.test.js scripts/aina/exportDataset.test.js",
+    "test:backend": "dotenv -e ./.env -- node --test backend/src/config.test.js backend/src/taskProvider.test.js backend/src/fileStorage.test.js backend/src/index.test.js scripts/aina/exportDataset.test.js scripts/aina/exportDatabuilderDataset.test.js",
     "serve": "concurrently \"pnpm run dev:backend\" \"pnpm --filter sound-collector-frontend serve\"",
     "aina:seed": "dotenv -e ./.env -- node scripts/aina/pushPrompts.js scripts/aina/short_finnish_prompts.json",
-    "aina:export": "dotenv -e ./.env -- node scripts/aina/exportDataset.js"
+    "aina:export": "dotenv -e ./.env -- node scripts/aina/exportDataset.js",
+    "aina:export:databuilder": "dotenv -e ./.env -- node scripts/aina/exportDatabuilderDataset.js"
   },
   "devDependencies": {
     "concurrently": "^9.0.1",

--- a/scripts/aina/exportDatabuilderDataset.js
+++ b/scripts/aina/exportDatabuilderDataset.js
@@ -1,0 +1,444 @@
+import { config } from 'dotenv';
+import { createHash } from 'crypto';
+import { copyFileSync, readdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  configValue,
+  createDbClient,
+  ensureDirectory,
+  expireStaleSessions,
+  fetchCompletedRows,
+  filterRowsForActiveStorage,
+  getActiveStorageType,
+  getDurationSec,
+  pseudonymizeDeviceId,
+  pseudonymizeSpeaker,
+} from './exportDataset.js';
+import {
+  getCollectionAudioPrefix,
+  getSoundRecordingsRoot,
+  normalizeStorageKey,
+} from '../../backend/src/config.js';
+import { FileStorage } from '../../backend/src/fileStorage.js';
+
+const DEFAULT_DATABUILDER_OUTPUT_DIR = './exports/short-finnish-responses/v1/databuilder';
+const DEFAULT_DATABUILDER_MANIFEST_VERSION = '20260501001';
+export const NO_CLASSIFIER_READY_RECORDINGS_MESSAGE =
+  'No classifier-ready recordings found. Record fresh samples after the 16 kHz processed-audio fix or reprocess legacy audio.';
+
+const EXPECTED_PROCESSED_AUDIO = {
+  sample_rate_hz: 16000,
+  channel_count: 1,
+  encoding: 'pcm_s16le',
+};
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeOptionalString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeTimestamp(value) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (typeof value === 'string' && value.trim()) {
+    return value.trim();
+  }
+
+  return null;
+}
+
+function assertSafeSampleId(sampleId) {
+  if (!sampleId || typeof sampleId !== 'string') {
+    throw new Error('recordings.id is required for databuilder export sample_id.');
+  }
+
+  if (sampleId.includes('/') || sampleId.includes('\\')) {
+    throw new Error(`Unsafe sample_id for databuilder export: ${sampleId}`);
+  }
+
+  return sampleId;
+}
+
+function assertPathInside(rootPath, targetPath) {
+  const relativePath = path.relative(rootPath, targetPath);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Refusing to read audio outside the local recordings root: ${targetPath}`);
+  }
+}
+
+function normalizeStorageObjectKey(objectKey) {
+  return normalizeStorageKey(objectKey);
+}
+
+function inferRemoteObjectKey(row, recordingMetadata) {
+  const storageMetadata = isPlainObject(recordingMetadata.storage) ? recordingMetadata.storage : {};
+  const explicitObjectKey =
+    normalizeOptionalString(storageMetadata.object_key) ||
+    normalizeOptionalString(recordingMetadata.object_key);
+
+  if (explicitObjectKey) {
+    return normalizeStorageObjectKey(explicitObjectKey);
+  }
+
+  const storageKey = normalizeStorageObjectKey(row.storage_key);
+  const prefix = getCollectionAudioPrefix();
+
+  if (!prefix || storageKey === prefix || storageKey.startsWith(`${prefix}/`)) {
+    return storageKey;
+  }
+
+  return normalizeStorageKey(prefix, storageKey);
+}
+
+function getBucketName(row, recordingMetadata) {
+  const storageMetadata = isPlainObject(recordingMetadata.storage) ? recordingMetadata.storage : {};
+  const explicitBucketName =
+    normalizeOptionalString(storageMetadata.bucket_name) ||
+    normalizeOptionalString(recordingMetadata.bucket_name);
+
+  if (explicitBucketName) {
+    return explicitBucketName;
+  }
+
+  if (row.storage_type === 'aws-s3') {
+    return normalizeOptionalString(process.env.AWS_BUCKET_NAME);
+  }
+
+  if (row.storage_type === 'r2') {
+    return normalizeOptionalString(process.env.CF_R2_BUCKET_NAME);
+  }
+
+  return null;
+}
+
+export function getDatabuilderOutputDir() {
+  return path.resolve(configValue('DATABUILDER_OUTPUT_DIR', DEFAULT_DATABUILDER_OUTPUT_DIR));
+}
+
+export function getDatabuilderManifestVersion() {
+  return configValue('DATABUILDER_MANIFEST_VERSION', DEFAULT_DATABUILDER_MANIFEST_VERSION);
+}
+
+export function getDatabuilderSampleId(row) {
+  return assertSafeSampleId(row.recording_id);
+}
+
+export function getDatabuilderStorageInfo(row) {
+  const recordingMetadata = isPlainObject(row.recording_metadata) ? row.recording_metadata : {};
+  const storageType = normalizeOptionalString(row.storage_type) || 'unknown';
+  const storageKey = normalizeStorageObjectKey(row.storage_key);
+  const objectKey =
+    storageType === 'local' ? storageKey : inferRemoteObjectKey(row, recordingMetadata);
+
+  return {
+    storage_type: storageType,
+    storage_key: storageKey,
+    object_key: objectKey || null,
+    bucket_name: getBucketName(row, recordingMetadata),
+  };
+}
+
+export function isClassifierReadyProcessedAudio(processedAudio) {
+  return (
+    isPlainObject(processedAudio) &&
+    processedAudio.sample_rate_hz === EXPECTED_PROCESSED_AUDIO.sample_rate_hz &&
+    processedAudio.channel_count === EXPECTED_PROCESSED_AUDIO.channel_count &&
+    processedAudio.encoding === EXPECTED_PROCESSED_AUDIO.encoding
+  );
+}
+
+export function isClassifierReadyRow(row) {
+  const recordingMetadata = isPlainObject(row.recording_metadata) ? row.recording_metadata : {};
+  return isClassifierReadyProcessedAudio(recordingMetadata.processed_audio);
+}
+
+export function filterRowsForClassifierReadyAudio(rows) {
+  const exportRows = [];
+  const skippedRows = [];
+
+  for (const row of rows) {
+    if (isClassifierReadyRow(row)) {
+      exportRows.push(row);
+      continue;
+    }
+
+    skippedRows.push(row);
+  }
+
+  return {
+    exportRows,
+    skippedRows,
+    skippedRowCount: skippedRows.length,
+  };
+}
+
+export function buildDatabuilderSidecar(row) {
+  const sampleId = getDatabuilderSampleId(row);
+  const recordingMetadata = isPlainObject(row.recording_metadata) ? row.recording_metadata : {};
+  const sessionMetadata = isPlainObject(row.session_metadata) ? row.session_metadata : {};
+  const sessionTechnical = isPlainObject(sessionMetadata.technical) ? sessionMetadata.technical : {};
+  const recordingTechnical = isPlainObject(recordingMetadata.technical)
+    ? recordingMetadata.technical
+    : {};
+  const normalizedLabel =
+    normalizeOptionalString(recordingMetadata.normalized_label) ||
+    normalizeOptionalString(row.label);
+  const promptedWord =
+    normalizeOptionalString(recordingMetadata.prompted_word) ||
+    normalizeOptionalString(row.transcript);
+  const language =
+    normalizeOptionalString(recordingMetadata.language) ||
+    normalizeOptionalString(row.language) ||
+    configValue('DATASET_LANGUAGE', 'fi');
+  const category =
+    normalizeOptionalString(recordingMetadata.category) ||
+    normalizeOptionalString(row.category);
+  const submittedAt = normalizeTimestamp(row.submitted_at || recordingMetadata.timestamp);
+
+  if (!normalizedLabel) {
+    throw new Error(`Recording ${sampleId} is missing normalized_label.`);
+  }
+
+  return {
+    sample_id: sampleId,
+    timestamp: submittedAt,
+    prompted_word: promptedWord,
+    normalized_label: normalizedLabel,
+    literal_transcript: recordingMetadata.literal_transcript ?? null,
+    label_source: recordingMetadata.label_source || 'prompt_assumed',
+    language,
+    category: category || null,
+    augmentation_strategy: null,
+    augmentations: [],
+    device_id: pseudonymizeDeviceId(row),
+    speaker_id: pseudonymizeSpeaker(row),
+    duration_sec: getDurationSec(row),
+    demographics: isPlainObject(sessionMetadata.demographics) ? sessionMetadata.demographics : {},
+    environment: isPlainObject(sessionMetadata.environment) ? sessionMetadata.environment : {},
+    technical: {
+      ...sessionTechnical,
+      ...recordingTechnical,
+    },
+    processed_audio: isPlainObject(recordingMetadata.processed_audio)
+      ? recordingMetadata.processed_audio
+      : null,
+    collection: {
+      topic_id: row.topic_id,
+      task_id: row.task_id,
+      session_id: row.session_id,
+      session_status: row.session_status,
+      submitted_at: submittedAt,
+      storage_type: row.storage_type,
+      category: category || null,
+    },
+    storage: getDatabuilderStorageInfo(row),
+  };
+}
+
+export function serializeDatabuilderJson(data) {
+  return `${JSON.stringify(data, null, 2)}\n`;
+}
+
+export function writeDatabuilderJsonFile(filePath, data) {
+  const bytes = Buffer.from(serializeDatabuilderJson(data), 'utf-8');
+  writeFileSync(filePath, bytes);
+  return bytes;
+}
+
+export function cleanDatabuilderOutputDir(outputDir) {
+  ensureDirectory(outputDir);
+
+  for (const entry of readdirSync(outputDir, { withFileTypes: true })) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    if (entry.name.endsWith('.wav') || entry.name.endsWith('.json')) {
+      rmSync(path.join(outputDir, entry.name), { force: true });
+    }
+  }
+}
+
+export function md5Bytes(bytes) {
+  return createHash('md5').update(bytes).digest('hex');
+}
+
+export function md5File(filePath) {
+  return md5Bytes(readFileSync(filePath));
+}
+
+export function getLocalAudioSourcePath(row, recordingsRoot = getSoundRecordingsRoot()) {
+  const storageKey = normalizeStorageObjectKey(row.storage_key);
+  if (!storageKey) {
+    throw new Error(`Recording ${row.recording_id} is missing storage_key.`);
+  }
+
+  const sourcePath = path.isAbsolute(storageKey)
+    ? path.normalize(storageKey)
+    : path.resolve(recordingsRoot, ...storageKey.split('/'));
+
+  assertPathInside(recordingsRoot, sourcePath);
+  return sourcePath;
+}
+
+export async function defaultDownloadObject({ storageType, objectKey, bucketName, destinationPath }) {
+  const fileStorage = new FileStorage(storageType);
+  await fileStorage.downloadObject(objectKey, destinationPath, { bucketName });
+}
+
+export async function writeDatabuilderAudioFile(row, outputDir, options = {}) {
+  const sampleId = getDatabuilderSampleId(row);
+  const activeStorageType = options.activeStorageType || getActiveStorageType();
+  const destinationPath = path.join(outputDir, `${sampleId}.wav`);
+  ensureDirectory(path.dirname(destinationPath));
+
+  if (activeStorageType === 'local') {
+    const sourcePath = getLocalAudioSourcePath(row, options.recordingsRoot || getSoundRecordingsRoot());
+    copyFileSync(sourcePath, destinationPath);
+    return destinationPath;
+  }
+
+  if (activeStorageType === 'aws-s3' || activeStorageType === 'r2') {
+    const storage = getDatabuilderStorageInfo(row);
+    if (!storage.object_key) {
+      throw new Error(`Recording ${sampleId} is missing a remote object key.`);
+    }
+
+    const downloadObject = options.downloadObject || defaultDownloadObject;
+    await downloadObject({
+      storageType: activeStorageType,
+      objectKey: storage.object_key,
+      bucketName: storage.bucket_name,
+      destinationPath,
+      row,
+    });
+    return destinationPath;
+  }
+
+  throw new Error(`Unsupported STORAGE value for databuilder export: ${activeStorageType}`);
+}
+
+export function buildDatabuilderManifest(writtenSamples, version = getDatabuilderManifestVersion()) {
+  const samples = {};
+
+  for (const sample of writtenSamples) {
+    samples[sample.sampleId] = {
+      wav_hash: md5File(sample.wavPath),
+      json_hash: md5File(sample.jsonPath),
+    };
+  }
+
+  return {
+    version,
+    hash_algorithm: 'md5',
+    samples,
+  };
+}
+
+export function buildDatabuilderExportSummary(summary) {
+  return [
+    'Databuilder export summary:',
+    `- considered recordings: ${summary.consideredRowCount}`,
+    `- exported recordings: ${summary.exportedRowCount}`,
+    `- skipped legacy/missing processed_audio: ${summary.skippedLegacyProcessedAudioCount}`,
+    `- skipped storage mismatch: ${summary.skippedStorageMismatchCount}`,
+    `- output directory: ${summary.outputDir}`,
+  ].join('\n');
+}
+
+export async function exportDatabuilderRows(rows, options = {}) {
+  const outputDir = path.resolve(options.outputDir || getDatabuilderOutputDir());
+  ensureDirectory(outputDir);
+
+  const storageFilter = filterRowsForActiveStorage(
+    rows,
+    options.activeStorageType || getActiveStorageType()
+  );
+  const classifierReadyFilter = filterRowsForClassifierReadyAudio(storageFilter.exportRows);
+  const summary = {
+    consideredRowCount: rows.length,
+    exportedRowCount: classifierReadyFilter.exportRows.length,
+    skippedLegacyProcessedAudioCount: classifierReadyFilter.skippedRowCount,
+    skippedStorageMismatchCount: storageFilter.skippedRowCount,
+    outputDir,
+  };
+  const summaryText = buildDatabuilderExportSummary(summary);
+
+  if (options.log !== false) {
+    console.log(summaryText);
+  }
+
+  cleanDatabuilderOutputDir(outputDir);
+
+  if (classifierReadyFilter.exportRows.length === 0) {
+    throw new Error(NO_CLASSIFIER_READY_RECORDINGS_MESSAGE);
+  }
+
+  const writtenSamples = [];
+  for (const row of classifierReadyFilter.exportRows) {
+    const sampleId = getDatabuilderSampleId(row);
+    const wavPath = await writeDatabuilderAudioFile(row, outputDir, {
+      ...options,
+      activeStorageType: storageFilter.activeStorageType,
+    });
+    const sidecar = buildDatabuilderSidecar(row);
+    const jsonPath = path.join(outputDir, `${sampleId}.json`);
+
+    writeDatabuilderJsonFile(jsonPath, sidecar);
+    writtenSamples.push({ sampleId, wavPath, jsonPath });
+  }
+
+  const manifest = buildDatabuilderManifest(
+    writtenSamples,
+    options.manifestVersion || getDatabuilderManifestVersion()
+  );
+  const manifestPath = path.join(outputDir, 'manifest.json');
+  writeDatabuilderJsonFile(manifestPath, manifest);
+
+  return {
+    outputDir,
+    manifest,
+    manifestPath,
+    samples: writtenSamples,
+    storageFilter,
+    classifierReadyFilter,
+    summary,
+    summaryText,
+  };
+}
+
+export async function exportDatabuilderDataset() {
+  config();
+
+  const client = createDbClient();
+  await client.connect();
+
+  try {
+    await expireStaleSessions(client);
+    const rows = await fetchCompletedRows(client);
+    const result = await exportDatabuilderRows(rows);
+
+    console.log(`Exported ${result.samples.length} classifier-ready databuilder sample(s).`);
+  } finally {
+    await client.end();
+  }
+}
+
+const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+const currentPath = fileURLToPath(import.meta.url);
+
+if (entryPath === currentPath) {
+  try {
+    await exportDatabuilderDataset();
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/aina/exportDatabuilderDataset.test.js
+++ b/scripts/aina/exportDatabuilderDataset.test.js
@@ -1,0 +1,453 @@
+import test, { afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import os from 'os';
+import path from 'path';
+
+import {
+  buildDatabuilderExportSummary,
+  buildDatabuilderSidecar,
+  exportDatabuilderRows,
+  md5Bytes,
+  NO_CLASSIFIER_READY_RECORDINGS_MESSAGE,
+  serializeDatabuilderJson,
+} from './exportDatabuilderDataset.js';
+
+const originalEnv = { ...process.env };
+const tempDirs = new Set();
+
+function makeTempDir() {
+  const dir = mkdtempSync(path.join(os.tmpdir(), 'speech-collector-databuilder-'));
+  tempDirs.add(dir);
+  return dir;
+}
+
+function cleanupTempDirs() {
+  for (const dir of tempDirs) {
+    const safePrefix = path.join(os.tmpdir(), 'speech-collector-databuilder-');
+    if (path.resolve(dir).startsWith(path.resolve(safePrefix))) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  tempDirs.clear();
+}
+
+afterEach(() => {
+  cleanupTempDirs();
+
+  for (const key of Object.keys(process.env)) {
+    if (!(key in originalEnv)) {
+      delete process.env[key];
+    }
+  }
+
+  Object.assign(process.env, originalEnv);
+});
+
+function makeRow(overrides = {}) {
+  return {
+    recording_id: '11111111-1111-4111-8111-111111111111',
+    session_id: 'session-123',
+    session_status: 'completed',
+    session_metadata: {
+      schema_version: 'v1',
+      device_id: 'device-123',
+      demographics: {
+        age_group: '26-35',
+        gender: 'prefer_not_to_say',
+        native_language: 'fi',
+      },
+      environment: {
+        noise_level: 'moderate',
+        audio_hardware: 'built_in_mic',
+      },
+      technical: {
+        user_agent: 'Mozilla/5.0',
+        inferred_browser: 'Chrome',
+      },
+    },
+    topic_id: 'short_finnish_responses_v1_0001',
+    task_id: 'short_finnish_responses_v1_0001_kylla',
+    storage_type: 'local',
+    storage_key: 'session-123/short_finnish_responses_v1_0001_kylla.wav',
+    transcript: 'Kylla',
+    label: 'kylla',
+    language: 'fi',
+    category: 'affirmative',
+    duration_sec: 0.82,
+    submitted_at: '2026-04-22T10:00:00.000Z',
+    recording_metadata: {
+      schema_version: 'v1',
+      prompted_word: 'Kylla',
+      normalized_label: 'kylla',
+      literal_transcript: 'kyl',
+      label_source: 'user_confirmed',
+      language: 'fi',
+      category: 'affirmative',
+      technical: {
+        sample_rate_hz: 48000,
+        channel_count: 1,
+      },
+      processed_audio: {
+        sample_rate_hz: 16000,
+        channel_count: 1,
+        encoding: 'pcm_s16le',
+      },
+      storage: {
+        object_key: 'session-123/short_finnish_responses_v1_0001_kylla.wav',
+        bucket_name: null,
+      },
+    },
+    ...overrides,
+  };
+}
+
+function writeLocalAudio(recordingsRoot, row, bytes = Buffer.from('wav-bytes')) {
+  const audioPath = path.join(recordingsRoot, ...row.storage_key.split('/'));
+  mkdirSync(path.dirname(audioPath), { recursive: true });
+  writeFileSync(audioPath, bytes);
+  return audioPath;
+}
+
+test('buildDatabuilderSidecar creates root-level databuilder fields', () => {
+  process.env.DATASET_SPEAKER_HASH_SALT = 'test-salt';
+
+  const sidecar = buildDatabuilderSidecar(makeRow());
+
+  assert.equal(sidecar.sample_id, '11111111-1111-4111-8111-111111111111');
+  assert.equal(sidecar.timestamp, '2026-04-22T10:00:00.000Z');
+  assert.equal(sidecar.prompted_word, 'Kylla');
+  assert.equal(sidecar.normalized_label, 'kylla');
+  assert.equal(sidecar.literal_transcript, 'kyl');
+  assert.equal(sidecar.label_source, 'user_confirmed');
+  assert.equal(sidecar.language, 'fi');
+  assert.equal(sidecar.category, 'affirmative');
+  assert.equal(sidecar.augmentation_strategy, null);
+  assert.deepEqual(sidecar.augmentations, []);
+  assert.match(sidecar.device_id, /^dev_[a-f0-9]{12}$/);
+  assert.match(sidecar.speaker_id, /^spk_[a-f0-9]{12}$/);
+  assert.equal(sidecar.demographics.native_language, 'fi');
+  assert.equal(sidecar.environment.noise_level, 'moderate');
+  assert.equal(sidecar.technical.inferred_browser, 'Chrome');
+  assert.equal(sidecar.technical.sample_rate_hz, 48000);
+  assert.deepEqual(sidecar.processed_audio, {
+    sample_rate_hz: 16000,
+    channel_count: 1,
+    encoding: 'pcm_s16le',
+  });
+  assert.equal(sidecar.collection.session_id, 'session-123');
+  assert.equal(sidecar.storage.storage_key, 'session-123/short_finnish_responses_v1_0001_kylla.wav');
+  assert.equal(Object.hasOwn(sidecar, 'metadata'), false);
+});
+
+test('required sidecar keys always exist for original recordings', () => {
+  const sidecar = buildDatabuilderSidecar(
+    makeRow({
+      recording_metadata: {
+        normalized_label: 'kylla',
+      },
+      session_metadata: {},
+    })
+  );
+
+  assert.equal(Object.hasOwn(sidecar, 'literal_transcript'), true);
+  assert.equal(sidecar.literal_transcript, null);
+  assert.equal(Object.hasOwn(sidecar, 'augmentation_strategy'), true);
+  assert.equal(sidecar.augmentation_strategy, null);
+  assert.equal(Object.hasOwn(sidecar, 'augmentations'), true);
+  assert.deepEqual(sidecar.augmentations, []);
+  assert.equal(Object.hasOwn(sidecar, 'processed_audio'), true);
+  assert.equal(sidecar.processed_audio, null);
+  assert.equal(Object.hasOwn(sidecar, 'demographics'), true);
+  assert.equal(Object.hasOwn(sidecar, 'environment'), true);
+  assert.equal(Object.hasOwn(sidecar, 'technical'), true);
+  assert.equal(Object.hasOwn(sidecar, 'collection'), true);
+  assert.equal(Object.hasOwn(sidecar, 'storage'), true);
+  assert.equal(Object.hasOwn(sidecar, 'speaker_id'), true);
+  assert.equal(Object.hasOwn(sidecar, 'device_id'), true);
+});
+
+test('exportDatabuilderRows copies local audio as sample_id.wav', async () => {
+  const recordingsRoot = makeTempDir();
+  const outputDir = makeTempDir();
+  const row = makeRow();
+  const wavBytes = Buffer.from('copied wav bytes');
+  writeLocalAudio(recordingsRoot, row, wavBytes);
+
+  const result = await exportDatabuilderRows([row], {
+    outputDir,
+    recordingsRoot,
+    activeStorageType: 'local',
+    manifestVersion: 'test-version',
+    log: false,
+  });
+
+  const sampleWav = path.join(outputDir, `${row.recording_id}.wav`);
+  const sampleJson = path.join(outputDir, `${row.recording_id}.json`);
+
+  assert.equal(result.samples[0].sampleId, row.recording_id);
+  assert.deepEqual(readFileSync(sampleWav), wavBytes);
+  assert.equal(existsSync(sampleJson), true);
+  assert.equal(existsSync(path.join(outputDir, 'manifest.json')), true);
+});
+
+test('manifest hashes are computed from exact written wav and json bytes', async () => {
+  const recordingsRoot = makeTempDir();
+  const outputDir = makeTempDir();
+  const row = makeRow();
+  const wavBytes = Buffer.from('hash me exactly');
+  writeLocalAudio(recordingsRoot, row, wavBytes);
+
+  const result = await exportDatabuilderRows([row], {
+    outputDir,
+    recordingsRoot,
+    activeStorageType: 'local',
+    manifestVersion: 'test-version',
+    log: false,
+  });
+
+  const manifestEntry = result.manifest.samples[row.recording_id];
+  const writtenWav = readFileSync(path.join(outputDir, `${row.recording_id}.wav`));
+  const writtenJson = readFileSync(path.join(outputDir, `${row.recording_id}.json`));
+  const sidecar = JSON.parse(writtenJson.toString('utf-8'));
+
+  assert.equal(result.manifest.hash_algorithm, 'md5');
+  assert.equal(result.manifest.version, 'test-version');
+  assert.equal(manifestEntry.wav_hash, md5Bytes(writtenWav));
+  assert.equal(manifestEntry.json_hash, md5Bytes(writtenJson));
+  assert.equal(sidecar.sample_id, row.recording_id);
+  assert.equal(Object.keys(result.manifest.samples)[0], row.recording_id);
+});
+
+test('rows whose storage_type does not match active STORAGE are skipped', async () => {
+  const recordingsRoot = makeTempDir();
+  const outputDir = makeTempDir();
+  const localRow = makeRow();
+  const s3Row = makeRow({
+    recording_id: '22222222-2222-4222-8222-222222222222',
+    storage_type: 'aws-s3',
+    storage_key: 'session-456/short_finnish_responses_v1_0001_kylla.wav',
+  });
+  writeLocalAudio(recordingsRoot, localRow);
+
+  const result = await exportDatabuilderRows([localRow, s3Row], {
+    outputDir,
+    recordingsRoot,
+    activeStorageType: 'local',
+    manifestVersion: 'test-version',
+    log: false,
+  });
+
+  assert.deepEqual(Object.keys(result.manifest.samples), [localRow.recording_id]);
+  assert.deepEqual(result.storageFilter.skippedCounts, { 'aws-s3': 1 });
+  assert.equal(existsSync(path.join(outputDir, `${localRow.recording_id}.wav`)), true);
+  assert.equal(existsSync(path.join(outputDir, `${s3Row.recording_id}.wav`)), false);
+  assert.equal(existsSync(path.join(outputDir, `${s3Row.recording_id}.json`)), false);
+});
+
+test('aws-s3 export downloads the metadata object key as sample_id.wav', async () => {
+  const outputDir = makeTempDir();
+  const row = makeRow({
+    storage_type: 'aws-s3',
+    storage_key: 'session-123/short_finnish_responses_v1_0001_kylla.wav',
+    recording_metadata: {
+      normalized_label: 'kylla',
+      processed_audio: {
+        sample_rate_hz: 16000,
+        channel_count: 1,
+        encoding: 'pcm_s16le',
+      },
+      storage: {
+        object_key: 'short-finnish-responses/v1/audio/session-123/short_finnish_responses_v1_0001_kylla.wav',
+        bucket_name: 'voice-training',
+      },
+    },
+  });
+  const calls = [];
+
+  await exportDatabuilderRows([row], {
+    outputDir,
+    activeStorageType: 'aws-s3',
+    manifestVersion: 'test-version',
+    log: false,
+    downloadObject: async (details) => {
+      calls.push(details);
+      writeFileSync(details.destinationPath, Buffer.from('downloaded wav'));
+    },
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].storageType, 'aws-s3');
+  assert.equal(
+    calls[0].objectKey,
+    'short-finnish-responses/v1/audio/session-123/short_finnish_responses_v1_0001_kylla.wav'
+  );
+  assert.equal(calls[0].bucketName, 'voice-training');
+  assert.deepEqual(
+    readFileSync(path.join(outputDir, `${row.recording_id}.wav`)),
+    Buffer.from('downloaded wav')
+  );
+});
+
+test('valid processed_audio rows are exported and summarized', async () => {
+  const recordingsRoot = makeTempDir();
+  const outputDir = makeTempDir();
+  const row = makeRow();
+  writeLocalAudio(recordingsRoot, row);
+
+  const result = await exportDatabuilderRows([row], {
+    outputDir,
+    recordingsRoot,
+    activeStorageType: 'local',
+    manifestVersion: 'test-version',
+    log: false,
+  });
+
+  assert.deepEqual(Object.keys(result.manifest.samples), [row.recording_id]);
+  assert.equal(result.summary.consideredRowCount, 1);
+  assert.equal(result.summary.exportedRowCount, 1);
+  assert.equal(result.summary.skippedLegacyProcessedAudioCount, 0);
+  assert.equal(result.summary.skippedStorageMismatchCount, 0);
+});
+
+test('rows with null or missing processed_audio are skipped by default', async () => {
+  const recordingsRoot = makeTempDir();
+  const outputDir = makeTempDir();
+  const validRow = makeRow({
+    recording_id: '11111111-1111-4111-8111-111111111111',
+  });
+  const nullProcessedAudioRow = makeRow({
+    recording_id: '22222222-2222-4222-8222-222222222222',
+    recording_metadata: {
+      normalized_label: 'kylla',
+      processed_audio: null,
+    },
+  });
+  const missingProcessedAudioRow = makeRow({
+    recording_id: '33333333-3333-4333-8333-333333333333',
+    recording_metadata: {
+      normalized_label: 'kylla',
+    },
+  });
+  writeLocalAudio(recordingsRoot, validRow);
+
+  const result = await exportDatabuilderRows(
+    [validRow, nullProcessedAudioRow, missingProcessedAudioRow],
+    {
+      outputDir,
+      recordingsRoot,
+      activeStorageType: 'local',
+      manifestVersion: 'test-version',
+      log: false,
+    }
+  );
+
+  assert.deepEqual(Object.keys(result.manifest.samples), [validRow.recording_id]);
+  assert.equal(result.summary.skippedLegacyProcessedAudioCount, 2);
+  assert.equal(existsSync(path.join(outputDir, `${nullProcessedAudioRow.recording_id}.wav`)), false);
+  assert.equal(existsSync(path.join(outputDir, `${missingProcessedAudioRow.recording_id}.json`)), false);
+});
+
+test('rows with wrong processed_audio values are skipped by default', async () => {
+  const recordingsRoot = makeTempDir();
+  const outputDir = makeTempDir();
+  const validRow = makeRow({
+    recording_id: '11111111-1111-4111-8111-111111111111',
+  });
+  const wrongRateRow = makeRow({
+    recording_id: '22222222-2222-4222-8222-222222222222',
+    recording_metadata: {
+      normalized_label: 'kylla',
+      processed_audio: {
+        sample_rate_hz: 48000,
+        channel_count: 1,
+        encoding: 'pcm_s16le',
+      },
+    },
+  });
+  const wrongChannelRow = makeRow({
+    recording_id: '33333333-3333-4333-8333-333333333333',
+    recording_metadata: {
+      normalized_label: 'kylla',
+      processed_audio: {
+        sample_rate_hz: 16000,
+        channel_count: 2,
+        encoding: 'pcm_s16le',
+      },
+    },
+  });
+  const wrongEncodingRow = makeRow({
+    recording_id: '44444444-4444-4444-8444-444444444444',
+    recording_metadata: {
+      normalized_label: 'kylla',
+      processed_audio: {
+        sample_rate_hz: 16000,
+        channel_count: 1,
+        encoding: 'opus',
+      },
+    },
+  });
+  writeLocalAudio(recordingsRoot, validRow);
+
+  const result = await exportDatabuilderRows(
+    [validRow, wrongRateRow, wrongChannelRow, wrongEncodingRow],
+    {
+      outputDir,
+      recordingsRoot,
+      activeStorageType: 'local',
+      manifestVersion: 'test-version',
+      log: false,
+    }
+  );
+
+  assert.deepEqual(Object.keys(result.manifest.samples), [validRow.recording_id]);
+  assert.equal(result.summary.skippedLegacyProcessedAudioCount, 3);
+});
+
+test('databuilder export fails clearly when no classifier-ready rows remain', async () => {
+  const outputDir = makeTempDir();
+  const invalidRow = makeRow({
+    recording_metadata: {
+      normalized_label: 'kylla',
+      processed_audio: null,
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      exportDatabuilderRows([invalidRow], {
+        outputDir,
+        activeStorageType: 'local',
+        manifestVersion: 'test-version',
+        log: false,
+      }),
+    { message: NO_CLASSIFIER_READY_RECORDINGS_MESSAGE }
+  );
+  assert.equal(existsSync(path.join(outputDir, 'manifest.json')), false);
+});
+
+test('databuilder export summary includes skipped legacy count', () => {
+  const summaryText = buildDatabuilderExportSummary({
+    consideredRowCount: 4,
+    exportedRowCount: 1,
+    skippedLegacyProcessedAudioCount: 3,
+    skippedStorageMismatchCount: 0,
+    outputDir: 'out',
+  });
+
+  assert.match(summaryText, /Databuilder export summary:/);
+  assert.match(summaryText, /- skipped legacy\/missing processed_audio: 3/);
+});
+
+test('serialized sidecar JSON is deterministic for stable hash generation', () => {
+  const sidecar = buildDatabuilderSidecar(makeRow());
+
+  assert.equal(serializeDatabuilderJson(sidecar), serializeDatabuilderJson(sidecar));
+});

--- a/scripts/aina/exportDataset.js
+++ b/scripts/aina/exportDataset.js
@@ -21,7 +21,7 @@ export function getActiveStorageType() {
   return configValue('STORAGE', 'local');
 }
 
-function createDbClient() {
+export function createDbClient() {
   config();
   const password = encodeURIComponent(process.env.PG_PASSWORD || '');
   const connString = `postgresql://${process.env.PG_USER}:${password}@${process.env.PG_HOST}:${process.env.PG_PORT}/${process.env.PG_DATABASE}`;
@@ -190,7 +190,7 @@ export function buildSample(row, index, dataset) {
   };
 }
 
-async function expireStaleSessions(client) {
+export async function expireStaleSessions(client) {
   await client.query(
     `
       UPDATE participant_sessions
@@ -204,7 +204,7 @@ async function expireStaleSessions(client) {
   );
 }
 
-async function fetchLabelVocabulary(client) {
+export async function fetchLabelVocabulary(client) {
   const result = await client.query(`
     SELECT DISTINCT metadata->>'label' AS label
     FROM tasks
@@ -215,7 +215,7 @@ async function fetchLabelVocabulary(client) {
   return result.rows.map((row) => row.label).filter(Boolean);
 }
 
-async function fetchCompletedRows(client) {
+export async function fetchCompletedRows(client) {
   const result = await client.query(`
     SELECT
       r.id AS recording_id,


### PR DESCRIPTION
﻿## Summary

Adds a strict export bridge from Speech Collector to the current `audio-classifier` databuilder format.

The existing collector-native export remains unchanged:

- `metadata/dataset.json`
- `metadata/samples.jsonl`

This PR adds a second compatibility export:

- `databuilder/manifest.json`
- `databuilder/<sample_id>.wav`
- `databuilder/<sample_id>.json`

## Why

The current `audio-classifier` `feature/databuilder` branch expects a flat package layout with `manifest.json` plus one WAV and one sidecar JSON per sample. The collector's existing JSONL export is useful, but it is not the exact layout expected by that databuilder.

This bridge keeps live collection safe:

- PostgreSQL remains the live metadata source of truth
- S3/local storage remains the audio storage backend
- frontend still does not append to shared JSONL
- derived handoff files are generated only at export time

## What Changed

- Added `pnpm run aina:export:databuilder`
- Added databuilder-compatible export script
- Added `manifest.json` generation with MD5 hashes from exact written WAV/JSON bytes
- Writes `<sample_id>.wav` and `<sample_id>.json`
- Uses `recordings.id` as:
  - manifest key
  - WAV basename
  - JSON basename
  - sidecar `sample_id`
- Sidecar JSON is root-level/flat because the current databuilder filters expect paths like `demographics.native_language`
- Added strict classifier-ready filtering:
  - only exports samples with `processed_audio` equal to 16 kHz, mono, `pcm_s16le`
  - skips legacy recordings with missing/null/wrong `processed_audio`
  - fails clearly if no classifier-ready recordings remain
- Added docs for the databuilder export bridge
- Added tests for sidecar creation, manifest hashing, storage filtering, and strict processed-audio filtering

## Validation

Validated before opening this PR:

```text
backend tests: passed
frontend build: passed
frontend lint: passed
normal export: blocked in clean company checkout because .env contains placeholder PostgreSQL settings
databuilder export: blocked in clean company checkout because .env contains placeholder PostgreSQL settings
```

Live validation from the thesis repo showed:

```text
normal export: exported 4 samples
strict databuilder export: considered 4, exported 1, skipped 3 legacy/missing processed_audio
ffprobe: exported WAV is pcm_s16le, 16000 Hz, mono
audio-classifier smoke test: read 1 manifest sample and wrote 1 dataset sample
```

## Notes

The skipped samples were old test recordings collected before the 16 kHz processed-audio fix. The strict exporter now protects the classifier pipeline from legacy or mixed-format samples.

Generated exports, WAV files, temp files, and `.env` are not included.
