### PR TITLE
Add v2 category phrase recording flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,7 +14,7 @@ PG_PASSWORD=postgres
 # Use aws-s3 for the production collection bucket.
 STORAGE=local
 SOUND_RECORDINGS_PATH=tmp/recordings
-COLLECTION_AUDIO_PREFIX=short-finnish-responses/v1/audio
+COLLECTION_AUDIO_PREFIX=short-finnish-responses/v2/audio
 SESSION_IDLE_TIMEOUT_HOURS=24
 MAX_RECORDING_SECONDS=5
 MAX_UPLOAD_BYTES=2000000
@@ -32,15 +32,15 @@ AINA_TOPIC_COPIES=100
 
 # Export settings for scripts/aina/exportDataset.js.
 DATASET_ID=short_finnish_responses
-DATASET_VERSION=v1
+DATASET_VERSION=v2
 DATASET_LANGUAGE=fi
 DATASET_DESCRIPTION=Short Finnish speech responses for voicemail keyword/audio classification
 DATASET_TASK=short_response_classification
-DATASET_OUTPUT_DIR=./exports/short-finnish-responses/v1
+DATASET_OUTPUT_DIR=./exports/short-finnish-responses/v2
 # Optional override. Leave empty to derive from local storage or S3 config.
 DATASET_AUDIO_ROOT=
 DATASET_SPEAKER_HASH_SALT=change-me-before-real-export
 
 # Compatibility export for audio-classifier databuilder.
-DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v1/databuilder
+DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v2/databuilder
 DATABUILDER_MANIFEST_VERSION=20260501001

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It is built for anonymous volunteer sessions:
 - no username/password login for volunteers
 - one prompt-set topic copy per session
 - metadata saved against the session
-- prompt-by-prompt recording flow
+- prompt-by-prompt recording flow today, with backend category-state support for the next UI
 - exit anytime without losing submitted prompts
 - PostgreSQL for session/task/recording state
 - AWS S3 as the production audio store
@@ -38,6 +38,7 @@ The old account flow has been replaced with:
 
 - `POST /api/start-session`
 - `POST /api/get-task`
+- `POST /api/category-state`
 - `POST /api/update-session-metadata`
 - `POST /api/upload-sound`
 - `POST /api/exit-session`
@@ -65,7 +66,7 @@ Important variables:
 ```env
 APP_URL=http://localhost:5173
 VITE_API_URL=http://localhost:8000
-VITE_APP_TITLE=Speech Collector
+VITE_APP_TITLE=AINA Speech Collector
 VITE_MAX_RECORDING_SECONDS=5
 VITE_TURNSTILE_SITE_KEY=
 
@@ -77,7 +78,7 @@ PG_PASSWORD=postgres
 
 STORAGE=local
 SOUND_RECORDINGS_PATH=tmp/recordings
-COLLECTION_AUDIO_PREFIX=short-finnish-responses/v1/audio
+COLLECTION_AUDIO_PREFIX=short-finnish-responses/v2/audio
 SESSION_IDLE_TIMEOUT_HOURS=24
 MAX_RECORDING_SECONDS=5
 MAX_UPLOAD_BYTES=2000000
@@ -92,15 +93,15 @@ AWS_BUCKET_NAME=
 AINA_TOPIC_COPIES=100
 
 DATASET_ID=short_finnish_responses
-DATASET_VERSION=v1
+DATASET_VERSION=v2
 DATASET_LANGUAGE=fi
 DATASET_DESCRIPTION=Short Finnish speech responses for voicemail keyword/audio classification
 DATASET_TASK=short_response_classification
-DATASET_OUTPUT_DIR=./exports/short-finnish-responses/v1
+DATASET_OUTPUT_DIR=./exports/short-finnish-responses/v2
 DATASET_AUDIO_ROOT=
 DATASET_SPEAKER_HASH_SALT=change-me-before-real-export
 
-DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v1/databuilder
+DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v2/databuilder
 DATABUILDER_MANIFEST_VERSION=20260501001
 ```
 
@@ -131,7 +132,7 @@ For installation help, see [docs/database-setup.md](docs/database-setup.md).
 
 ## Seed AINA Prompts
 
-The AINA seed script creates prompt-set copies ahead of time so concurrent volunteers can each get their own session topic.
+The AINA seed script creates v2 category phrase-bank copies ahead of time so concurrent volunteers can each get their own session topic.
 
 ```bash
 pnpm run aina:seed
@@ -142,9 +143,18 @@ The seeding step uses:
 - [scripts/aina/migration.sql](scripts/aina/migration.sql)
 - [scripts/aina/short_finnish_prompts.json](scripts/aina/short_finnish_prompts.json)
 
-`AINA_TOPIC_COPIES` controls how many topic copies exist. If local testing exhausts them, raise `AINA_TOPIC_COPIES` in `.env` and rerun `pnpm run aina:seed` to add more copies. Existing copies are upserted; new higher-numbered copies are created.
+`AINA_TOPIC_COPIES` controls how many topic copies exist. If local testing exhausts them, raise `AINA_TOPIC_COPIES` in `.env` and rerun `pnpm run aina:seed` to add more copies. Existing v2 copies are upserted; new higher-numbered copies are created.
 
-Note: number prompt IDs changed from digit IDs such as `1` to Finnish word IDs such as `yksi` while keeping classifier labels as digits. If your local database was seeded before that change, reset the seeded collection tables before reseeding:
+When reseeding the same v2 topic copy, the seeder removes obsolete task rows only when they have no recordings. If an obsolete task already has recordings, seeding stops with an explicit reset/archive message instead of deleting collected samples.
+
+The v2 prompt bank stores:
+
+- `phrase_id`: stable phrase identity such as `yes_kylla`
+- `label`: phrase-level classifier target such as `kylla`
+- `semantic_label`: broader future target such as `yes`
+- `category`: UI grouping such as `yes`
+
+If your local database was seeded with old prompt rows and you want a clean v2 run, reset the seeded collection tables before reseeding:
 
 ```sql
 DELETE FROM recordings;
@@ -182,13 +192,23 @@ The main collection flow is:
 2. If Turnstile is configured, the volunteer completes the human verification gate.
 3. Backend starts or resumes an anonymous session.
 4. Volunteer sees the intro and metadata form.
-5. Volunteer records one prompt at a time; each recording auto-stops after 5 seconds by default.
+5. Volunteer records one prompt at a time in the current frontend; the backend also exposes category progress for the next UI.
 6. Each successful upload is stored and linked to the session.
 7. Volunteer can continue, refresh, or leave.
 8. Submitted recordings stay valid even if the session ends early.
 9. Completed sessions show a thank-you screen.
 
 The browser stores the active session token locally so an active session can resume automatically in the same browser.
+
+## Category Progress API
+
+`POST /api/category-state` prepares the backend for the category-based UI. It returns fixed category order, per-session shuffled phrase order, current-session phrase counts, same-device previous phrase state, and unlock eligibility.
+
+Progress counts distinct `phrase_id` values, not raw recording rows. Re-recording the same phrase inserts another valid sample but does not advance unique phrase progress twice. Previous recordings from the same anonymous browser ID count toward category unlocks.
+
+The shuffled phrase order is stored in `participant_sessions.metadata.ui.category_phrase_v1` so refreshing a session does not reshuffle phrases. If new phrases are later added to a seeded topic, missing phrase IDs are appended in `task_idx` order.
+
+`exit-session` remains the anytime stop path. A `completed` session still means every assigned task/phrase in the current topic has at least one current-session recording; early exits are `abandoned`, and submitted recordings remain exportable.
 
 ## No Prompts Available During Testing
 
@@ -233,7 +253,7 @@ DATASET_AUDIO_ROOT=
 
 In local mode:
 
-- uploads are re-encoded and persisted under `SOUND_RECORDINGS_PATH/{session_id}/{task_id}.wav`
+- uploads are re-encoded and persisted under `SOUND_RECORDINGS_PATH/{session_id}/{task_id}/{recording_id}.wav`
 - relative local paths are anchored to `apps/speech-collector`, not the backend package directory
 - exporter writes manifests that reference the same local audio root directly
 - audio is not copied into the export folder as the source of truth
@@ -248,14 +268,14 @@ AWS_REGION=eu-north-1
 AWS_BUCKET_NAME=<bucket>
 AWS_ACCESS_KEY_ID=<access-key>
 AWS_SECRET_ACCESS_KEY=<secret>
-COLLECTION_AUDIO_PREFIX=short-finnish-responses/v1/audio
+COLLECTION_AUDIO_PREFIX=short-finnish-responses/v2/audio
 ```
 
 In S3 mode:
 
 - uploads are re-encoded locally first
-- final object key is `{COLLECTION_AUDIO_PREFIX}/{session_id}/{task_id}.wav`
-- PostgreSQL stores `storage_key` as `{session_id}/{task_id}.wav`
+- final object key is `{COLLECTION_AUDIO_PREFIX}/{session_id}/{task_id}/{recording_id}.wav`
+- PostgreSQL stores `storage_key` as `{session_id}/{task_id}/{recording_id}.wav`
 - exporter writes `audio_root=s3://<bucket>/<COLLECTION_AUDIO_PREFIX>/`
 - manifest `audio_path` values stay relative to that root
 
@@ -287,7 +307,7 @@ pnpm run aina:export
 The exporter writes:
 
 ```text
-exports/short-finnish-responses/v1/
+exports/short-finnish-responses/v2/
   metadata/
     dataset.json
     samples.jsonl
@@ -301,6 +321,7 @@ Export behavior:
 - filters rows to the active `STORAGE` backend before building the manifest
 - uses `recordings.id` as `sample_id`
 - exports `normalized_label` and keeps `label` as its compatibility alias
+- exports `phrase_id` and nullable `semantic_label` at the sample root and in collection metadata
 - stores Finnish prompt text separately as `prompted_word`
 - hashes the anonymous browser `device_id` into stable `speaker_id`
 - references permanent storage directly
@@ -318,7 +339,7 @@ pnpm run aina:export:databuilder
 Default output:
 
 ```text
-exports/short-finnish-responses/v1/databuilder/
+exports/short-finnish-responses/v2/databuilder/
   manifest.json
   <sample_id>.wav
   <sample_id>.json
@@ -332,6 +353,7 @@ Databuilder export behavior:
 - skips legacy recordings where `processed_audio` is missing, null, or different from the classifier-ready format
 - fails clearly when no classifier-ready recordings remain
 - uses `recordings.id` as `sample_id`, the file basename, and the manifest key
+- includes `phrase_id` and nullable `semantic_label` at the sidecar root and under `collection`
 - copies local audio or downloads S3 audio into `<sample_id>.wav`
 - writes root-level sidecar JSON because databuilder filters use paths such as `demographics.native_language`
 - writes MD5 hashes for the exact WAV and JSON bytes in `manifest.json`
@@ -347,7 +369,7 @@ cd D:\ass_vscode\AIN\packages\audio-classifier
 python - <<'PY'
 from audio_classifier.data import load_dataset
 
-dataset = load_dataset(r"D:\ass_vscode\AIN\apps\speech-collector\exports\short-finnish-responses\v1")
+dataset = load_dataset(r"D:\ass_vscode\AIN\apps\speech-collector\exports\short-finnish-responses\v2")
 print(f"loaded {len(dataset)} samples")
 print(dataset[0] if dataset else "no samples")
 PY
@@ -378,9 +400,11 @@ If you only need more test sessions and want to keep the existing prompt copies,
 ## Related Docs
 
 - [docs/aina-refactor-plan.md](docs/aina-refactor-plan.md)
+- [docs/category-phrase-ui-plan.md](docs/category-phrase-ui-plan.md)
 - [docs/aina-s3-integration.md](docs/aina-s3-integration.md)
 - [docs/aina-data-contract.md](docs/aina-data-contract.md)
 - [docs/databuilder-export.md](docs/databuilder-export.md)
+- [docs/cloud-validation-session-2026-05-04.md](docs/cloud-validation-session-2026-05-04.md)
 - [docs/database-structure.md](docs/database-structure.md)
 - [docs/database-setup.md](docs/database-setup.md)
 - [docs/dev-reset-session-data.sql](docs/dev-reset-session-data.sql)

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -10,6 +10,8 @@ const DEFAULT_SOUND_RECORDINGS_PATH = 'tmp/recordings';
 const DEFAULT_MAX_RECORDING_SECONDS = 5;
 const DEFAULT_MAX_UPLOAD_BYTES = 2_000_000;
 const DEFAULT_MAX_RECORDING_DURATION_TOLERANCE_SECONDS = 1;
+const DEFAULT_DATASET_ID = 'short_finnish_responses';
+const DEFAULT_DATASET_VERSION = 'v2';
 
 function normalizePosixPrefix(prefix) {
   return (prefix || '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
@@ -71,9 +73,17 @@ export function getTurnstileSecretKey() {
   return (process.env.TURNSTILE_SECRET_KEY || '').trim();
 }
 
+export function getDatasetId() {
+  return process.env.DATASET_ID || DEFAULT_DATASET_ID;
+}
+
+export function getDatasetVersion() {
+  return process.env.DATASET_VERSION || DEFAULT_DATASET_VERSION;
+}
+
 export function getCollectionAudioPrefix() {
-  const datasetId = (process.env.DATASET_ID || 'short_finnish_responses').replace(/_/g, '-');
-  const datasetVersion = process.env.DATASET_VERSION || 'v1';
+  const datasetId = getDatasetId().replace(/_/g, '-');
+  const datasetVersion = getDatasetVersion();
   return normalizePosixPrefix(
     process.env.COLLECTION_AUDIO_PREFIX || `${datasetId}/${datasetVersion}/audio`
   );

--- a/backend/src/fileStorage.js
+++ b/backend/src/fileStorage.js
@@ -37,8 +37,12 @@ export function getProcessedAudioMetadata() {
   };
 }
 
-export function buildRecordingStorageKey(sessionId, taskId) {
-  return normalizeStorageKey(sessionId, `${taskId}.wav`);
+export function buildRecordingStorageKey(sessionId, taskId, recordingId) {
+  if (!recordingId) {
+    throw new Error('recordingId is required to build a unique recording storage key.');
+  }
+
+  return normalizeStorageKey(sessionId, taskId, `${recordingId}.wav`);
 }
 
 export class RecordingTooLongError extends Error {
@@ -155,7 +159,7 @@ export class FileStorage {
     ensureDirectory(path.dirname(finalPath));
 
     if (fs.existsSync(finalPath)) {
-      fs.unlinkSync(finalPath);
+      throw new Error(`Refusing to overwrite an existing recording: ${storageKey}`);
     }
 
     fs.copyFileSync(tempFilePath, finalPath);
@@ -202,9 +206,9 @@ export class FileStorage {
     return destinationPath;
   }
 
-  async saveRecording(file, { sessionId, taskId }) {
-    const storageKey = buildRecordingStorageKey(sessionId, taskId);
-    const tempFilePath = this.getTempFilePath(sessionId, taskId);
+  async saveRecording(file, { sessionId, taskId, recordingId }) {
+    const storageKey = buildRecordingStorageKey(sessionId, taskId, recordingId);
+    const tempFilePath = this.getTempFilePath(sessionId, `${taskId}-${recordingId}`);
 
     try {
       if (!Buffer.isBuffer(file.buffer) || file.buffer.length === 0) {

--- a/backend/src/fileStorage.test.js
+++ b/backend/src/fileStorage.test.js
@@ -29,10 +29,14 @@ afterEach(() => {
   }
 });
 
-test('buildRecordingStorageKey uses a stable session/task layout', () => {
+test('buildRecordingStorageKey uses a unique session/task/recording layout', () => {
   assert.equal(
-    buildRecordingStorageKey('session-123', 'short_finnish_responses_v1_0001_kylla'),
-    'session-123/short_finnish_responses_v1_0001_kylla.wav'
+    buildRecordingStorageKey(
+      'session-123',
+      'short_finnish_responses_v2_0001_yes_kylla',
+      'recording-789'
+    ),
+    'session-123/short_finnish_responses_v2_0001_yes_kylla/recording-789.wav'
   );
 });
 
@@ -78,7 +82,7 @@ test('local persistence writes files under the same root the exporter publishes'
 
   const recordingsRoot = path.join(tempRoot, 'recordings');
   const sourceFilePath = path.join(tempRoot, 'source.wav');
-  const storageKey = buildRecordingStorageKey('session-123', 'task-456');
+  const storageKey = buildRecordingStorageKey('session-123', 'task-456', 'recording-789');
 
   process.env.STORAGE = 'local';
   process.env.SOUND_RECORDINGS_PATH = path.relative(appRoot, recordingsRoot);
@@ -87,7 +91,7 @@ test('local persistence writes files under the same root the exporter publishes'
   fs.writeFileSync(sourceFilePath, Buffer.from('wav-data'));
 
   const finalPath = await storage.persistLocally(sourceFilePath, storageKey);
-  const expectedPath = path.join(inferAudioRoot(), 'session-123', 'task-456.wav');
+  const expectedPath = path.join(inferAudioRoot(), 'session-123', 'task-456', 'recording-789.wav');
 
   assert.equal(finalPath, expectedPath);
   assert.equal(fs.readFileSync(finalPath, 'utf-8'), 'wav-data');
@@ -111,8 +115,9 @@ test('saveRecording returns processed audio metadata with persisted local record
 
   const result = await storage.saveRecording(
     { buffer: Buffer.from('wav-data') },
-    { sessionId: 'session-123', taskId: 'task-456' }
+    { sessionId: 'session-123', taskId: 'task-456', recordingId: 'recording-789' }
   );
 
   assert.deepEqual(result.processedAudio, getProcessedAudioMetadata());
+  assert.equal(result.storageKey, 'session-123/task-456/recording-789.wav');
 });

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import cors from 'cors';
 import multer from 'multer';
+import { randomUUID } from 'crypto';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -94,6 +95,11 @@ export function buildRecordingMetadata(frontendMetadata, task, submittedAt, stor
     metadata: {
       schema_version: 'v1',
       timestamp: submittedAt,
+      phrase_id:
+        normalizeOptionalString(taskMetadata.phrase_id) ||
+        normalizeOptionalString(taskMetadata.prompt_id) ||
+        normalizeOptionalString(task?.id),
+      semantic_label: normalizeOptionalString(taskMetadata.semantic_label),
       prompted_word: normalizeOptionalString(task?.text),
       normalized_label: normalizedLabel,
       literal_transcript: normalizeOptionalString(literalTranscript),
@@ -294,6 +300,28 @@ export function createApp(options = {}) {
     }
   });
 
+  app.post('/api/category-state', async (req, res) => {
+    const sessionToken = normalizeSessionToken(req.body?.sessionToken);
+    if (!sessionToken) {
+      return res.status(400).json({
+        success: false,
+        code: 'missing_session_token',
+        message: 'sessionToken is required.',
+      });
+    }
+
+    try {
+      const result = await provider.getCategoryState(sessionToken);
+      res.status(result.success ? 200 : 400).json(result);
+    } catch (error) {
+      console.error('Error in /api/category-state:', error);
+      res.status(500).json({
+        success: false,
+        message: 'An internal server error occurred.',
+      });
+    }
+  });
+
   app.post('/api/upload-sound', createUploadMiddleware(upload), async (req, res) => {
     const sessionToken = normalizeSessionToken(req.body?.sessionToken);
     const taskId =
@@ -322,6 +350,7 @@ export function createApp(options = {}) {
       }
 
       const submittedAt = new Date().toISOString();
+      const recordingId = randomUUID();
       const recordingMetadata = buildRecordingMetadata(
         parsedMetadata.metadata,
         uploadTarget.task,
@@ -335,6 +364,7 @@ export function createApp(options = {}) {
       const recording = await fileStorage.saveRecording(file, {
         sessionId: uploadTarget.sessionId,
         taskId,
+        recordingId,
       });
 
       const metadataWithStorage = {
@@ -349,6 +379,7 @@ export function createApp(options = {}) {
       };
 
       const result = await provider.submitRecording(sessionToken, taskId, {
+        recordingId,
         storageType: recording.storageType,
         storageKey: recording.storageKey,
         durationSec: recording.durationSec,

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -14,6 +14,7 @@ import { RecordingTooLongError } from './fileStorage.js';
 function createProvider(overrides = {}) {
   return {
     startSessionCalls: 0,
+    getCategoryStateCalls: 0,
     getUploadTargetCalls: 0,
     submitRecordingCalls: 0,
     async startSession() {
@@ -31,9 +32,20 @@ function createProvider(overrides = {}) {
           metadata: {
             label: 'kylla',
             language: 'fi',
-            category: 'affirmative',
+            category: 'yes',
+            phrase_id: 'yes_kylla',
+            semantic_label: 'yes',
           },
         },
+      };
+    },
+    async getCategoryState() {
+      this.getCategoryStateCalls += 1;
+      return {
+        success: true,
+        categoryOrder: ['yes'],
+        activeCategoryId: 'yes',
+        categories: [],
       };
     },
     async submitRecording(_sessionToken, _taskId, recordingDetails) {
@@ -48,12 +60,14 @@ function createProvider(overrides = {}) {
 function createFileStorage(overrides = {}) {
   return {
     saveRecordingCalls: 0,
-    async saveRecording() {
+    async saveRecording(_file, options) {
       this.saveRecordingCalls += 1;
+      this.lastSaveOptions = options;
+      const storageKey = `${options.sessionId}/${options.taskId}/${options.recordingId}.wav`;
       return {
         storageType: 'local',
-        storageKey: 'session-123/task-123.wav',
-        objectKey: 'session-123/task-123.wav',
+        storageKey,
+        objectKey: storageKey,
         bucketName: null,
         durationSec: 0.8,
         processedAudio: {
@@ -113,7 +127,9 @@ test('buildRecordingMetadata accepts null literal_transcript and defaults label_
       metadata: {
         label: 'kylla',
         language: 'fi',
-        category: 'affirmative',
+        category: 'yes',
+        phrase_id: 'yes_kylla',
+        semantic_label: 'yes',
       },
     },
     '2026-05-03T12:00:00.000Z'
@@ -123,6 +139,8 @@ test('buildRecordingMetadata accepts null literal_transcript and defaults label_
   assert.equal(result.metadata.literal_transcript, null);
   assert.equal(result.metadata.label_source, 'prompt_assumed');
   assert.equal(result.metadata.prompted_word, 'Kyllä');
+  assert.equal(result.metadata.phrase_id, 'yes_kylla');
+  assert.equal(result.metadata.semantic_label, 'yes');
   assert.equal(result.metadata.normalized_label, 'kylla');
 });
 
@@ -144,6 +162,40 @@ test('buildRecordingMetadata stores user-confirmed literal transcript', () => {
   assert.equal(result.success, true);
   assert.equal(result.metadata.literal_transcript, 'kyl');
   assert.equal(result.metadata.label_source, 'user_confirmed');
+});
+
+test('buildRecordingMetadata ignores frontend-provided trusted label fields', () => {
+  const result = buildRecordingMetadata(
+    {
+      phrase_id: 'malicious_phrase',
+      semantic_label: 'malicious_semantic',
+      normalized_label: 'malicious_label',
+      category: 'malicious_category',
+      language: 'xx',
+      prompted_word: 'malicious prompt',
+      literal_transcript: null,
+    },
+    {
+      id: 'task-123',
+      text: 'Kyl',
+      metadata: {
+        phrase_id: 'yes_kyl',
+        semantic_label: 'yes',
+        label: 'kyl',
+        category: 'yes',
+        language: 'fi',
+      },
+    },
+    '2026-05-03T12:00:00.000Z'
+  );
+
+  assert.equal(result.success, true);
+  assert.equal(result.metadata.phrase_id, 'yes_kyl');
+  assert.equal(result.metadata.semantic_label, 'yes');
+  assert.equal(result.metadata.normalized_label, 'kyl');
+  assert.equal(result.metadata.category, 'yes');
+  assert.equal(result.metadata.language, 'fi');
+  assert.equal(result.metadata.prompted_word, 'Kyl');
 });
 
 test('too-large uploads are rejected before provider or storage work', async () => {
@@ -285,11 +337,43 @@ test('upload continues past upload target when session metadata is valid', async
     assert.equal(provider.getUploadTargetCalls, 1);
     assert.equal(fileStorage.saveRecordingCalls, 1);
     assert.equal(provider.submitRecordingCalls, 1);
+    assert.match(fileStorage.lastSaveOptions.recordingId, /^[0-9a-f-]{36}$/);
+    assert.equal(provider.lastRecordingDetails.recordingId, fileStorage.lastSaveOptions.recordingId);
+    assert.equal(
+      provider.lastRecordingDetails.storageKey,
+      `session-123/task-123/${fileStorage.lastSaveOptions.recordingId}.wav`
+    );
+    assert.equal(provider.lastRecordingDetails.metadata.phrase_id, 'yes_kylla');
+    assert.equal(provider.lastRecordingDetails.metadata.semantic_label, 'yes');
     assert.deepEqual(provider.lastRecordingDetails.metadata.processed_audio, {
       sample_rate_hz: 16000,
       channel_count: 1,
       encoding: 'pcm_s16le',
     });
+  });
+});
+
+test('category-state endpoint returns provider category progress', async () => {
+  const provider = createProvider();
+  const app = createApp({
+    provider,
+    fileStorage: createFileStorage(),
+    turnstileSecretKey: '',
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/category-state`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ sessionToken: 'session-token' }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.deepEqual(body.categoryOrder, ['yes']);
+    assert.equal(body.activeCategoryId, 'yes');
+    assert.equal(provider.getCategoryStateCalls, 1);
   });
 });
 

--- a/backend/src/taskProvider.js
+++ b/backend/src/taskProvider.js
@@ -23,6 +23,10 @@ function normalizeMetadata(metadata) {
   return metadata && typeof metadata === 'object' && !Array.isArray(metadata) ? metadata : {};
 }
 
+function normalizeOptionalString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
 function isPlainObject(value) {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
 }
@@ -41,6 +45,337 @@ export function hasRequiredSessionMetadata(metadata) {
     isPlainObject(metadata.environment) &&
     isPlainObject(metadata.technical)
   );
+}
+
+export const CATEGORY_UI_METADATA_KEY = 'category_phrase_v1';
+export const DEFAULT_CATEGORY_ORDER = ['yes', 'no', 'maybe', 'dont_know', 'correct', 'number'];
+const DEFAULT_CATEGORY_REQUIRED_COUNT = 3;
+
+function titleizeCategoryId(categoryId) {
+  return categoryId
+    .split('_')
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ');
+}
+
+function normalizeStringArray(value) {
+  return Array.isArray(value)
+    ? value.filter((entry) => typeof entry === 'string' && entry.trim()).map((entry) => entry.trim())
+    : [];
+}
+
+function normalizeCategoryMetadata(topicMetadata) {
+  const categories = Array.isArray(topicMetadata.categories) ? topicMetadata.categories : [];
+  const result = new Map();
+
+  for (const category of categories) {
+    if (!isPlainObject(category)) {
+      continue;
+    }
+
+    const id = normalizeOptionalString(category.id);
+    if (!id) {
+      continue;
+    }
+
+    const requiredCount = Number.parseInt(category.required_count, 10);
+    result.set(id, {
+      id,
+      title: normalizeOptionalString(category.title) || titleizeCategoryId(id),
+      required_count:
+        Number.isFinite(requiredCount) && requiredCount > 0
+          ? requiredCount
+          : DEFAULT_CATEGORY_REQUIRED_COUNT,
+    });
+  }
+
+  return result;
+}
+
+export function getTaskPhraseId(task) {
+  const taskMetadata = normalizeMetadata(task?.metadata);
+  return (
+    normalizeOptionalString(taskMetadata.phrase_id) ||
+    normalizeOptionalString(taskMetadata.prompt_id) ||
+    normalizeOptionalString(task?.id)
+  );
+}
+
+function getTaskCategory(task) {
+  const taskMetadata = normalizeMetadata(task?.metadata);
+  return normalizeOptionalString(taskMetadata.category) || 'uncategorized';
+}
+
+function getTaskNormalizedLabel(task) {
+  const taskMetadata = normalizeMetadata(task?.metadata);
+  return normalizeOptionalString(taskMetadata.label) || normalizeOptionalString(task?.text);
+}
+
+function getTaskSemanticLabel(task) {
+  const taskMetadata = normalizeMetadata(task?.metadata);
+  return normalizeOptionalString(taskMetadata.semantic_label);
+}
+
+export function getCategoryOrder(topicMetadata, tasks) {
+  const configuredOrder = normalizeStringArray(topicMetadata.category_order);
+  const orderedCategories = configuredOrder.length > 0 ? configuredOrder : DEFAULT_CATEGORY_ORDER;
+  const taskCategories = [];
+
+  for (const task of tasks) {
+    const category = getTaskCategory(task);
+    if (!taskCategories.includes(category)) {
+      taskCategories.push(category);
+    }
+  }
+
+  return [
+    ...orderedCategories,
+    ...taskCategories.filter((category) => !orderedCategories.includes(category)),
+  ];
+}
+
+export function shuffleItems(items, rng = Math.random) {
+  const shuffled = [...items];
+  for (let index = shuffled.length - 1; index > 0; index -= 1) {
+    const swapIndex = Math.floor(rng() * (index + 1));
+    [shuffled[index], shuffled[swapIndex]] = [shuffled[swapIndex], shuffled[index]];
+  }
+  return shuffled;
+}
+
+function arraysEqual(left, right) {
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return left.every((value, index) => value === right[index]);
+}
+
+function groupPhraseIdsByCategory(tasks, categoryOrder) {
+  const grouped = new Map(categoryOrder.map((categoryId) => [categoryId, []]));
+
+  for (const task of tasks) {
+    const phraseId = getTaskPhraseId(task);
+    if (!phraseId) {
+      continue;
+    }
+
+    const category = getTaskCategory(task);
+    if (!grouped.has(category)) {
+      grouped.set(category, []);
+    }
+
+    grouped.get(category).push(phraseId);
+  }
+
+  return grouped;
+}
+
+export function ensureCategoryPhraseUiState(
+  sessionMetadata,
+  tasks,
+  topicMetadata,
+  options = {}
+) {
+  const metadata = normalizeMetadata(sessionMetadata);
+  const topic = normalizeMetadata(topicMetadata);
+  const now = options.now || new Date().toISOString();
+  const rng = options.rng || Math.random;
+  const uiMetadata = normalizeMetadata(metadata.ui);
+  const existingState = normalizeMetadata(uiMetadata[CATEGORY_UI_METADATA_KEY]);
+  const existingOrderByCategory = normalizeMetadata(existingState.phrase_order_by_category);
+  const categoryOrder = getCategoryOrder(topic, tasks);
+  const grouped = groupPhraseIdsByCategory(tasks, categoryOrder);
+  const phraseOrderByCategory = {};
+  let changed = !isPlainObject(uiMetadata[CATEGORY_UI_METADATA_KEY]);
+
+  for (const categoryId of categoryOrder) {
+    const phraseIds = grouped.get(categoryId) || [];
+    const phraseIdSet = new Set(phraseIds);
+    const storedOrder = normalizeStringArray(existingOrderByCategory[categoryId]).filter((phraseId) =>
+      phraseIdSet.has(phraseId)
+    );
+    const missingPhraseIds = phraseIds.filter((phraseId) => !storedOrder.includes(phraseId));
+    const nextOrder =
+      storedOrder.length > 0 || isPlainObject(uiMetadata[CATEGORY_UI_METADATA_KEY])
+        ? [...storedOrder, ...missingPhraseIds]
+        : shuffleItems(phraseIds, rng);
+
+    phraseOrderByCategory[categoryId] = nextOrder;
+
+    if (
+      !arraysEqual(normalizeStringArray(existingOrderByCategory[categoryId]), nextOrder) ||
+      !arraysEqual(normalizeStringArray(existingState.category_order), categoryOrder)
+    ) {
+      changed = true;
+    }
+  }
+
+  const state = {
+    category_order: categoryOrder,
+    phrase_order_by_category: phraseOrderByCategory,
+    created_at: normalizeOptionalString(existingState.created_at) || now,
+    updated_at: changed
+      ? now
+      : normalizeOptionalString(existingState.updated_at) ||
+        normalizeOptionalString(existingState.created_at) ||
+        now,
+  };
+
+  return {
+    changed,
+    state,
+    metadata: {
+      ...metadata,
+      ui: {
+        ...uiMetadata,
+        [CATEGORY_UI_METADATA_KEY]: state,
+      },
+    },
+  };
+}
+
+function getCountForPhrase(counts, phraseId) {
+  if (counts instanceof Map) {
+    return Number.parseInt(counts.get(phraseId), 10) || 0;
+  }
+
+  if (isPlainObject(counts)) {
+    return Number.parseInt(counts[phraseId], 10) || 0;
+  }
+
+  return 0;
+}
+
+function setHas(setLike, phraseId) {
+  if (setLike instanceof Set) {
+    return setLike.has(phraseId);
+  }
+
+  if (Array.isArray(setLike)) {
+    return setLike.includes(phraseId);
+  }
+
+  return false;
+}
+
+function getTasksByPhraseId(tasks) {
+  const result = new Map();
+  for (const task of tasks) {
+    const phraseId = getTaskPhraseId(task);
+    if (phraseId && !result.has(phraseId)) {
+      result.set(phraseId, task);
+    }
+  }
+
+  return result;
+}
+
+export function buildCategoryStatePayload({
+  tasks,
+  topicMetadata = {},
+  phraseUiState = {},
+  currentRecordingCounts = new Map(),
+  previousPhraseIds = new Set(),
+}) {
+  const topic = normalizeMetadata(topicMetadata);
+  const categoryMetadata = normalizeCategoryMetadata(topic);
+  const categoryOrder = normalizeStringArray(phraseUiState.category_order);
+  const effectiveCategoryOrder = categoryOrder.length > 0 ? categoryOrder : getCategoryOrder(topic, tasks);
+  const orderByCategory = normalizeMetadata(phraseUiState.phrase_order_by_category);
+  const tasksByPhraseId = getTasksByPhraseId(tasks);
+  let previousCategoriesMeetRequired = true;
+
+  const categories = effectiveCategoryOrder.map((categoryId, categoryIndex) => {
+    const taskIdsInCategory = tasks
+      .filter((task) => getTaskCategory(task) === categoryId)
+      .map((task) => getTaskPhraseId(task))
+      .filter(Boolean);
+    const storedOrder = normalizeStringArray(orderByCategory[categoryId]).filter((phraseId) =>
+      tasksByPhraseId.has(phraseId)
+    );
+    const orderedPhraseIds = [
+      ...storedOrder,
+      ...taskIdsInCategory.filter((phraseId) => !storedOrder.includes(phraseId)),
+    ];
+    const categoryInfo = categoryMetadata.get(categoryId) || {
+      id: categoryId,
+      title: titleizeCategoryId(categoryId),
+      required_count: DEFAULT_CATEGORY_REQUIRED_COUNT,
+    };
+    const currentUnique = new Set();
+    const previousUnique = new Set();
+    const combinedUnique = new Set();
+    const phrases = orderedPhraseIds
+      .map((phraseId) => tasksByPhraseId.get(phraseId))
+      .filter(Boolean)
+      .map((task) => {
+        const phraseId = getTaskPhraseId(task);
+        const currentCount = getCountForPhrase(currentRecordingCounts, phraseId);
+        const recordedInCurrentSession = currentCount > 0;
+        const recordedPreviouslyOnDevice = setHas(previousPhraseIds, phraseId);
+
+        if (recordedInCurrentSession) {
+          currentUnique.add(phraseId);
+          combinedUnique.add(phraseId);
+        }
+
+        if (recordedPreviouslyOnDevice) {
+          previousUnique.add(phraseId);
+          combinedUnique.add(phraseId);
+        }
+
+        return {
+          taskId: task.id,
+          phraseId,
+          text: task.text,
+          category: getTaskCategory(task),
+          semanticLabel: getTaskSemanticLabel(task),
+          normalizedLabel: getTaskNormalizedLabel(task),
+          recordedInCurrentSession,
+          recordedPreviouslyOnDevice,
+          recordingCountCurrentSession: currentCount,
+        };
+      });
+    const totalPhrases = phrases.length;
+    const requiredCount =
+      totalPhrases > 0 ? Math.min(categoryInfo.required_count, totalPhrases) : 0;
+    const uniqueRecordedCount = combinedUnique.size;
+    const unlocked = categoryIndex === 0 || previousCategoriesMeetRequired;
+    const complete = totalPhrases === 0 || uniqueRecordedCount >= totalPhrases;
+    const category = {
+      id: categoryId,
+      title: categoryInfo.title,
+      totalPhrases,
+      requiredCount,
+      unlocked,
+      complete,
+      progress: {
+        currentSessionUniqueCount: currentUnique.size,
+        previousSameDeviceUniqueCount: previousUnique.size,
+        uniqueRecordedCount,
+        totalPhrases,
+      },
+      phrases,
+    };
+
+    previousCategoriesMeetRequired =
+      previousCategoriesMeetRequired && uniqueRecordedCount >= requiredCount;
+
+    return category;
+  });
+
+  const firstBelowRequired = categories.find(
+    (category) => category.progress.uniqueRecordedCount < category.requiredCount
+  );
+  const firstIncomplete = categories.find((category) => !category.complete);
+
+  return {
+    categoryOrder: effectiveCategoryOrder,
+    activeCategoryId:
+      firstBelowRequired?.id || firstIncomplete?.id || categories[categories.length - 1]?.id || null,
+    categories,
+  };
 }
 
 function buildSessionPayload(row) {
@@ -64,6 +399,9 @@ export class TaskProvider {
   constructor(connString, options = {}) {
     this.connString = connString;
     this.sessionIdleTimeoutHours = options.sessionIdleTimeoutHours || 24;
+    this.datasetId = options.datasetId || process.env.DATASET_ID || 'short_finnish_responses';
+    this.datasetVersion = options.datasetVersion || process.env.DATASET_VERSION || 'v2';
+    this.rng = options.rng || Math.random;
   }
 
   async withClient(run) {
@@ -106,7 +444,7 @@ export class TaskProvider {
           ps.exited_at,
           t.name AS topic_name,
           t.task_count,
-          COUNT(r.id)::integer AS completed_task_count
+          COUNT(DISTINCT r.task_id)::integer AS completed_task_count
         FROM participant_sessions ps
         JOIN topics t
           ON t.id = ps.topic_id
@@ -186,10 +524,19 @@ export class TaskProvider {
 
         // Topic copies are intentionally single-use. Once a participant_sessions row exists for
         // a topic, that copy is not reused, even after the session is completed or abandoned.
-        const topicResult = await client.query(`
+        const topicIdPrefix = `${this.datasetId}_${this.datasetVersion}_%`;
+        const topicResult = await client.query(
+          `
           SELECT t.id
           FROM topics t
-          WHERE NOT EXISTS (
+          WHERE (
+              (
+                COALESCE(t.metadata, '{}'::jsonb)->>'dataset_id' = $1
+                AND COALESCE(t.metadata, '{}'::jsonb)->>'dataset_version' = $2
+              )
+              OR t.id LIKE $3
+            )
+            AND NOT EXISTS (
             SELECT 1
             FROM participant_sessions ps
             WHERE ps.topic_id = t.id
@@ -197,7 +544,9 @@ export class TaskProvider {
           ORDER BY t.id ASC
           LIMIT 1
           FOR UPDATE SKIP LOCKED
-        `);
+        `,
+          [this.datasetId, this.datasetVersion, topicIdPrefix]
+        );
 
         if (topicResult.rowCount === 0) {
           await client.query('ROLLBACK');
@@ -307,6 +656,176 @@ export class TaskProvider {
         session: refreshedSession,
         task: taskResult.rows[0],
         progress: refreshedSession.progress,
+      };
+    });
+  }
+
+  async getTopicTasks(client, topicId) {
+    const topicResult = await client.query(
+      `
+        SELECT COALESCE(metadata, '{}'::jsonb) AS metadata
+        FROM topics
+        WHERE id = $1
+        LIMIT 1
+      `,
+      [topicId]
+    );
+    const taskResult = await client.query(
+      `
+        SELECT
+          id,
+          topic_id,
+          task_idx,
+          text,
+          COALESCE(metadata, '{}'::jsonb) AS metadata
+        FROM tasks
+        WHERE topic_id = $1
+        ORDER BY task_idx ASC
+      `,
+      [topicId]
+    );
+
+    return {
+      topicMetadata: normalizeMetadata(topicResult.rows[0]?.metadata),
+      tasks: taskResult.rows,
+    };
+  }
+
+  async updateSessionMetadataDocument(client, sessionId, metadata) {
+    await client.query(
+      `
+        UPDATE participant_sessions
+        SET metadata = $2::jsonb,
+            updated_at = NOW(),
+            last_activity_at = NOW()
+        WHERE id = $1
+      `,
+      [sessionId, normalizeMetadata(metadata)]
+    );
+  }
+
+  async getCurrentSessionPhraseCounts(client, sessionId) {
+    const result = await client.query(
+      `
+        SELECT
+          COALESCE(
+            r.metadata->>'phrase_id',
+            tk.metadata->>'phrase_id',
+            tk.metadata->>'prompt_id',
+            r.task_id
+          ) AS phrase_id,
+          COUNT(r.id)::integer AS recording_count
+        FROM recordings r
+        LEFT JOIN tasks tk
+          ON tk.id = r.task_id
+        WHERE r.session_id = $1
+        GROUP BY COALESCE(
+          r.metadata->>'phrase_id',
+          tk.metadata->>'phrase_id',
+          tk.metadata->>'prompt_id',
+          r.task_id
+        )
+      `,
+      [sessionId]
+    );
+
+    return new Map(
+      result.rows
+        .map((row) => [normalizeOptionalString(row.phrase_id), row.recording_count])
+        .filter(([phraseId]) => phraseId)
+    );
+  }
+
+  async getPreviousSameDevicePhraseIds(client, session, currentPhraseIds) {
+    const deviceId = normalizeOptionalString(session.metadata?.device_id);
+    if (!deviceId) {
+      return new Set();
+    }
+
+    const result = await client.query(
+      `
+        SELECT DISTINCT
+          COALESCE(
+            r.metadata->>'phrase_id',
+            tk.metadata->>'phrase_id',
+            tk.metadata->>'prompt_id',
+            r.task_id
+          ) AS phrase_id
+        FROM recordings r
+        JOIN participant_sessions ps
+          ON ps.id = r.session_id
+        LEFT JOIN tasks tk
+          ON tk.id = r.task_id
+        WHERE ps.id <> $1
+          AND ps.metadata->>'device_id' = $2
+      `,
+      [session.id, deviceId]
+    );
+
+    return new Set(
+      result.rows
+        .map((row) => normalizeOptionalString(row.phrase_id))
+        .filter((phraseId) => phraseId && currentPhraseIds.has(phraseId))
+    );
+  }
+
+  async getCategoryState(sessionToken) {
+    return this.withClient(async (client) => {
+      await this.expireStaleSessions(client);
+      let session = await this.getSessionSummaryByToken(client, sessionToken);
+
+      if (!session) {
+        return {
+          success: false,
+          code: 'invalid_session',
+          message: 'Session was not found.',
+        };
+      }
+
+      if (session.status === SESSION_STATUS.ACTIVE && !hasRequiredSessionMetadata(session.metadata)) {
+        return {
+          success: false,
+          code: 'session_metadata_required',
+          message: 'Session details must be completed before loading category progress.',
+          session,
+        };
+      }
+
+      const { tasks, topicMetadata } = await this.getTopicTasks(client, session.topicId);
+      const phraseUiState = ensureCategoryPhraseUiState(session.metadata, tasks, topicMetadata, {
+        rng: this.rng,
+      });
+
+      if (phraseUiState.changed && session.status === SESSION_STATUS.ACTIVE) {
+        await this.updateSessionMetadataDocument(client, session.id, phraseUiState.metadata);
+        session = await this.getSessionSummaryByToken(client, sessionToken);
+      }
+
+      const currentPhraseIds = new Set(tasks.map((task) => getTaskPhraseId(task)).filter(Boolean));
+      const currentRecordingCounts = await this.getCurrentSessionPhraseCounts(client, session.id);
+      const previousPhraseIds = await this.getPreviousSameDevicePhraseIds(
+        client,
+        session,
+        currentPhraseIds
+      );
+      const categoryState = buildCategoryStatePayload({
+        tasks,
+        topicMetadata,
+        phraseUiState: phraseUiState.state,
+        currentRecordingCounts,
+        previousPhraseIds,
+      });
+
+      if (session.status === SESSION_STATUS.ACTIVE) {
+        await this.touchSession(client, session.id);
+        session = await this.getSessionSummaryByToken(client, sessionToken);
+      }
+
+      return {
+        success: true,
+        sessionStatus: session.status,
+        session,
+        ...categoryState,
       };
     });
   }
@@ -456,9 +975,11 @@ export class TaskProvider {
 
       try {
         await client.query('BEGIN');
+        const recordingId = recordingDetails.recordingId || randomUUID();
         const insertResult = await client.query(
           `
             INSERT INTO recordings (
+              id,
               session_id,
               task_id,
               storage_type,
@@ -467,17 +988,11 @@ export class TaskProvider {
               submitted_at,
               metadata
             )
-            VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb)
-            ON CONFLICT (session_id, task_id)
-            DO UPDATE SET
-              storage_type = EXCLUDED.storage_type,
-              storage_key = EXCLUDED.storage_key,
-              duration_sec = EXCLUDED.duration_sec,
-              submitted_at = EXCLUDED.submitted_at,
-              metadata = EXCLUDED.metadata
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb)
             RETURNING id
           `,
           [
+            recordingId,
             session.id,
             taskId,
             recordingDetails.storageType,

--- a/backend/src/taskProvider.test.js
+++ b/backend/src/taskProvider.test.js
@@ -1,7 +1,13 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { calculateProgress, hasRequiredSessionMetadata, TaskProvider } from './taskProvider.js';
+import {
+  buildCategoryStatePayload,
+  calculateProgress,
+  ensureCategoryPhraseUiState,
+  hasRequiredSessionMetadata,
+  TaskProvider,
+} from './taskProvider.js';
 
 const validV1SessionMetadata = {
   schema_version: 'v1',
@@ -117,4 +123,264 @@ test('getUploadTarget allows valid v1 session metadata', async () => {
   assert.equal(result.task.text, 'Kyllä');
   assert.equal(result.task.metadata.label, 'kylla');
   assert.equal(getTaskQueryCount(), 1);
+});
+
+test('category phrase order is stable and appends newly added phrases', () => {
+  const topicMetadata = {
+    category_order: ['yes'],
+  };
+  const initialTasks = [
+    {
+      id: 'topic_yes_kylla',
+      task_idx: 0,
+      text: 'Kylla',
+      metadata: { phrase_id: 'yes_kylla', category: 'yes' },
+    },
+    {
+      id: 'topic_yes_joo',
+      task_idx: 1,
+      text: 'Joo',
+      metadata: { phrase_id: 'yes_joo', category: 'yes' },
+    },
+    {
+      id: 'topic_yes_on',
+      task_idx: 2,
+      text: 'On',
+      metadata: { phrase_id: 'yes_on', category: 'yes' },
+    },
+  ];
+
+  const first = ensureCategoryPhraseUiState({}, initialTasks, topicMetadata, {
+    now: '2026-05-25T00:00:00.000Z',
+    rng: () => 0,
+  });
+  const next = ensureCategoryPhraseUiState(
+    first.metadata,
+    [
+      ...initialTasks,
+      {
+        id: 'topic_yes_olen',
+        task_idx: 3,
+        text: 'Olen',
+        metadata: { phrase_id: 'yes_olen', category: 'yes' },
+      },
+    ],
+    topicMetadata,
+    {
+      now: '2026-05-25T00:01:00.000Z',
+      rng: () => 0.99,
+    }
+  );
+
+  assert.deepEqual(first.state.phrase_order_by_category.yes, [
+    'yes_joo',
+    'yes_on',
+    'yes_kylla',
+  ]);
+  assert.deepEqual(next.state.phrase_order_by_category.yes, [
+    'yes_joo',
+    'yes_on',
+    'yes_kylla',
+    'yes_olen',
+  ]);
+});
+
+test('new sessions can receive different phrase orders when enough phrases exist', () => {
+  const tasks = [
+    { id: 'topic_yes_1', task_idx: 0, text: 'A', metadata: { phrase_id: 'yes_1', category: 'yes' } },
+    { id: 'topic_yes_2', task_idx: 1, text: 'B', metadata: { phrase_id: 'yes_2', category: 'yes' } },
+    { id: 'topic_yes_3', task_idx: 2, text: 'C', metadata: { phrase_id: 'yes_3', category: 'yes' } },
+  ];
+
+  const first = ensureCategoryPhraseUiState({}, tasks, { category_order: ['yes'] }, { rng: () => 0 });
+  const second = ensureCategoryPhraseUiState(
+    {},
+    tasks,
+    { category_order: ['yes'] },
+    { rng: () => 0.99 }
+  );
+
+  assert.notDeepEqual(
+    first.state.phrase_order_by_category.yes,
+    second.state.phrase_order_by_category.yes
+  );
+});
+
+test('category state counts distinct current and previous same-device phrases for unlocks', () => {
+  const tasks = [
+    {
+      id: 'topic_yes_kylla',
+      task_idx: 0,
+      text: 'Kylla',
+      metadata: {
+        phrase_id: 'yes_kylla',
+        label: 'kylla',
+        semantic_label: 'yes',
+        category: 'yes',
+      },
+    },
+    {
+      id: 'topic_yes_joo',
+      task_idx: 1,
+      text: 'Joo',
+      metadata: { phrase_id: 'yes_joo', label: 'joo', semantic_label: 'yes', category: 'yes' },
+    },
+    {
+      id: 'topic_yes_on',
+      task_idx: 2,
+      text: 'On',
+      metadata: { phrase_id: 'yes_on', label: 'on', semantic_label: 'yes', category: 'yes' },
+    },
+    {
+      id: 'topic_no_ei',
+      task_idx: 3,
+      text: 'Ei',
+      metadata: { phrase_id: 'no_ei', label: 'ei', semantic_label: 'no', category: 'no' },
+    },
+    {
+      id: 'topic_no_en',
+      task_idx: 4,
+      text: 'En',
+      metadata: { phrase_id: 'no_en', label: 'en', semantic_label: 'no', category: 'no' },
+    },
+    {
+      id: 'topic_correct_niin',
+      task_idx: 5,
+      text: 'Niin',
+      metadata: {
+        phrase_id: 'correct_niin',
+        label: 'niin',
+        semantic_label: 'correct',
+        category: 'correct',
+      },
+    },
+  ];
+  const phraseUiState = {
+    category_order: ['yes', 'no', 'correct'],
+    phrase_order_by_category: {
+      yes: ['yes_kylla', 'yes_joo', 'yes_on'],
+      no: ['no_ei', 'no_en'],
+      correct: ['correct_niin'],
+    },
+  };
+
+  const payload = buildCategoryStatePayload({
+    tasks,
+    topicMetadata: {
+      category_order: ['yes', 'no', 'correct'],
+      categories: [
+        { id: 'yes', title: 'Yes', required_count: 3 },
+        { id: 'no', title: 'No', required_count: 3 },
+        { id: 'correct', title: 'Correct', required_count: 3 },
+      ],
+    },
+    phraseUiState,
+    currentRecordingCounts: new Map([
+      ['yes_kylla', 2],
+      ['yes_joo', 1],
+      ['no_ei', 2],
+    ]),
+    previousPhraseIds: new Set(['yes_on', 'no_en', 'correct_niin']),
+  });
+
+  const [yes, no, correct] = payload.categories;
+
+  assert.equal(yes.requiredCount, 3);
+  assert.equal(yes.progress.currentSessionUniqueCount, 2);
+  assert.equal(yes.progress.previousSameDeviceUniqueCount, 1);
+  assert.equal(yes.progress.uniqueRecordedCount, 3);
+  assert.equal(yes.phrases[0].recordingCountCurrentSession, 2);
+  assert.equal(no.requiredCount, 2);
+  assert.equal(no.unlocked, true);
+  assert.equal(no.progress.uniqueRecordedCount, 2);
+  assert.equal(correct.requiredCount, 1);
+  assert.equal(correct.unlocked, true);
+  assert.equal(correct.progress.uniqueRecordedCount, 1);
+  assert.equal(payload.activeCategoryId, 'correct');
+});
+
+test('legacy category rows without semantic_label stay readable', () => {
+  const payload = buildCategoryStatePayload({
+    tasks: [
+      {
+        id: 'legacy_topic_kylla',
+        task_idx: 0,
+        text: 'Kylla',
+        metadata: {
+          prompt_id: 'kylla',
+          label: 'kylla',
+          category: 'affirmative',
+        },
+      },
+    ],
+    topicMetadata: { category_order: ['affirmative'] },
+    phraseUiState: {
+      category_order: ['affirmative'],
+      phrase_order_by_category: { affirmative: ['kylla'] },
+    },
+  });
+
+  assert.equal(payload.categories[0].phrases[0].phraseId, 'kylla');
+  assert.equal(payload.categories[0].phrases[0].semanticLabel, null);
+});
+
+test('submitRecording inserts repeat recordings as separate rows', async () => {
+  const provider = new TaskProvider('postgresql://example');
+  const inserts = [];
+
+  provider.withClient = async (run) =>
+    run({
+      query: async (sql, params = []) => {
+        if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') {
+          return { rowCount: 0, rows: [] };
+        }
+
+        if (sql.includes('FROM tasks')) {
+          return { rowCount: 1, rows: [{ id: 'task-123' }] };
+        }
+
+        if (sql.includes('INSERT INTO recordings')) {
+          assert.doesNotMatch(sql, /ON CONFLICT/);
+          inserts.push(params);
+          return { rowCount: 1, rows: [{ id: params[0] }] };
+        }
+
+        return { rowCount: 0, rows: [] };
+      },
+    });
+  provider.expireStaleSessions = async () => {};
+  provider.touchSession = async () => {};
+  provider.getSessionSummaryByToken = async () => ({
+    id: 'session-123',
+    sessionToken: 'session-token',
+    topicId: 'topic-123',
+    status: 'active',
+    metadata: validV1SessionMetadata,
+    progress: {
+      totalTasks: 2,
+      completedTasks: 1,
+      remainingTasks: 1,
+    },
+  });
+
+  const first = await provider.submitRecording('session-token', 'task-123', {
+    recordingId: '11111111-1111-4111-8111-111111111111',
+    storageType: 'local',
+    storageKey: 'session-123/task-123/11111111-1111-4111-8111-111111111111.wav',
+    durationSec: 0.8,
+    metadata: { phrase_id: 'yes_kylla' },
+  });
+  const second = await provider.submitRecording('session-token', 'task-123', {
+    recordingId: '22222222-2222-4222-8222-222222222222',
+    storageType: 'local',
+    storageKey: 'session-123/task-123/22222222-2222-4222-8222-222222222222.wav',
+    durationSec: 0.9,
+    metadata: { phrase_id: 'yes_kylla' },
+  });
+
+  assert.equal(first.success, true);
+  assert.equal(second.success, true);
+  assert.equal(inserts.length, 2);
+  assert.equal(inserts[0][0], '11111111-1111-4111-8111-111111111111');
+  assert.equal(inserts[1][0], '22222222-2222-4222-8222-222222222222');
 });

--- a/docs/aina-data-contract.md
+++ b/docs/aina-data-contract.md
@@ -1,8 +1,8 @@
-# AINA Speech Collector Data Contract v1
+# AINA Speech Collector Data Contract
 
 ## Purpose
 
-`schema_version = "v1"` is the first stable contract between the browser collector, backend storage, and downstream dataset tooling. The collector stores live data safely as PostgreSQL rows plus audio files in local storage or S3-compatible storage. The normal collector export is produced by `scripts/aina/exportDataset.js`. The current audio-classifier databuilder receives a separate compatibility bridge from `scripts/aina/exportDatabuilderDataset.js`.
+`schema_version = "v1"` remains the stable session/recording metadata shape. The active AINA prompt bank is `short_finnish_responses` `v2`, which adds category UI metadata, `phrase_id`, and nullable `semantic_label` while keeping `normalized_label` as the phrase-level classifier target. The collector stores live data safely as PostgreSQL rows plus audio files in local storage or S3-compatible storage. The normal collector export is produced by `scripts/aina/exportDataset.js`. The current audio-classifier databuilder receives a separate compatibility bridge from `scripts/aina/exportDatabuilderDataset.js`.
 
 The frontend must not append directly to a shared `samples.jsonl` file. Public volunteers can upload at the same time, and concurrent appends to one shared manifest can corrupt data. Each upload is stored as one database recording row plus one audio object/file, then exporters create derived handoff files.
 
@@ -12,6 +12,7 @@ The frontend must not append directly to a shared `samples.jsonl` file. Public v
 - Local storage or S3 stores audio files.
 - `recordings.metadata` stores recording-level v1 metadata without a DB schema change.
 - `participant_sessions.metadata` stores session-level v1 metadata without a DB schema change.
+- Each upload inserts a new `recordings` row. Repeat recordings for the same `(session_id, task_id)` are separate samples.
 - Backend safety limits are authoritative. The frontend timer improves UX, but the backend rejects files that are too large or too long.
 
 ## Session Metadata
@@ -46,7 +47,7 @@ Required v1 shape:
 }
 ```
 
-The volunteer does not type `device_id`, ISO language codes, browser user agent, OS, browser, or device type. `device_id` is an anonymous browser UUID stored in `localStorage` under `aina.speechCollector.deviceId`; it is not a real hardware ID or serial number.
+The volunteer does not type `device_id`, ISO language codes, browser user agent, OS, browser, or device type. `device_id` is an anonymous browser UUID stored in `localStorage` under `aina.speechCollector.deviceId` after consent is accepted; it is not a real hardware ID or serial number. It is used to resume an active session and show which phrases this browser has already recorded.
 
 `native_language_other` is only shown and stored when `native_language` is `other`; otherwise it is `null`. `dialect_region_other` behaves the same way for `dialect_region = "other"`.
 
@@ -60,12 +61,14 @@ Required v1 shape:
 {
   "schema_version": "v1",
   "timestamp": "2026-05-03T12:00:00.000Z",
+  "phrase_id": "yes_kylla",
+  "semantic_label": "yes",
   "prompted_word": "Kyllä",
   "normalized_label": "kylla",
   "literal_transcript": null,
   "label_source": "prompt_assumed",
   "language": "fi",
-  "category": "affirmative",
+  "category": "yes",
   "technical": {
     "sample_rate_hz": 48000,
     "channel_count": 1,
@@ -83,11 +86,11 @@ Required v1 shape:
 }
 ```
 
-The backend derives `prompted_word`, `normalized_label`, `language`, and `category` from the task row. The frontend is not trusted for classifier labels.
+The backend derives `phrase_id`, `semantic_label`, `prompted_word`, `normalized_label`, `language`, and `category` from the task row. The frontend is not trusted for classifier labels or category metadata.
 
 The `technical` object keeps browser/media-stream capture metadata. `processed_audio` describes the audio file after backend processing; saved recordings are WAV PCM 16-bit, 16 kHz, mono.
 
-`normalized_label` is the required canonical classifier training label. For compatibility with the current audio-classifier loader, labels remain ASCII, for example `kylla` and `eipa`. `prompted_word` stores the Finnish display text, for example `Kyllä`.
+`normalized_label` is the required canonical classifier training label. For compatibility with the current audio-classifier loader, labels remain ASCII, for example `kylla`, `ei_oo`, and `kaks`. `semantic_label` is broader metadata for future targets, for example `yes`, `no`, or `number_2`. `prompted_word` stores the Finnish display text, for example `Kyllä`.
 
 `literal_transcript` is optional metadata for review/debugging. It is `null` when the volunteer leaves the transcript unchanged or empty. It is a trimmed string when the volunteer edits the "What did you actually say?" field.
 
@@ -98,6 +101,23 @@ Allowed `label_source` values:
 - `reviewed`: reserved for a later manual review workflow.
 
 The classifier should train on `normalized_label`, not `literal_transcript`.
+
+## Category Progress Metadata
+
+The category UI backend stores session-specific phrase order in `participant_sessions.metadata.ui.category_phrase_v1`:
+
+```json
+{
+  "category_order": ["yes", "no", "maybe", "dont_know", "correct", "number"],
+  "phrase_order_by_category": {
+    "yes": ["yes_kyl", "yes_joo", "yes_kylla"]
+  },
+  "created_at": "2026-05-25T00:00:00.000Z",
+  "updated_at": "2026-05-25T00:00:00.000Z"
+}
+```
+
+Progress counts unique `phrase_id` values. Repeat recordings are exported as additional samples but do not increase unique phrase progress twice. Previous recordings from the same anonymous browser `device_id` count toward category unlocks.
 
 ## Safety And Turnstile
 
@@ -121,7 +141,7 @@ Turnstile is a session-start gate only. When `TURNSTILE_SECRET_KEY` is configure
 `scripts/aina/exportDataset.js` writes:
 
 ```text
-exports/short-finnish-responses/v1/
+exports/short-finnish-responses/v2/
   metadata/
     dataset.json
     samples.jsonl
@@ -140,8 +160,10 @@ Example exported row:
 ```json
 {
   "sample_id": "recording-uuid",
-  "audio_path": "session-uuid/task-id.wav",
+  "audio_path": "session-uuid/task-id/recording-uuid.wav",
   "prompted_word": "Kyllä",
+  "phrase_id": "yes_kylla",
+  "semantic_label": "yes",
   "normalized_label": "kylla",
   "label": "kylla",
   "transcript": "Kyllä",
@@ -181,13 +203,15 @@ Example exported row:
       "encoding": "pcm_s16le"
     },
     "collection": {
-      "topic_id": "short_finnish_responses_v1_0001",
-      "task_id": "short_finnish_responses_v1_0001_kylla",
+      "topic_id": "short_finnish_responses_v2_0001",
+      "task_id": "short_finnish_responses_v2_0001_yes_kylla",
       "session_id": "session-uuid",
       "session_status": "completed",
       "submitted_at": "2026-05-03T12:00:00.000Z",
       "storage_type": "local",
-      "category": "affirmative"
+      "category": "yes",
+      "phrase_id": "yes_kylla",
+      "semantic_label": "yes"
     }
   }
 }
@@ -202,7 +226,7 @@ Example exported row:
 It writes:
 
 ```text
-exports/short-finnish-responses/v1/databuilder/
+exports/short-finnish-responses/v2/databuilder/
   manifest.json
   <sample_id>.wav
   <sample_id>.json
@@ -211,7 +235,7 @@ exports/short-finnish-responses/v1/databuilder/
 The output directory and manifest version can be configured with:
 
 ```env
-DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v1/databuilder
+DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v2/databuilder
 DATABUILDER_MANIFEST_VERSION=20260501001
 ```
 
@@ -245,12 +269,14 @@ Each `<sample_id>.json` sidecar is root-level for fields used by classifier filt
 {
   "sample_id": "recording-uuid",
   "timestamp": "2026-05-03T12:00:00.000Z",
-  "prompted_word": "Kyll??",
+  "prompted_word": "Kyllä",
+  "phrase_id": "yes_kylla",
+  "semantic_label": "yes",
   "normalized_label": "kylla",
   "literal_transcript": null,
   "label_source": "prompt_assumed",
   "language": "fi",
-  "category": "affirmative",
+  "category": "yes",
   "augmentation_strategy": null,
   "augmentations": [],
   "device_id": "dev_ab12cd34ef56",

--- a/docs/aina-refactor-plan.md
+++ b/docs/aina-refactor-plan.md
@@ -23,7 +23,7 @@ browser
 1. Replace volunteer login/account routes with anonymous session routes.
 2. Replace `users`-based task assignment with `participant_sessions` + `recordings`.
 3. Keep prompt copies as immutable topics/tasks seeded ahead of time.
-4. Store audio with deterministic `{session_id}/{task_id}.wav` relative keys.
+4. Store audio with unique `{session_id}/{task_id}/{recording_id}.wav` relative keys.
 5. Make the exporter reference the real storage layout directly instead of copying local audio as the canonical path.
 6. Replace login-first frontend UX with intro, metadata, recording, exit, and completion states.
 
@@ -31,6 +31,7 @@ browser
 
 - `POST /api/start-session`
 - `POST /api/get-task`
+- `POST /api/category-state`
 - `POST /api/update-session-metadata`
 - `POST /api/upload-sound`
 - `POST /api/exit-session`
@@ -45,7 +46,7 @@ browser
 
 ## Storage Contract
 
-- `storage_key` is always relative, for example `session-id/task-id.wav`
+- `storage_key` is always relative, for example `session-id/task-id/recording-id.wav`
 - S3 object key is `{COLLECTION_AUDIO_PREFIX}/{storage_key}`
 - export manifest `audio_path` is `storage_key`
 - export `audio_root` points at the permanent storage root

--- a/docs/aina-s3-integration.md
+++ b/docs/aina-s3-integration.md
@@ -9,7 +9,7 @@ volunteer session
   -> PostgreSQL participant_sessions row
   -> prompt task from tasks/topic copy
   -> upload processed by backend
-  -> deterministic storage_key
+  -> unique storage_key
   -> S3 object key
   -> recordings row
   -> exportDataset.js writes manifests
@@ -20,19 +20,19 @@ volunteer session
 Relative recording key:
 
 ```text
-{session_id}/{task_id}.wav
+{session_id}/{task_id}/{recording_id}.wav
 ```
 
 S3 object key:
 
 ```text
-{COLLECTION_AUDIO_PREFIX}/{session_id}/{task_id}.wav
+{COLLECTION_AUDIO_PREFIX}/{session_id}/{task_id}/{recording_id}.wav
 ```
 
 Example:
 
 ```text
-short-finnish-responses/v1/audio/92b65d47-.../short_finnish_responses_v1_0001_kylla.wav
+short-finnish-responses/v2/audio/92b65d47-.../short_finnish_responses_v2_0001_yes_kylla/11111111-1111-4111-8111-111111111111.wav
 ```
 
 ## Why The Exporter Uses Direct References
@@ -47,6 +47,8 @@ Instead:
 
 That keeps the manifest aligned with the real audio location in both local and S3 modes.
 
+`recordings.id` is generated before storage, and the ID is included in the audio path. Re-recording the same phrase creates a new row and a new object/file instead of overwriting the earlier sample.
+
 ## Local Mode
 
 ```env
@@ -57,7 +59,7 @@ SOUND_RECORDINGS_PATH=tmp/recordings
 Local uploads are persisted to:
 
 ```text
-SOUND_RECORDINGS_PATH/{session_id}/{task_id}.wav
+SOUND_RECORDINGS_PATH/{session_id}/{task_id}/{recording_id}.wav
 ```
 
 Relative local paths are resolved from the `apps/speech-collector` root so backend persistence and export use the same absolute directory.
@@ -66,7 +68,7 @@ Export derives:
 
 ```text
 audio_root=<absolute SOUND_RECORDINGS_PATH>
-audio_path={session_id}/{task_id}.wav
+audio_path={session_id}/{task_id}/{recording_id}.wav
 ```
 
 ## AWS S3 Mode
@@ -75,14 +77,14 @@ audio_path={session_id}/{task_id}.wav
 STORAGE=aws-s3
 AWS_BUCKET_NAME=<bucket>
 AWS_REGION=eu-north-1
-COLLECTION_AUDIO_PREFIX=short-finnish-responses/v1/audio
+COLLECTION_AUDIO_PREFIX=short-finnish-responses/v2/audio
 ```
 
 Export derives:
 
 ```text
 audio_root=s3://<bucket>/<COLLECTION_AUDIO_PREFIX>/
-audio_path={session_id}/{task_id}.wav
+audio_path={session_id}/{task_id}/{recording_id}.wav
 ```
 
 ## Session Status And Export
@@ -119,7 +121,7 @@ cd D:\ass_vscode\AIN\packages\audio-classifier
 python - <<'PY'
 from audio_classifier.data import load_dataset
 
-dataset = load_dataset(r"D:\ass_vscode\AIN\apps\speech-collector\exports\short-finnish-responses\v1")
+dataset = load_dataset(r"D:\ass_vscode\AIN\apps\speech-collector\exports\short-finnish-responses\v2")
 print(f"loaded {len(dataset)} samples")
 print(dataset[0] if dataset else "no samples")
 PY

--- a/docs/category-phrase-ui-audit.md
+++ b/docs/category-phrase-ui-audit.md
@@ -1,0 +1,713 @@
+# Category Phrase UI Audit And Implementation Plan
+
+Scope: `apps/speech-collector/` only.
+
+This is a planning document. No runtime code was changed as part of this audit.
+
+## 1. Current System Summary
+
+The current collector is a linear prompt recorder. A volunteer starts or resumes an anonymous browser session, completes Turnstile if configured, fills a metadata and consent form, then records one prompt at a time in `task_idx` order. Each successful upload creates or replaces one `recordings` row for the current `(session_id, task_id)` and stores processed WAV audio in local storage or S3-compatible storage.
+
+Important current files:
+
+- `frontend/src/App.tsx`: phase orchestration, session start/resume, metadata, current task, exit and terminal screens.
+- `frontend/contexts/SessionProvider.tsx`: localStorage session token under `aina.speechCollector.sessionToken`.
+- `frontend/utils/deviceId.ts`: localStorage device ID under `aina.speechCollector.deviceId`.
+- `frontend/utils/sessionMetadata.ts`: v1 session metadata builder, including `device_id` and browser technical metadata.
+- `frontend/components/InfoForm.tsx`: consent and session metadata form.
+- `frontend/components/SoundRecorder.tsx`: recording, auto-stop, playback, literal transcript text input, upload.
+- `frontend/components/TurnstileGate.tsx`: Cloudflare Turnstile widget.
+- `backend/src/index.js`: Express API, Turnstile verification, upload parsing, trusted recording metadata derivation.
+- `backend/src/taskProvider.js`: session allocation, next-task selection, session metadata update, recording insert/upsert, exit and completion.
+- `backend/src/fileStorage.js`: upload re-encoding, duration safety check, local/S3 persistence, processed audio metadata.
+- `scripts/aina/short_finnish_prompts.json`: current linear prompt seed.
+- `scripts/aina/pushPrompts.js`: prompt seeding into `topics` and `tasks`.
+- `scripts/aina/exportDataset.js`: normal `dataset.json` and `samples.jsonl` export.
+- `scripts/aina/exportDatabuilderDataset.js`: strict databuilder bridge export.
+
+The current DB model is JSONB-friendly for metadata evolution:
+
+- `topics.metadata`
+- `tasks.metadata`
+- `participant_sessions.metadata`
+- `recordings.metadata`
+
+That means fields like `semantic_label`, `phrase_id`, and per-session phrase order can be added without adding ordinary DB columns. Some planned behavior still needs a migration because the current recordings table enforces one recording per task per session.
+
+## 2. Current Flow Diagram
+
+```text
+Browser loads App
+  -> SessionProvider reads session token from localStorage
+  -> if VITE_TURNSTILE_SITE_KEY exists, show TurnstileGate
+  -> POST /api/start-session
+       backend verifies Turnstile if TURNSTILE_SECRET_KEY exists
+       TaskProvider resumes active token or assigns one unused topic copy
+  -> if metadata incomplete, show SessionIntro then InfoForm
+  -> InfoForm builds v1 session metadata
+       getOrCreateDeviceId() writes localStorage device ID
+       getBrowserTechnicalMetadata() adds browser info
+  -> POST /api/update-session-metadata
+  -> POST /api/get-task
+       backend returns first unrecorded task by task_idx
+  -> TextContainer shows one prompt
+  -> SoundRecorder records audio
+       frontend auto-stops at VITE_MAX_RECORDING_SECONDS
+       user can play back and re-record before upload
+       frontend sends only literal_transcript, label_source, and technical capture metadata
+  -> POST /api/upload-sound multipart
+       multer enforces MAX_UPLOAD_BYTES
+       backend validates active session and required session metadata
+       backend derives labels from tasks row
+       FileStorage re-encodes WAV PCM 16-bit, 16 kHz, mono
+       FileStorage rejects duration over MAX_RECORDING_SECONDS + tolerance
+       TaskProvider upserts recordings row for (session_id, task_id)
+  -> user clicks Next prompt
+  -> repeat /api/get-task until no unrecorded tasks
+  -> backend marks session completed, or user exits and session becomes abandoned
+  -> exporters include completed and abandoned sessions, excluding active sessions
+```
+
+## 3. Proposed New Flow Diagram
+
+```text
+Browser loads App
+  -> Turnstile/start-session flow remains
+  -> metadata and consent flow remains
+  -> show category recording intro
+  -> POST /api/category-state
+       backend ensures per-session phrase order in participant_sessions.metadata
+       backend returns fixed category order, shuffled phrase order per category,
+       current-session progress, same-device previous progress, and unlock state
+  -> category screen
+       show category title, helper text, unique recorded / total phrases
+       show phrase cards in stored shuffled order
+       show recorded this session / recorded before / not recorded
+       volunteer selects any visible phrase
+  -> SoundRecorder records selected phrase
+       playback and re-record remain before upload
+       literal transcript confirmation uses Same as shown or typed different form
+  -> POST /api/upload-sound
+       backend still derives normalized_label, semantic_label, phrase_id, category,
+       language, and prompted_word from the trusted task row
+       repeat recordings insert new rows instead of replacing prior rows
+  -> refresh category state
+  -> Next category unlocks after min(3, category total) unique phrases
+  -> user may finish/stop anytime via secondary action
+  -> if all phrases in a category are recorded, UI may auto-advance
+  -> final screen thanks volunteer and summarizes current-session recordings
+```
+
+## 4. Direct Answers: Current System Map
+
+1. Current volunteer flow is Turnstile gate, start/resume session, intro, metadata/consent form, linear one-prompt recording, upload, next prompt, automatic completed state or explicit exit.
+2. `device_id` is generated in `frontend/utils/deviceId.ts` by `getOrCreateDeviceId()` and stored in localStorage key `aina.speechCollector.deviceId`. It is first called by `buildV1SessionMetadata()` in `frontend/utils/sessionMetadata.ts`, not at initial page load.
+3. Session metadata is created in `frontend/utils/sessionMetadata.ts`, posted by `InfoForm.tsx` to `/api/update-session-metadata`, and merged into `participant_sessions.metadata` by `TaskProvider.updateSessionMetadata()`.
+4. Prompts are loaded from `scripts/aina/short_finnish_prompts.json`, seeded by `scripts/aina/pushPrompts.js` into `topics` and `tasks`.
+5. The backend next-task decision is in `TaskProvider.getTask()`: first task in the session topic with no matching `recordings` row for that session, ordered by `task_idx`.
+6. The frontend sends upload metadata in `SoundRecorder.tsx` as multipart JSON field `metadata`, containing `schema_version`, `literal_transcript`, `label_source`, and `technical`.
+7. Backend label derivation is in `backend/src/index.js` `buildRecordingMetadata()`:
+   - `prompted_word`: `task.text`
+   - `normalized_label`: `task.metadata.label`, fallback `task.text`
+   - `category`: `task.metadata.category`
+   - `language`: `task.metadata.language`
+   - `literal_transcript`: frontend value, normalized to string or null
+   - `label_source`: frontend value if in allowed set, else `prompt_assumed`
+8. Turnstile is in `TurnstileGate.tsx` and `/api/start-session`. Auto-stop is in `SoundRecorder.tsx`. Upload size limit is multer in `backend/src/index.js`. Duration limit is in `backend/src/fileStorage.js` after ffprobe.
+9. Processed audio metadata is produced by `getProcessedAudioMetadata()` in `fileStorage.js` and attached to `recordings.metadata.processed_audio` in `/api/upload-sound`.
+10. Normal export and databuilder export read joined rows from `recordings`, `participant_sessions`, `tasks`, and `topics`. Both prefer `recordings.metadata` and fall back to task metadata where needed.
+
+## 5. Data Model Impact
+
+### JSONB fields
+
+`semantic_label` and `phrase_id` can be added to `tasks.metadata` without a DB migration because `tasks.metadata` is JSONB. The same is true for copying these fields into `recordings.metadata`.
+
+Recommended task metadata fields:
+
+```json
+{
+  "prompt_id": "yes_kyl",
+  "phrase_id": "yes_kyl",
+  "label": "kyl",
+  "semantic_label": "yes",
+  "language": "fi",
+  "category": "yes",
+  "dataset_id": "short_finnish_responses",
+  "dataset_version": "v2"
+}
+```
+
+Recommended top-level prompt seed additions:
+
+```json
+{
+  "dataset_id": "short_finnish_responses",
+  "version": "v2",
+  "language": "fi",
+  "category_order": ["yes", "no", "maybe", "dont_know", "correct", "number"],
+  "categories": [
+    { "id": "yes", "title": "Yes", "required_count": 3 },
+    { "id": "no", "title": "No", "required_count": 3 },
+    { "id": "maybe", "title": "Maybe", "required_count": 3 },
+    { "id": "dont_know", "title": "Don't know / Not sure", "required_count": 3 },
+    { "id": "correct", "title": "That's correct", "required_count": 3 },
+    { "id": "number", "title": "Numbers", "required_count": 3 }
+  ],
+  "prompts": [
+    {
+      "id": "yes_kyl",
+      "phrase_id": "yes_kyl",
+      "label": "kyl",
+      "semantic_label": "yes",
+      "text": "Kyl",
+      "category": "yes"
+    }
+  ]
+}
+```
+
+`normalized_label` must remain the phrase-level classifier target. Do not replace it with `semantic_label`.
+
+Examples:
+
+- phrase label `kyl`, semantic label `yes`
+- phrase label `ei_oo`, semantic label `no`
+- phrase label `kaks`, semantic label `number_2`
+
+### Category values
+
+For newly seeded tasks, use the planned category IDs:
+
+- `yes`
+- `no`
+- `maybe`
+- `dont_know`
+- `correct`
+- `number`
+
+Keep legacy rows readable. Existing recordings may still have `affirmative`, `negative`, `number`, or `common`. Exporters should not fail on either legacy or new values.
+
+### Recording metadata
+
+At upload time, copy these trusted task fields into `recordings.metadata`:
+
+- `phrase_id`
+- `semantic_label`
+- `prompted_word`
+- `normalized_label`
+- `language`
+- `category`
+
+The frontend should not send trusted label fields. If it sends them accidentally, backend code should ignore them.
+
+### Export fields
+
+Normal export should add:
+
+- root `phrase_id`
+- root `semantic_label`
+- `metadata.collection.phrase_id`
+- `metadata.collection.semantic_label`
+
+Databuilder sidecar should add:
+
+- root `phrase_id`
+- root `semantic_label`
+- `collection.phrase_id`
+- `collection.semantic_label`
+
+Legacy rows should export `semantic_label: null` and `phrase_id` fallback to `recording_metadata.phrase_id`, then `task_metadata.phrase_id`, then `task_metadata.prompt_id`, then null. Do not silently rewrite old classifier labels.
+
+### Migration impact
+
+Adding JSON metadata alone does not need a migration. Supporting repeat recordings as additional valid samples does need a migration and storage-key change:
+
+- Current unique index: `recordings_session_task_idx ON recordings(session_id, task_id)`.
+- Current upload behavior: `ON CONFLICT (session_id, task_id) DO UPDATE`.
+- Current audio key: `{session_id}/{task_id}.wav`.
+
+Those three facts mean a repeat recording currently replaces the previous DB row and overwrites the previous audio file. To keep repeats as extra samples, drop or replace the unique index, stop upserting by `(session_id, task_id)`, and generate a unique storage key per recording.
+
+Recommended storage key for repeats:
+
+```text
+{session_id}/{recording_id}.wav
+```
+
+or:
+
+```text
+{session_id}/{task_id}/{recording_id}.wav
+```
+
+Generate `recording_id` before saving the file so the DB row and audio path share the same durable ID.
+
+## 6. Required Backend Changes
+
+### New session/category API
+
+Recommended clean API:
+
+```text
+POST /api/category-state
+```
+
+Request:
+
+```json
+{ "sessionToken": "..." }
+```
+
+Response:
+
+```json
+{
+  "success": true,
+  "session": {},
+  "categoryOrder": ["yes", "no", "maybe", "dont_know", "correct", "number"],
+  "activeCategoryId": "yes",
+  "categories": [
+    {
+      "id": "yes",
+      "title": "Yes",
+      "totalPhrases": 8,
+      "requiredCount": 3,
+      "unlocked": true,
+      "complete": false,
+      "progress": {
+        "currentSessionUniqueCount": 1,
+        "previousSameDeviceUniqueCount": 2,
+        "uniqueRecordedCount": 3,
+        "totalPhrases": 8
+      },
+      "phrases": [
+        {
+          "taskId": "short_finnish_responses_v2_0001_yes_kyl",
+          "phraseId": "yes_kyl",
+          "text": "Kyl",
+          "category": "yes",
+          "recordedInCurrentSession": false,
+          "recordedPreviouslyOnDevice": true,
+          "recordingCountCurrentSession": 0
+        }
+      ]
+    }
+  ]
+}
+```
+
+Use `POST`, not `GET`, because the current API already uses JSON bodies for session tokens and putting session tokens in URLs is avoidable.
+
+Keep existing endpoints during migration:
+
+- `POST /api/start-session`: unchanged Turnstile and session allocation behavior.
+- `POST /api/get-task`: keep for compatibility until the old linear UI is removed.
+- `POST /api/update-session-metadata`: unchanged, but may need to preserve UI ordering metadata when merging.
+- `POST /api/upload-sound`: same request shape, expanded trusted metadata and repeat-recording support.
+- `POST /api/exit-session`: keep as the anytime stop/finish action.
+- `POST /api/complete-session`: either keep all-current-topic-complete semantics or deliberately redefine. Do not change this casually.
+
+### Phrase order storage
+
+Store session-level shuffle in `participant_sessions.metadata`, for example:
+
+```json
+{
+  "ui": {
+    "category_phrase_v1": {
+      "category_order": ["yes", "no", "maybe", "dont_know", "correct", "number"],
+      "phrase_order_by_category": {
+        "yes": ["yes_kyl", "yes_joo", "yes_on"]
+      },
+      "created_at": "2026-05-25T00:00:00.000Z"
+    }
+  }
+}
+```
+
+Backend should create this only when missing. Refreshing an active session must reuse the stored order. If newly seeded phrases exist that are not in the stored order, append them after stored phrases in stable `task_idx` order rather than reshuffling.
+
+### Progress logic
+
+Progress should be authoritative on the backend. Do not rely only on frontend state.
+
+Counts needed per category:
+
+- `currentSessionUniqueCount`: distinct phrase IDs recorded in the current session.
+- `previousSameDeviceUniqueCount`: distinct phrase IDs recorded in earlier sessions with the same `participant_sessions.metadata.device_id`.
+- `uniqueRecordedCount`: union of current and previous phrase IDs if returning-device progress is enabled.
+- `totalPhrases`: number of current-topic phrases in category.
+- `requiredCount`: `Math.min(3, totalPhrases)`.
+
+Phrase state:
+
+- `recordedInCurrentSession`
+- `recordedPreviouslyOnDevice`
+- `recordingCountCurrentSession`
+
+Unlocking:
+
+- First category is always unlocked.
+- Category N is unlocked only if all previous categories have `uniqueRecordedCount >= requiredCount`.
+- Repeat recordings insert rows but do not increase unique progress for that phrase.
+
+### Recording insert changes
+
+For repeat recordings:
+
+- Drop or stop depending on `recordings_session_task_idx`.
+- Insert a new `recordings` row for every upload.
+- Add a non-unique index on `(session_id, task_id)` if query speed matters.
+- Consider expression indexes:
+  - `participant_sessions ((metadata->>'device_id'))`
+  - `recordings ((metadata->>'phrase_id'))`
+
+`TaskProvider.getSessionSummaryByToken()` should stop counting raw `COUNT(r.id)` if repeats are allowed. Use distinct current-session task or phrase count for session summary.
+
+`TaskProvider.submitRecording()` should mark a session completed only after all required current-topic phrase IDs are recorded according to the chosen completion policy. Raw row count will be wrong once repeats exist.
+
+### Trusted metadata derivation
+
+Extend `buildRecordingMetadata()` to derive these from `task.metadata`:
+
+- `phrase_id`
+- `semantic_label`
+- `normalized_label`
+- `category`
+- `language`
+
+Do not accept these fields from frontend upload metadata as authoritative.
+
+## 7. Required Frontend Changes
+
+### App orchestration
+
+`frontend/src/App.tsx` needs to move from one `currentTask` to category state:
+
+- add a post-metadata category intro phase
+- load `/api/category-state`
+- track selected category and selected phrase
+- refresh category state after uploads
+- preserve Turnstile, metadata, exit, error, unavailable, and end screens
+
+### Existing components to modify
+
+- `SessionIntro.tsx`: reuse or replace for the category-recording intro.
+- `SoundRecorder.tsx`: make it phrase-selected and category-screen friendly. Remove old "Next prompt" responsibility. Keep playback and re-record before upload.
+- `InfoForm.tsx`: mostly unchanged, but consent copy should be updated.
+- `SessionEndScreen.tsx`: optionally accept current-session and total summary counts.
+- `TextContainer.tsx`: likely replace with a selected phrase panel or merge into new category screen.
+- `SessionProvider.tsx` and `types/session.ts`: add category state types if context remains central.
+
+### New components recommended
+
+- `CategoryRecordingIntro.tsx`
+- `CategoryRecorderScreen.tsx`
+- `CategoryProgressBar.tsx`
+- `PhraseGrid.tsx`
+- `PhraseCard.tsx`
+- `SelectedPhrasePanel.tsx`
+- `LiteralTranscriptControl.tsx`
+
+### Category recording screen
+
+Required UI state:
+
+- fixed category order: `Yes -> No -> Maybe -> Don't know / Not sure -> That's correct -> Numbers`
+- category title and helper text
+- progress bar: `unique recorded / total phrases`
+- required text: `3 required to continue` or smaller count for small categories
+- phrase cards in backend-provided session order
+- phrase state labels:
+  - `recorded this session`
+  - `recorded before`
+  - `not recorded yet`
+- clickable recorded phrases
+- selected phrase text
+- recorder with playback, re-record, and upload
+- literal transcript confirmation:
+  - button/control: `Same as shown`
+  - text input: `I said it differently / in my local dialect`
+- next category button locked until required unique count is reached
+- stop/finish session always available, secondary
+- optional auto-advance when all phrases in current category are recorded
+
+The frontend should display label/progress state from backend, but backend must remain the source of truth for recording metadata and unlock eligibility.
+
+## 8. Shuffling Design
+
+Use backend/session-level shuffle, not frontend-only shuffle.
+
+Reason:
+
+- refresh must not reshuffle
+- backend can persist the order in `participant_sessions.metadata`
+- order is tied to the assigned topic copy and current prompt bank
+- frontend-only shuffle would make state recovery and debugging weaker
+
+Behavior:
+
+- On first `/api/category-state`, backend groups current-topic tasks by category and shuffles phrase IDs once per category.
+- Store the order in `participant_sessions.metadata.ui.category_phrase_v1`.
+- On refresh, return stored order.
+- For a returning device in a later session, create a new session-specific shuffle but mark same-device previous recordings.
+- Avoid reshuffling by only creating order when the metadata key is absent.
+
+This fits the current code because `participant_sessions.metadata` already exists and is used for extensible JSON session state. It does require careful merge logic so form updates do not overwrite UI ordering metadata.
+
+## 9. Privacy And Consent Impact
+
+Current consent text already says an anonymous browser ID may be stored in this browser to group recordings from the same device. That is a good base, but returning-progress UI makes the browser ID more visible and more clearly used for progress tracking.
+
+Recommended consent wording addition:
+
+```text
+An anonymous random browser ID is stored in this browser so we can resume an active session
+and show which phrases this browser has already recorded. It is not a hardware serial number
+and does not include your name, email, or phone number. Clearing browser storage removes this
+ID from this browser, but recordings already submitted remain stored under the previous
+anonymous ID.
+```
+
+Engineering classification: this is pseudonymous, not directly identifying by itself. It still links recordings from the same browser/device and voice recordings can be sensitive depending on the research/privacy context. Treat it as pseudonymous research data, not truly anonymous data.
+
+Important current behavior to review: `buildV1SessionMetadata()` calls `getOrCreateDeviceId()` even when the user selects consent response `no`, because metadata is built before the decline path closes the session. Consider changing that during implementation so declined-consent sessions do not create or persist a device ID unless that behavior is explicitly approved.
+
+Reference note: GDPR Article 4 defines pseudonymisation as processing where data cannot be attributed to a specific data subject without additional information kept separately and protected by technical/organizational measures. See EUR-Lex Regulation (EU) 2016/679 Article 4.
+
+Source: https://eur-lex.europa.eu/legal-content/EN-ES/TXT/?uri=CELEX%3A32016R0679
+
+Current returning-user support check: the backend can identify same-device history only after v1 session metadata exists, because `device_id` is stored inside `participant_sessions.metadata` and is not sent to `/api/start-session`. There is no current API for previous same-device progress and no dedicated `device_id` column or index. The new backend should query JSONB metadata, and add an expression index if the dataset grows.
+
+## 10. Required Prompt And Schema Changes
+
+Replace the current seed with the category phrase bank using a new dataset version, for example `v2`, unless you intentionally reset all seeded dev data.
+
+Do not update the existing seed in-place against a populated database without a reset or seeder cleanup. Current `pushPrompts.js` upserts tasks by `id` and the database also has a unique `(topic_id, task_idx)` index. Changing prompt IDs/order can either leave old tasks behind or fail on task index conflicts.
+
+Safest options:
+
+1. Dev/local reset before reseeding:
+   - delete `recordings`
+   - delete `participant_sessions`
+   - delete `tasks`
+   - delete `topics`
+2. Production-like strategy:
+   - use a new dataset version/topic namespace such as `short_finnish_responses_v2`
+   - keep old recordings/export compatibility
+   - seed new topic copies separately
+
+Recommended normalized labels:
+
+- Use ASCII, phrase-level labels with underscores for spaces.
+- Keep Finnish display text in `text`.
+- Use `semantic_label` for broad/future targets.
+- Use `category` only for UI grouping.
+
+Examples:
+
+- `label: "kylla"`, `semantic_label: "yes"`, `category: "yes"`
+- `label: "ei_oo"`, `semantic_label: "no"`, `category: "no"`
+- `label: "en_tieda"`, `semantic_label: "dont_know"`, `category: "dont_know"`
+- `label: "kaks"`, `semantic_label: "number_2"`, `category: "number"`
+
+## 11. Required Export Changes
+
+Normal export in `scripts/aina/exportDataset.js`:
+
+- Include `phrase_id` and `semantic_label` at the sample root.
+- Include both under `metadata.collection`.
+- Preserve `normalized_label` and `label` as phrase-level classifier targets.
+- For legacy rows, return null instead of throwing when `semantic_label` is absent.
+- Consider adding `semantic_labels` or a `semantic_label_vocabulary` list to `dataset.json` only if downstream tooling needs it. Do not replace `labels`.
+
+Databuilder export in `scripts/aina/exportDatabuilderDataset.js`:
+
+- Include root-level `phrase_id` and `semantic_label` in each sidecar JSON.
+- Include both under `collection`.
+- Preserve strict `processed_audio` filtering.
+- Keep `normalized_label` as the classifier target.
+- Missing `semantic_label` should not make legacy rows invalid.
+
+Expected test impact:
+
+- Existing export tests will need assertions for new fields.
+- Existing databuilder tests should not break merely because extra fields exist, but tests should verify them.
+- Repeat-recording support will affect storage key tests, task progress tests, and any test assuming one row per task.
+
+## 12. Testing Plan
+
+Backend tests:
+
+- seed parser accepts new phrase schema
+- `pushPrompts.js` stores `phrase_id`, `semantic_label`, category metadata, and category order
+- upload copies `phrase_id` and `semantic_label` from task metadata into recording metadata
+- upload ignores frontend-provided label, category, semantic label, and phrase ID
+- progress counts distinct phrase IDs
+- previous same-device recordings can be included in progress
+- repeated same phrase inserts another row but does not increase unique progress twice
+- phrase order is stable within a session
+- phrase order differs across new sessions
+- next-category eligibility uses `min(3, totalPhrases)`
+- categories with fewer than 3 phrases unlock after all available phrases
+- legacy tasks without `semantic_label` do not crash
+- `getSessionSummaryByToken()` does not count repeat rows as linear progress
+- `complete-session` behavior matches the final chosen completion policy
+- Turnstile failure still blocks session start
+- `MAX_UPLOAD_BYTES` still rejects oversized uploads before storage
+- duration limit still rejects too-long recordings before DB submit
+- processed audio metadata remains WAV PCM 16-bit, 16 kHz, mono
+
+Frontend tests:
+
+- build and lint
+- category progress renders `unique recorded / total phrases`
+- next category button locks/unlocks correctly
+- phrase card states render current-session, previous-device, and not-recorded states
+- recorded phrases remain clickable
+- selecting a phrase updates recorder prompt
+- same-as-shown transcript sends `literal_transcript: null` and `label_source: "prompt_assumed"`
+- typed transcript sends trimmed value and `label_source: "user_confirmed"`
+- re-record before upload still replaces the pending local blob only
+- upload refreshes category state
+- stop/finish session remains available
+- final screen summarizes current-session recordings
+
+Export tests:
+
+- normal export includes `phrase_id` and `semantic_label` when available
+- normal export keeps legacy rows with null semantic metadata
+- databuilder sidecar includes `phrase_id` and `semantic_label` when available
+- databuilder sidecar keeps missing semantic metadata as null
+- strict processed audio filtering still works
+
+## 13. Risks And Recommendations
+
+### Risks
+
+- DB migration risk: repeat recordings require removing or replacing the unique `(session_id, task_id)` upsert model.
+- Storage overwrite risk: current `{session_id}/{task_id}.wav` path cannot preserve repeat recordings.
+- Seeder risk: changing prompt IDs/order against existing topics can conflict with `(topic_id, task_idx)` or leave obsolete tasks.
+- Existing sessions risk: active sessions created before the prompt update may not have category metadata or shuffled order.
+- Legacy recordings risk: older rows do not have `semantic_label` or `phrase_id`.
+- Label compatibility risk: changing number labels from digits to phrase-level labels changes classifier vocabulary.
+- Consent risk: returning-progress behavior makes browser ID usage more explicit and should be stated clearly.
+- Declined-consent risk: current code creates/stores `device_id` even for consent `no`.
+- UX risk: category unlocking can make volunteers think only 3 recordings matter unless progress clearly shows all phrases remain useful.
+- Trust boundary risk: category progress must be calculated by backend, not only frontend state.
+
+### Recommendations
+
+- Use a new dataset version for the new phrase bank.
+- Add `semantic_label` as metadata only. Keep `normalized_label` as phrase-level training target.
+- Implement backend category/progress API before frontend redesign.
+- Persist shuffle in `participant_sessions.metadata`, not local frontend state.
+- Decide repeat-recording schema first because it changes DB and storage behavior.
+- Keep old linear endpoints until the new UI is verified locally.
+- Keep legacy export behavior tolerant.
+- Add tests before connecting the new frontend.
+
+## 14. Recommended Staged Implementation Order
+
+### Stage 1: Prompt schema and trusted metadata
+
+- Update prompt seed schema with `phrase_id`, `semantic_label`, new categories, and category order.
+- Update `pushPrompts.js` to store new metadata and handle prompt-set changes safely.
+- Update backend recording metadata derivation to copy `phrase_id` and `semantic_label` from task rows.
+- Update normal and databuilder exports to include new fields.
+- Add backend/export tests.
+
+### Stage 2: Repeat recording storage and category progress backend
+
+- Add migration for repeat recordings:
+  - remove or replace unique `(session_id, task_id)` behavior
+  - add non-unique indexes needed for progress
+  - change storage keys to include recording ID
+- Add provider methods for category state, phrase order creation, progress, previous same-device status, and unlock eligibility.
+- Add `POST /api/category-state`.
+- Update `/api/upload-sound` to insert repeat rows and return/refetch category progress.
+- Add backend tests for progress, shuffle stability, repeats, and legacy rows.
+
+### Stage 3: Category frontend
+
+- Add category intro screen.
+- Add category recorder screen, phrase grid, progress UI, selected phrase panel, and literal transcript control.
+- Refactor `SoundRecorder.tsx` to work as a reusable selected-phrase recorder.
+- Update app phase orchestration and session context/types.
+- Keep Turnstile, metadata form, auto-stop, playback, re-record, upload safety, and exit behavior.
+- Run frontend build/lint and focused UI tests if available.
+
+### Stage 4: Docs and end-to-end validation
+
+- Update `README.md`, `docs/aina-data-contract.md`, `docs/databuilder-export.md`, `docs/database-structure.md`, and consent wording in `infoFormConfig.json`.
+- Validate local storage flow.
+- Validate Supabase/PostgreSQL and S3 flow.
+- Verify normal export.
+- Verify databuilder export.
+- Smoke-test downstream classifier loading separately only when explicitly in scope.
+
+## 15. Exact Files Likely To Change
+
+Backend:
+
+- `apps/speech-collector/backend/src/index.js`
+- `apps/speech-collector/backend/src/taskProvider.js`
+- `apps/speech-collector/backend/src/fileStorage.js`
+- `apps/speech-collector/backend/src/index.test.js`
+- `apps/speech-collector/backend/src/taskProvider.test.js`
+- `apps/speech-collector/backend/src/fileStorage.test.js`
+
+Database and seed:
+
+- `apps/speech-collector/scripts/aina/migration.sql`
+- `apps/speech-collector/scripts/aina/short_finnish_prompts.json`
+- `apps/speech-collector/scripts/aina/pushPrompts.js`
+
+Exports:
+
+- `apps/speech-collector/scripts/aina/exportDataset.js`
+- `apps/speech-collector/scripts/aina/exportDataset.test.js`
+- `apps/speech-collector/scripts/aina/exportDatabuilderDataset.js`
+- `apps/speech-collector/scripts/aina/exportDatabuilderDataset.test.js`
+
+Frontend:
+
+- `apps/speech-collector/frontend/src/App.tsx`
+- `apps/speech-collector/frontend/src/App.css`
+- `apps/speech-collector/frontend/types/session.ts`
+- `apps/speech-collector/frontend/contexts/SessionProvider.tsx`
+- `apps/speech-collector/frontend/components/SoundRecorder.tsx`
+- `apps/speech-collector/frontend/components/SoundRecorder.css`
+- `apps/speech-collector/frontend/components/TextContainer.tsx`
+- `apps/speech-collector/frontend/components/TextContainer.css`
+- new category UI components and CSS files
+- `apps/speech-collector/frontend/utils/sessionMetadata.ts`
+- `apps/speech-collector/frontend/utils/deviceId.ts` only if declined-consent behavior is adjusted
+
+Docs/config:
+
+- `apps/speech-collector/infoFormConfig.json`
+- `apps/speech-collector/README.md`
+- `apps/speech-collector/docs/aina-data-contract.md`
+- `apps/speech-collector/docs/databuilder-export.md`
+- `apps/speech-collector/docs/database-structure.md`
+- `apps/speech-collector/docs/aina-s3-integration.md`
+
+## 16. Questions To Answer Before Coding
+
+1. Should repeat recordings definitely be stored as separate samples? If yes, approve the DB/storage migration.
+2. Should previous same-device recordings count toward category unlocks, or only display as recorded before?
+3. If previous same-device recordings count toward unlocks, should they also count toward session completion?
+4. Should `complete-session` keep its current meaning, or should early user finish continue to use `exit-session`/`abandoned`?
+5. Should the new phrase bank use `DATASET_VERSION=v2` to avoid mixing old and new task schemas?
+6. Should old seeded topics be reset in local/dev, or should `pushPrompts.js` learn to delete obsolete tasks safely?
+7. What exact normalized labels should be used for phrase variants with Finnish characters and spaces?
+8. Should `phrase_id` equal prompt `id`, or should both be stored separately for future prompt display changes?
+9. Should same-device previous progress include recordings from active sessions in another tab, or only completed/abandoned sessions?
+10. Should declined-consent sessions avoid generating/storing `device_id`?
+11. Should frontend show `semantic_label` anywhere, or keep it entirely hidden metadata?
+12. Should the category screen allow jumping back to earlier unlocked categories, or only next/previous sequential navigation?
+13. Should auto-advance trigger at all phrases recorded, or only after upload when no pending playback exists?
+14. Should all categories be required for a `completed` session, or is early finish expected to be the normal valid final state?
+15. Should top-level `dataset.json` include semantic-label vocabulary, or only per-sample semantic metadata?

--- a/docs/category-phrase-ui-plan.md
+++ b/docs/category-phrase-ui-plan.md
@@ -1,0 +1,53 @@
+# Category Phrase Backend Foundation
+
+This note describes the backend/data foundation for the planned category-based phrase recording UI. The full frontend category UI is not implemented yet.
+
+## Prompt Bank
+
+The active AINA seed is `short_finnish_responses` `v2`.
+
+Each task stores trusted metadata in `tasks.metadata`:
+
+- `phrase_id`: stable phrase identity, for example `yes_kylla`
+- `label`: phrase-level classifier label, for example `kylla`
+- `semantic_label`: broader future target, for example `yes`
+- `category`: UI group, for example `yes`
+- `language`, `dataset_id`, and `dataset_version`
+
+`normalized_label` in recording/export metadata is still the phrase-level classifier target. It is not replaced by `semantic_label`.
+
+When reseeding an existing v2 topic copy, the seeder removes obsolete task rows only if they have no recordings. If obsolete tasks have recordings, seeding stops and asks for an explicit reset/archive decision.
+
+## Category State
+
+`POST /api/category-state` accepts:
+
+```json
+{ "sessionToken": "..." }
+```
+
+It returns category order, active category, progress, unlock state, and phrase cards. Progress counts unique `phrase_id` values, not raw recording rows. Previous recordings from the same anonymous browser `device_id` count toward category unlocks.
+
+Unlock rule:
+
+- first category is unlocked
+- later categories unlock when every previous category has `uniqueRecordedCount >= requiredCount`
+- `requiredCount = min(3, totalPhrases)`
+
+Phrase order is shuffled once per session and stored in `participant_sessions.metadata.ui.category_phrase_v1`. Refreshing a session reuses the stored order. Newly added phrase IDs are appended in stable `task_idx` order.
+
+## Repeat Recordings
+
+Each upload inserts a new `recordings` row. The backend generates `recordings.id` before saving audio and stores audio at:
+
+```text
+{session_id}/{task_id}/{recording_id}.wav
+```
+
+This prevents re-recordings of the same phrase from overwriting earlier samples.
+
+## Completion And Reset Notes
+
+`exit-session` remains the anytime stop path. Early exits are `abandoned`, and submitted recordings remain exportable. `completed` means every assigned current-session task/phrase has at least one recording; category unlock minimums do not automatically close the session.
+
+Experimental local/Supabase/S3 data can be reset manually during validation, but reset commands are documented rather than automated. Generated exports, audio, and temp files should not be committed.

--- a/docs/database-structure.md
+++ b/docs/database-structure.md
@@ -29,7 +29,7 @@ Fields include:
 - `text`
 - `metadata`
 
-`metadata` stores prompt label/category/language information used during export.
+`metadata` stores prompt label/category/language information used during upload metadata derivation and export. The v2 prompt bank stores `phrase_id`, phrase-level `label`, nullable `semantic_label`, `category`, `language`, `dataset_id`, and `dataset_version`.
 
 ### `participant_sessions`
 
@@ -54,9 +54,11 @@ Status values:
 - `completed`
 - `abandoned`
 
+`metadata.ui.category_phrase_v1` stores the shuffled phrase order for the category UI. The order is created once per session and reused on refresh. If newly seeded phrases appear later, missing phrase IDs are appended in stable `task_idx` order.
+
 ### `recordings`
 
-One saved recording per `(session_id, task_id)`.
+One saved recording row per upload. Repeat recordings for the same `(session_id, task_id)` are separate valid samples.
 
 Fields include:
 
@@ -69,11 +71,18 @@ Fields include:
 - `submitted_at`
 - `metadata`
 
+Useful indexes include:
+
+- non-unique `recordings(session_id, task_id)` lookup
+- `recordings(session_id, submitted_at)`
+- `participant_sessions ((metadata->>'device_id'))`
+- `recordings ((metadata->>'phrase_id'))`
+
 ## Allocation Model
 
 - one topic copy is assigned to one session
 - one session token auto-resumes in the same browser while active
-- recordings determine progress
+- recordings determine progress; linear progress uses distinct current-session tasks, and category progress uses distinct `phrase_id` values
 - tasks themselves are not marked complete globally
 
 This avoids the old `users`-table coupling and makes partial sessions safe to keep.
@@ -84,7 +93,7 @@ Session creation uses row locking with `FOR UPDATE SKIP LOCKED` so concurrent vo
 
 Topic reuse is prevented by a unique index on `participant_sessions.topic_id`.
 
-`startSession()` also only selects topics with no `participant_sessions` row at all, so a topic copy is permanently consumed once it has been assigned. That means `completed` and `abandoned` sessions both continue to reserve their topic copy by design.
+`startSession()` only selects topics for the configured `DATASET_ID` and `DATASET_VERSION`, and only where no `participant_sessions` row exists. A topic copy is permanently consumed once it has been assigned. That means `completed` and `abandoned` sessions both continue to reserve their topic copy by design.
 
 For local/dev testing, you can either:
 
@@ -93,9 +102,11 @@ For local/dev testing, you can either:
 
 ## Exit And Completion
 
-- `completed` means every task in the assigned topic has a recording
+- `completed` means every task in the assigned topic has at least one current-session recording
 - `abandoned` means the volunteer exited or the session expired after inactivity
 - both statuses keep already submitted recordings valid for export
+
+The category UI unlock rule is separate from session completion: category unlocks use `min(3, total phrases)` unique `phrase_id` values and may count previous recordings from the same anonymous browser `device_id`.
 
 ## Export Relationship
 

--- a/docs/databuilder-export.md
+++ b/docs/databuilder-export.md
@@ -5,7 +5,7 @@
 The normal Speech Collector export remains:
 
 ```text
-exports/short-finnish-responses/v1/
+exports/short-finnish-responses/v2/
   metadata/
     dataset.json
     samples.jsonl
@@ -14,7 +14,7 @@ exports/short-finnish-responses/v1/
 The current `audio-classifier` `feature/databuilder` branch expects a different flat package, so Speech Collector adds a separate compatibility export:
 
 ```text
-exports/short-finnish-responses/v1/databuilder/
+exports/short-finnish-responses/v2/databuilder/
   manifest.json
   <sample_id>.wav
   <sample_id>.json
@@ -31,7 +31,7 @@ pnpm run aina:export:databuilder
 Optional settings:
 
 ```env
-DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v1/databuilder
+DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v2/databuilder
 DATABUILDER_MANIFEST_VERSION=20260501001
 ```
 
@@ -72,11 +72,13 @@ Each `<sample_id>.json` sidecar is root-level:
   "sample_id": "recording-uuid",
   "timestamp": "submitted_at",
   "prompted_word": "Kylla",
+  "phrase_id": "yes_kylla",
+  "semantic_label": "yes",
   "normalized_label": "kylla",
   "literal_transcript": null,
   "label_source": "prompt_assumed",
   "language": "fi",
-  "category": "affirmative",
+  "category": "yes",
   "augmentation_strategy": null,
   "augmentations": [],
   "device_id": "dev_...",
@@ -99,7 +101,9 @@ It is flat because audio-classifier filters use dotted paths like `demographics.
 
 `literal_transcript`, `augmentation_strategy`, and `augmentations` always exist. Original recordings use `augmentation_strategy: null` and `augmentations: []`.
 
-Older recordings collected before the processed-audio fix may not contain `processed_audio`; those sidecars keep the root-level key with `null`.
+Older recordings collected before the processed-audio fix may not contain `processed_audio`; those sidecars keep the root-level key with `null`. Legacy recordings without `phrase_id` or `semantic_label` keep those keys as `null`; missing semantic metadata does not make an otherwise classifier-ready recording invalid.
+
+The same `phrase_id` and `semantic_label` values are also included under `collection.phrase_id` and `collection.semantic_label`. `normalized_label` remains the phrase-level classifier target.
 
 ## Manifest
 
@@ -126,7 +130,7 @@ The current databuilder can be smoke-tested directly against the generated direc
 
 ```powershell
 cd D:\ass_vscode\AIN\tmp\audio-classifier-audit
-python -c "import sys; sys.path.insert(0, 'src'); from pathlib import Path; from databuilder.builder import build_dataset; from databuilder.config import Config, SourceConfig, CacheDirConfig, DatasetConfig, FiltersConfig, AugmentationsConfig; cache=Path(r'D:\ass_vscode\AIN\apps\speech-collector\exports\short-finnish-responses\v1\databuilder'); out=cache.parent / 'databuilder-smoke-dataset'; cfg=Config(source=SourceConfig(endpoint_url='local', bucket='local', prefix='local'), cache_dir=CacheDirConfig(path=cache), dataset=DatasetConfig(path=out, clear=True), filters=FiltersConfig(include={}, exclude={}), augmentations=AugmentationsConfig()); print(build_dataset(cfg))"
+python -c "import sys; sys.path.insert(0, 'src'); from pathlib import Path; from databuilder.builder import build_dataset; from databuilder.config import Config, SourceConfig, CacheDirConfig, DatasetConfig, FiltersConfig, AugmentationsConfig; cache=Path(r'D:\ass_vscode\AIN\apps\speech-collector\exports\short-finnish-responses\v2\databuilder'); out=cache.parent / 'databuilder-smoke-dataset'; cfg=Config(source=SourceConfig(endpoint_url='local', bucket='local', prefix='local'), cache_dir=CacheDirConfig(path=cache), dataset=DatasetConfig(path=out, clear=True), filters=FiltersConfig(include={}, exclude={}), augmentations=AugmentationsConfig()); print(build_dataset(cfg))"
 ```
 
 That check verifies that the classifier can read `manifest.json`, find each `<sample_id>.wav` and `<sample_id>.json`, validate that sidecar `sample_id` equals the manifest key, and write its local dataset output.

--- a/docs/session-logs/2026-05-25-v2-category-ui-foundation-and-frontend.md
+++ b/docs/session-logs/2026-05-25-v2-category-ui-foundation-and-frontend.md
@@ -1,0 +1,146 @@
+# 2026-05-25 v2 Category UI Foundation And Frontend
+
+## Date
+
+2026-05-25
+
+## Goal
+
+Implement the v2 category phrase recording UI for the volunteer Speech Collector flow.
+
+## Backend Foundation Already Completed
+
+- v2 phrase bank with Finnish phrases grouped by category.
+- `phrase_id` stored as a stable phrase identity.
+- `semantic_label` stored as extra metadata/future target while `normalized_label` remains the phrase-level classifier label.
+- `POST /api/category-state` returns fixed category order, shuffled phrase order, progress, phrase state, and unlock information.
+- Repeat recordings insert separate `recordings` rows instead of overwriting earlier samples.
+- Audio storage keys include `recording_id`, for example `session_id/task_id/recording_id.wav`.
+- Progress logic counts unique phrase IDs and is repeat-safe.
+- Normal export and databuilder export include `phrase_id` and `semantic_label`.
+
+## Validation Completed Before Frontend Work
+
+- `corepack pnpm install` passed.
+- `corepack pnpm run test:backend` passed.
+- `corepack pnpm build` passed.
+- `corepack pnpm --filter sound-collector-frontend lint` passed.
+- Supabase/S3 experimental flow was tested with 3 fresh recordings.
+- Normal export passed.
+- Databuilder export passed.
+- `python scripts/aina/verify_v2_exports.py --run-exports` passed.
+
+## Known Experimental Path Note
+
+- `.env` has `DATASET_VERSION=v2`.
+- Some output/S3 paths still contain `v1`.
+- This is accepted for current experimental testing.
+- Do not commit `.env`.
+
+## Frontend Design Implemented
+
+- Added the category recording intro shown after session metadata/consent is complete.
+- Replaced the linear prompt recording screen with a category recording screen driven by `/api/category-state`.
+- Added category progress showing unique recorded phrases over total phrases.
+- Added required-count messaging for next-category unlocks.
+- Added category stepper/navigation for unlocked categories.
+- Added phrase cards in backend-provided shuffled order.
+- Added phrase states for not recorded, recorded this session, and recorded before on this browser/device.
+- Added selected phrase panel with the existing recorder.
+- Updated literal transcript UX with a `Same as shown` option and a separate dialect/different-form input.
+- Kept stop/finish session available from intro and recording screens.
+- Kept playback and re-record before upload behavior.
+
+## Responsive UI Polish
+
+- Added mobile/tablet/desktop layout polish for the category intro and category recording screens.
+- The app shell and panels now use constrained viewport widths, smaller mobile padding, and overflow-safe wrapping to avoid expected page-level horizontal scrolling.
+- The category stepper uses contained horizontal scrolling on phone widths and switches to a wrapped grid on tablet/desktop widths.
+- Phrase cards now use an adaptive grid:
+  - narrow phones can fall back to one column when needed
+  - typical mobile widths can fit two columns
+  - tablet/desktop widths expand to additional columns as space allows
+- Phrase card labels and recorded-state text wrap safely and keep comfortable tap targets.
+- The selected phrase panel stacks below the phrase grid on smaller screens and moves into a wider two-column workspace on desktop.
+- Recorder playback, transcript controls, and action buttons are constrained to their panel and stack on narrow phones.
+- The literal transcript input is full-width on small screens.
+- Focus-visible outlines were added for primary category and recorder controls.
+- Remaining manual smoke test requirement: verify the UI interactively at 360x800, 390x844, 768x1024, and 1366x768, including microphone recording and upload behavior.
+
+## Security Retained
+
+- Cloudflare Turnstile remains the session-start gate.
+- Session metadata is still required before category progress/upload.
+- Frontend recording auto-stop remains controlled by `VITE_MAX_RECORDING_SECONDS`.
+- Backend upload size and duration limits remain authoritative.
+- Frontend upload metadata sends only literal transcript, label source, and technical metadata.
+- Backend still derives trusted labels and category fields from the task row.
+- Backend processed audio behavior remains 16 kHz mono `pcm_s16le`.
+
+## Testing Results
+
+- `corepack pnpm run test:backend`: passed with 57 tests.
+- `corepack pnpm build`: passed.
+- `corepack pnpm --filter sound-collector-frontend lint`: passed.
+- `python scripts/aina/verify_v2_exports.py --run-exports`: passed.
+- Normal export produced 3 samples; all include `phrase_id`, `semantic_label`, and valid processed-audio metadata.
+- Databuilder export considered 3 recordings, exported 3 recordings, skipped 0 legacy/missing processed-audio rows, and skipped 0 storage mismatches.
+- Manual browser/microphone category UI smoke test was not completed in this shell because no interactive browser/microphone automation is available here.
+- Extra `tsc --noEmit` check was attempted and found existing project type errors in `InfoForm.tsx` and `deviceId.ts`; the current project validation scripts do not run this command, and Vite build passed.
+
+## Final Validation And Browser Smoke
+
+- `corepack pnpm install`: passed.
+- `corepack pnpm run test:backend`: passed with 57 tests.
+- `corepack pnpm build`: passed.
+- `corepack pnpm --filter sound-collector-frontend lint`: passed.
+- `python scripts/aina/verify_v2_exports.py --run-exports`: passed.
+- Automated browser smoke used Chrome DevTools Protocol with a temporary local backend/frontend:
+  - backend served on port `18000` with Turnstile disabled for the smoke process only
+  - frontend served on port `5174` with `VITE_TURNSTILE_SITE_KEY` empty and `VITE_API_URL` pointed to the smoke backend
+  - `.env` was not edited
+- Browser smoke confirmed:
+  - page loaded
+  - metadata form completed
+  - category intro appeared
+  - category recording screen appeared
+  - `/api/category-state` was called
+  - phrase cards appeared
+  - selecting a phrase updated the selected phrase panel
+  - recorder UI appeared
+  - 5-second recording limit text was visible
+  - same-as-shown control and dialect/different-form input were visible
+  - next category was locked before enough unique recordings
+  - finish/stop action was visible
+- Responsive viewport checks passed without horizontal overflow at:
+  - 360x800
+  - 390x844
+  - 768x1024
+  - 1366x768
+- Fake microphone upload:
+  - fake recording was attempted
+  - upload succeeded
+  - post-upload `/api/category-state` check showed category `yes` with `uniqueRecordedCount = 1` out of 8 and one phrase marked `recordedInCurrentSession`
+- Export verification was rerun after the fake upload and passed. The active smoke session was not included in export output; normal export still reported 3 exported samples.
+
+## Remaining TODOs
+
+- Run an interactive browser/microphone smoke test locally:
+  - complete Turnstile/local bypass
+  - complete metadata
+  - verify category intro appears
+  - verify category-state loads
+  - record at least 3 phrases in the first category
+  - verify progress updates and next category unlocks
+  - verify same-as-shown uploads `literal_transcript: null` and `label_source: "prompt_assumed"`
+  - verify typed transcript uploads the typed value and `label_source: "user_confirmed"`
+  - verify stop session still works
+- Optionally add focused frontend tests around category selection and recorder metadata payloads if the frontend test setup is expanded.
+- Clean up existing full-TypeScript-check issues if the project starts enforcing `tsc --noEmit`.
+
+## Company PR Strategy
+
+- First validate this feature in the personal repo.
+- Later create a clean company PR from latest company `main`.
+- Include only the necessary code/docs changes.
+- Do not include experimental `.env`, exports, audio files, temp files, screenshots, validation artifacts, S3/Supabase credentials, or unrelated audio-classifier changes.

--- a/docs/session-logs/2026-05-25-v2-category-ui-foundation-and-frontend.md
+++ b/docs/session-logs/2026-05-25-v2-category-ui-foundation-and-frontend.md
@@ -54,6 +54,7 @@ Implement the v2 category phrase recording UI for the volunteer Speech Collector
 ## Responsive UI Polish
 
 - Added mobile/tablet/desktop layout polish for the category intro and category recording screens.
+- Polished the category intro copy from the earlier category-focused wording to the more volunteer-friendly title `Record Finnish short responses` with a shorter explanation of the grouped phrase recording task.
 - The app shell and panels now use constrained viewport widths, smaller mobile padding, and overflow-safe wrapping to avoid expected page-level horizontal scrolling.
 - The category stepper uses contained horizontal scrolling on phone widths and switches to a wrapped grid on tablet/desktop widths.
 - Phrase cards now use an adaptive grid:

--- a/frontend/components/SoundRecorder.css
+++ b/frontend/components/SoundRecorder.css
@@ -1,17 +1,22 @@
 .recorder-panel {
-  margin-top: 20px;
+  margin-top: 16px;
   border: 1px solid #d7e2ea;
   border-radius: 8px;
-  padding: 20px;
+  padding: 14px;
   background: #f9fbfc;
+  min-width: 0;
+  overflow: hidden;
 }
 
 .recorder-preview {
   margin-bottom: 16px;
+  min-width: 0;
 }
 
 .recorder-preview audio {
   width: 100%;
+  max-width: 100%;
+  display: block;
 }
 
 .recorder-transcript {
@@ -20,6 +25,37 @@
   gap: 8px;
   margin-top: 16px;
   color: #12324a;
+}
+
+.recorder-transcript__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.recorder-transcript__choice {
+  border: 1px solid #c6d4de;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #12324a;
+  min-height: 44px;
+  padding: 8px 12px;
+  cursor: pointer;
+  line-height: 1.2;
+  text-align: center;
+}
+
+.recorder-transcript__choice--selected {
+  border-color: #0f766e;
+  background: #e8f4f2;
+  color: #0b5f58;
+  font-weight: 700;
+}
+
+.recorder-transcript__different {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
 }
 
 .recorder-transcript__helper {
@@ -36,21 +72,47 @@
 }
 
 .recorder-transcript__input {
+  width: 100%;
+  min-height: 44px;
   border: 1px solid #c6d4de;
   border-radius: 8px;
   padding: 10px 12px;
   background: #ffffff;
   color: #12324a;
+  min-width: 0;
+}
+
+.recorder-transcript__choice:focus-visible,
+.recorder-transcript__input:focus-visible {
+  outline: 3px solid rgba(15, 118, 110, 0.32);
+  outline-offset: 2px;
 }
 
 .recorder-actions {
   display: flex;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
-@media (max-width: 720px) {
+.recorder-actions > button {
+  flex: 1 1 132px;
+}
+
+@media (max-width: 420px) {
   .recorder-actions > button {
+    flex-basis: 100%;
     width: 100%;
+  }
+}
+
+@media (min-width: 720px) {
+  .recorder-panel {
+    padding: 18px;
+  }
+}
+
+@media (min-width: 960px) {
+  .recorder-panel {
+    padding: 20px;
   }
 }

--- a/frontend/components/SoundRecorder.tsx
+++ b/frontend/components/SoundRecorder.tsx
@@ -8,9 +8,12 @@ interface SoundRecorderProps {
   sessionToken: string | null;
   taskId: string;
   promptedWord: string;
-  onUploadComplete: (result: any) => void;
-  onNextTask: () => Promise<void> | void;
+  onUploadComplete: (result: any) => Promise<void> | void;
+  onNextTask?: () => Promise<void> | void;
+  nextActionLabel?: string;
 }
+
+type TranscriptMode = "same" | "different";
 
 function getMaxRecordingSeconds() {
   const parsed = Number.parseInt(import.meta.env.VITE_MAX_RECORDING_SECONDS || "5", 10);
@@ -23,6 +26,7 @@ const SoundRecorder = ({
   promptedWord,
   onUploadComplete,
   onNextTask,
+  nextActionLabel = "Next prompt",
 }: SoundRecorderProps) => {
   const {
     error: recorderError,
@@ -41,7 +45,8 @@ const SoundRecorder = ({
   const [uploadFailed, setUploadFailed] = useState<boolean>(false);
   const [uploadMessage, setUploadMessage] = useState<string>("");
   const [elapsedSeconds, setElapsedSeconds] = useState<number>(0);
-  const [literalTranscript, setLiteralTranscript] = useState<string>(promptedWord);
+  const [transcriptMode, setTranscriptMode] = useState<TranscriptMode>("same");
+  const [literalTranscript, setLiteralTranscript] = useState<string>("");
   const clearBlobUrlRef = useRef(clearBlobUrl);
   const stopRecordingRef = useRef(stopRecording);
   const maxRecordingSeconds = getMaxRecordingSeconds();
@@ -58,9 +63,10 @@ const SoundRecorder = ({
     setUploadFailed(false);
     setUploadMessage("");
     setElapsedSeconds(0);
-    setLiteralTranscript(promptedWord);
+    setTranscriptMode("same");
+    setLiteralTranscript("");
     clearBlobUrlRef.current();
-  }, [promptedWord, taskId]);
+  }, [taskId]);
 
   useEffect(() => {
     if (status !== "recording") {
@@ -88,9 +94,10 @@ const SoundRecorder = ({
   useEffect(() => {
     if (status === "stopped" && mediaBlobUrl) {
       setElapsedSeconds(maxRecordingSeconds);
-      setLiteralTranscript(promptedWord);
+      setTranscriptMode("same");
+      setLiteralTranscript("");
     }
-  }, [maxRecordingSeconds, mediaBlobUrl, promptedWord, status]);
+  }, [maxRecordingSeconds, mediaBlobUrl, status]);
 
   const handleStartRecording = () => {
     clearBlobUrl();
@@ -98,14 +105,14 @@ const SoundRecorder = ({
     setUploadFailed(false);
     setUploadMessage("");
     setElapsedSeconds(0);
-    setLiteralTranscript(promptedWord);
+    setTranscriptMode("same");
+    setLiteralTranscript("");
     startRecording();
   };
 
   const buildUploadMetadata = () => {
     const trimmedTranscript = literalTranscript.trim();
-    const trimmedPrompt = promptedWord.trim();
-    const userConfirmed = Boolean(trimmedTranscript) && trimmedTranscript !== trimmedPrompt;
+    const userConfirmed = transcriptMode === "different" && Boolean(trimmedTranscript);
     const settings = previewAudioStream?.getAudioTracks()[0]?.getSettings();
 
     return {
@@ -153,21 +160,46 @@ const SoundRecorder = ({
         {mediaBlobUrl ? (
           <>
             <audio src={mediaBlobUrl} controls />
-            <label className="recorder-transcript" htmlFor={`literal-transcript-${taskId}`}>
-              <span>What did you actually say? (optional)</span>
+            <div className="recorder-transcript">
+              <span>What did you actually say?</span>
+              <div className="recorder-transcript__options">
+                <button
+                  type="button"
+                  className={
+                    transcriptMode === "same"
+                      ? "recorder-transcript__choice recorder-transcript__choice--selected"
+                      : "recorder-transcript__choice"
+                  }
+                  onClick={() => {
+                    setTranscriptMode("same");
+                    setLiteralTranscript("");
+                  }}
+                >
+                  Same as shown
+                </button>
+              </div>
+              <label
+                className="recorder-transcript__different"
+                htmlFor={`literal-transcript-${taskId}`}
+              >
+                <span>I said it differently / in my local dialect</span>
+                <input
+                  id={`literal-transcript-${taskId}`}
+                  type="text"
+                  value={literalTranscript}
+                  onFocus={() => setTranscriptMode("different")}
+                  onChange={(event) => {
+                    setTranscriptMode("different");
+                    setLiteralTranscript(event.target.value);
+                  }}
+                  placeholder="Type what you actually said"
+                  className="recorder-transcript__input"
+                />
+              </label>
               <span className="recorder-transcript__helper">
-                Leave this as shown if you followed the prompt. If you said a shorter or dialect
-                form, you can write it here, for example <code>kyl</code> instead of{" "}
-                <code>kyllä</code>.
+                Leave the field empty to submit this as "{promptedWord}".
               </span>
-              <input
-                id={`literal-transcript-${taskId}`}
-                type="text"
-                value={literalTranscript}
-                onChange={(event) => setLiteralTranscript(event.target.value)}
-                className="recorder-transcript__input"
-              />
-            </label>
+            </div>
           </>
         ) : (
           <p className="app-copy">
@@ -210,9 +242,10 @@ const SoundRecorder = ({
               setUploadFailed(false);
               setUploadMessage("");
               const result = await uploadSound();
-              setTaskDone(result.sessionStatus !== "completed");
+              setTaskDone(Boolean(onNextTask) && result.sessionStatus !== "completed");
+              clearBlobUrlRef.current();
               setUploadMessage("Recording saved.");
-              onUploadComplete(result);
+              await onUploadComplete(result);
             } catch (error) {
               setUploadFailed(true);
               setUploadMessage(
@@ -226,18 +259,20 @@ const SoundRecorder = ({
         >
           {soundUploading ? "Uploading..." : "Upload"}
         </button>
-        <button
-          type="button"
-          className="app-secondary-button"
-          onClick={() => {
-            setTaskDone(false);
-            setUploadMessage("");
-            void onNextTask();
-          }}
-          disabled={!taskDone}
-        >
-          Next prompt
-        </button>
+        {onNextTask && (
+          <button
+            type="button"
+            className="app-secondary-button"
+            onClick={() => {
+              setTaskDone(false);
+              setUploadMessage("");
+              void onNextTask();
+            }}
+            disabled={!taskDone}
+          >
+            {nextActionLabel}
+          </button>
+        )}
       </div>
 
       {status === "recording" && (

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,20 +1,25 @@
 #root {
   min-height: 100vh;
+  overflow-x: hidden;
 }
 
 .app-shell {
   min-height: 100vh;
-  padding: 32px 16px;
+  width: 100%;
+  overflow-x: hidden;
+  padding: 12px;
 }
 
 .app-panel {
   width: 100%;
+  max-width: calc(100vw - 24px);
   margin: 0 auto;
   background: #ffffff;
   border: 1px solid #d7e2ea;
   border-radius: 8px;
   box-shadow: 0 10px 28px rgba(18, 50, 74, 0.08);
-  padding: 24px;
+  padding: 16px;
+  min-width: 0;
 }
 
 .app-panel--narrow {
@@ -22,16 +27,17 @@
 }
 
 .app-panel--wide {
-  max-width: 960px;
+  max-width: 1120px;
 }
 
 .app-header {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: 20px;
+  gap: 16px;
   margin-bottom: 20px;
   flex-wrap: wrap;
+  min-width: 0;
 }
 
 .app-header__content {
@@ -41,15 +47,16 @@
 
 .app-header-actions {
   display: flex;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
   flex: 0 1 auto;
-  justify-content: flex-end;
+  justify-content: stretch;
   max-width: 100%;
+  width: 100%;
 }
 
 .app-header-actions > button {
-  white-space: nowrap;
+  flex: 1 1 150px;
 }
 
 .app-eyebrow {
@@ -69,7 +76,7 @@
 }
 
 .app-title {
-  font-size: 32px;
+  font-size: 28px;
   line-height: 1.15;
 }
 
@@ -81,6 +88,7 @@
 .app-copy {
   margin: 0;
   color: #4d677a;
+  overflow-wrap: anywhere;
 }
 
 .app-list {
@@ -93,8 +101,15 @@
 .app-secondary-button {
   border-radius: 8px;
   border: 1px solid transparent;
+  min-height: 44px;
   padding: 10px 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   cursor: pointer;
+  line-height: 1.2;
+  text-align: center;
+  overflow-wrap: anywhere;
   transition: background-color 0.2s ease, border-color 0.2s ease, color 0.2s ease;
 }
 
@@ -121,6 +136,14 @@
 .app-secondary-button:disabled {
   cursor: not-allowed;
   opacity: 0.6;
+}
+
+.app-primary-button:focus-visible,
+.app-secondary-button:focus-visible,
+.category-stepper__item:focus-visible,
+.category-phrase-card:focus-visible {
+  outline: 3px solid rgba(15, 118, 110, 0.32);
+  outline-offset: 2px;
 }
 
 .app-progress {
@@ -150,29 +173,365 @@
   margin-top: 20px;
 }
 
-@media (max-width: 720px) {
+.category-intro-copy {
+  display: grid;
+  gap: 12px;
+  margin: 16px 0 20px;
+  color: #36556f;
+  line-height: 1.55;
+}
+
+.category-intro-copy p {
+  margin: 0;
+}
+
+.category-intro-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.category-intro-actions > button {
+  flex: 1 1 160px;
+}
+
+.category-stepper {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 24px;
+  overflow-x: auto;
+  overscroll-behavior-inline: contain;
+  padding: 2px 2px 8px;
+  scroll-snap-type: inline proximity;
+  scrollbar-width: thin;
+}
+
+.category-stepper__item {
+  min-height: 74px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex: 0 0 min(252px, 82vw);
+  border: 1px solid #c6d4de;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #12324a;
+  padding: 10px;
+  text-align: left;
+  cursor: pointer;
+  scroll-snap-align: start;
+  min-width: 0;
+}
+
+.category-stepper__item:hover:not(:disabled) {
+  border-color: #0f766e;
+  background: #f4fbf9;
+}
+
+.category-stepper__item:disabled {
+  cursor: not-allowed;
+  opacity: 0.58;
+  background: #f7fafc;
+}
+
+.category-stepper__item--selected {
+  border-color: #0f766e;
+  box-shadow: inset 0 0 0 1px #0f766e;
+}
+
+.category-stepper__number {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 28px;
+  background: #e8f4f2;
+  color: #0f766e;
+  font-weight: 700;
+  font-size: 14px;
+}
+
+.category-stepper__body {
+  min-width: 0;
+  display: grid;
+  gap: 2px;
+}
+
+.category-stepper__title {
+  font-weight: 700;
+  overflow-wrap: anywhere;
+}
+
+.category-stepper__meta {
+  color: #4d677a;
+  font-size: 13px;
+  line-height: 1.3;
+}
+
+.category-workspace {
+  display: grid;
+  gap: 22px;
+}
+
+.category-summary {
+  display: grid;
+  gap: 18px;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.category-summary__title {
+  margin: 0 0 8px;
+  font-size: 24px;
+  line-height: 1.2;
+  color: #12324a;
+}
+
+.category-summary__counter {
+  border: 1px solid #c6d4de;
+  border-radius: 8px;
+  padding: 10px 12px;
+  color: #12324a;
+  background: #f7fafc;
+  font-weight: 700;
+  width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.category-progress {
+  display: grid;
+  gap: 8px;
+}
+
+.category-progress__bar {
+  height: 12px;
+  width: 100%;
+  background: #dfe9ef;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.category-progress__fill {
+  height: 100%;
+  background: #0f766e;
+}
+
+.category-progress__labels {
+  display: grid;
+  gap: 4px;
+  color: #4d677a;
+  font-size: 14px;
+  overflow-wrap: anywhere;
+}
+
+.category-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 16px;
+  align-items: start;
+  min-width: 0;
+}
+
+.category-phrase-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 142px), 1fr));
+  gap: 10px;
+  min-width: 0;
+}
+
+.category-phrase-card {
+  min-height: 88px;
+  display: grid;
+  gap: 6px;
+  align-content: start;
+  border: 1px solid #c6d4de;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #12324a;
+  padding: 12px;
+  text-align: left;
+  cursor: pointer;
+  min-width: 0;
+}
+
+.category-phrase-card:hover {
+  border-color: #0f766e;
+  background: #f4fbf9;
+}
+
+.category-phrase-card--selected {
+  border-color: #0f766e;
+  box-shadow: inset 0 0 0 1px #0f766e;
+}
+
+.category-phrase-card__text {
+  font-weight: 700;
+  font-size: 17px;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+}
+
+.category-phrase-card__status {
+  color: #6a7f8f;
+  font-size: 13px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+.category-phrase-card__status--current {
+  color: #0f766e;
+}
+
+.category-phrase-card__status--previous {
+  color: #5f4b8b;
+}
+
+.selected-phrase-panel {
+  min-width: 0;
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 16px;
+  overflow: hidden;
+}
+
+.selected-phrase-panel__text {
+  margin: 0 0 8px;
+  font-size: 28px;
+  line-height: 1.15;
+  color: #12324a;
+  overflow-wrap: anywhere;
+}
+
+.category-navigation {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+  justify-content: stretch;
+}
+
+.category-navigation > button {
+  flex: 1 1 150px;
+}
+
+.category-complete-note {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  align-items: baseline;
+  border: 1px solid #c6d4de;
+  border-radius: 8px;
+  padding: 12px 14px;
+  background: #f7fafc;
+  color: #36556f;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 420px) {
   .app-shell {
-    padding: 16px;
+    padding: 10px;
   }
 
+  .app-panel {
+    max-width: calc(100vw - 20px);
+    padding: 14px;
+  }
+
+  .app-header-actions > button,
+  .category-intro-actions > button,
+  .category-navigation > button {
+    flex-basis: 100%;
+    width: 100%;
+  }
+}
+
+@media (min-width: 560px) {
   .app-panel {
     padding: 20px;
   }
 
-  .app-header {
-    flex-direction: column;
+  .category-progress__labels {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    justify-content: space-between;
   }
 
-  .app-header__content {
-    width: 100%;
+  .category-progress__labels > span:last-child {
+    text-align: right;
+  }
+}
+
+@media (min-width: 720px) {
+  .app-shell {
+    padding: 24px 16px;
+  }
+
+  .app-title {
+    font-size: 32px;
   }
 
   .app-header-actions {
-    width: 100%;
-    justify-content: stretch;
+    width: auto;
+    justify-content: flex-end;
   }
 
   .app-header-actions > button {
-    flex: 1 1 180px;
+    flex: 0 1 auto;
+  }
+
+  .category-stepper {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    overflow-x: visible;
+    padding: 0;
+  }
+
+  .category-stepper__item {
+    flex: initial;
+  }
+
+  .category-layout {
+    gap: 20px;
+  }
+
+  .category-summary {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  .category-summary__counter {
+    width: auto;
+    max-width: 260px;
+    text-align: right;
+  }
+
+  .category-navigation {
+    justify-content: flex-end;
+  }
+
+  .category-navigation > button {
+    flex: 0 1 auto;
+  }
+
+  .selected-phrase-panel__text {
+    font-size: 34px;
+  }
+}
+
+@media (min-width: 960px) {
+  .app-shell {
+    padding: 32px 16px;
+  }
+
+  .app-panel {
+    padding: 24px;
+  }
+
+  .category-layout {
+    grid-template-columns: minmax(0, 1.15fr) minmax(340px, 0.85fr);
+  }
+
+  .category-phrase-list {
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,14 +5,18 @@ import InfoForm from "../components/InfoForm";
 import SessionIntro from "../components/SessionIntro";
 import SessionEndScreen from "../components/SessionEndScreen";
 import SoundRecorder from "../components/SoundRecorder";
-import TextContainer from "../components/TextContainer";
 import TurnstileGate from "../components/TurnstileGate";
 import {
   getConsentDeclineMessage,
   hasDeclinedConsent,
   isMetadataComplete,
 } from "../utils/sessionMetadata";
-import type { SessionState, SessionTask } from "../types/session";
+import type {
+  CategoryPhraseState,
+  CategoryStateCategory,
+  CategoryStateResponse,
+  SessionState,
+} from "../types/session";
 
 import "bootstrap/dist/css/bootstrap.min.css";
 import "./App.css";
@@ -22,7 +26,8 @@ type Phase =
   | "verification"
   | "intro"
   | "metadata"
-  | "task"
+  | "categoryIntro"
+  | "categoryRecording"
   | "completed"
   | "abandoned"
   | "declined"
@@ -30,18 +35,164 @@ type Phase =
   | "error";
 
 type MetadataMode = "required" | "edit";
+type CategoryStateApiResponse = CategoryStateResponse & {
+  code?: string;
+  message?: string;
+};
+
+const CATEGORY_HELPER_TEXT: Record<string, string> = {
+  yes: "Choose natural Finnish ways to answer yes. Recording more than the minimum helps balance the dataset.",
+  no: "Record short negative answers. You can repeat a phrase if you want to contribute another sample.",
+  maybe: "Record phrases that mean maybe or possibly.",
+  dont_know: "Record short not-sure answers, including local or informal forms when they feel natural.",
+  correct: "Record short confirmation phrases.",
+  number: "Record number words in a clear, natural voice.",
+};
 
 function getVolunteerAppTitle(value: unknown) {
   const title = typeof value === "string" ? value.replace(/\bAINA\s*/gi, "").trim() : "";
   return title || "Speech Collector";
 }
 
+function getCategoryHelpText(category: CategoryStateCategory | null) {
+  if (!category) {
+    return "";
+  }
+
+  return CATEGORY_HELPER_TEXT[category.id] || "Record several different phrases in this category.";
+}
+
+function getCategoryById(
+  state: CategoryStateResponse | null,
+  categoryId: string | null | undefined
+) {
+  if (!state || !categoryId) {
+    return null;
+  }
+
+  return state.categories.find((category) => category.id === categoryId) || null;
+}
+
+function getCategoryIndex(state: CategoryStateResponse | null, categoryId: string | null | undefined) {
+  if (!state || !categoryId) {
+    return -1;
+  }
+
+  return state.categories.findIndex((category) => category.id === categoryId);
+}
+
+function getInitialCategoryId(
+  state: CategoryStateResponse,
+  preferredCategoryId: string | null | undefined
+) {
+  const preferredCategory = getCategoryById(state, preferredCategoryId);
+  if (preferredCategory?.unlocked) {
+    return preferredCategory.id;
+  }
+
+  const backendActiveCategory = getCategoryById(state, state.activeCategoryId);
+  if (backendActiveCategory?.unlocked) {
+    return backendActiveCategory.id;
+  }
+
+  return state.categories.find((category) => category.unlocked)?.id || state.categories[0]?.id || null;
+}
+
+function phraseHasBackendRecordedState(phrase: CategoryPhraseState) {
+  return phrase.recordedInCurrentSession || phrase.recordedPreviouslyOnDevice;
+}
+
+function getInitialPhraseId(
+  category: CategoryStateCategory | null,
+  preferredPhraseId: string | null | undefined
+) {
+  if (!category) {
+    return null;
+  }
+
+  if (preferredPhraseId && category.phrases.some((phrase) => phrase.phraseId === preferredPhraseId)) {
+    return preferredPhraseId;
+  }
+
+  return (
+    category.phrases.find((phrase) => !phraseHasBackendRecordedState(phrase))?.phraseId ||
+    category.phrases[0]?.phraseId ||
+    null
+  );
+}
+
+function getNextCategory(state: CategoryStateResponse | null, categoryId: string | null | undefined) {
+  const index = getCategoryIndex(state, categoryId);
+  return index >= 0 ? state?.categories[index + 1] || null : null;
+}
+
+function getPreviousCategory(
+  state: CategoryStateResponse | null,
+  categoryId: string | null | undefined
+) {
+  const index = getCategoryIndex(state, categoryId);
+  return index > 0 ? state?.categories[index - 1] || null : null;
+}
+
+function isCategoryEligibleForNext(category: CategoryStateCategory | null) {
+  if (!category) {
+    return false;
+  }
+
+  return (
+    category.complete ||
+    category.requiredCount === 0 ||
+    category.progress.uniqueRecordedCount >= category.requiredCount
+  );
+}
+
+function getProgressPercent(category: CategoryStateCategory) {
+  if (!category.progress.totalPhrases) {
+    return 0;
+  }
+
+  return Math.min(
+    (category.progress.uniqueRecordedCount / category.progress.totalPhrases) * 100,
+    100
+  );
+}
+
+function getRequirementText(category: CategoryStateCategory) {
+  if (category.requiredCount <= 1) {
+    return "1 phrase required to continue";
+  }
+
+  return `${category.requiredCount} different phrases required to continue`;
+}
+
+function getPhraseStatusLabel(phrase: CategoryPhraseState) {
+  if (phrase.recordedInCurrentSession) {
+    return "Recorded this session";
+  }
+
+  if (phrase.recordedPreviouslyOnDevice) {
+    return "Recorded before on this browser/device";
+  }
+
+  return "Not recorded yet";
+}
+
+function getPhraseStatusClassName(phrase: CategoryPhraseState) {
+  if (phrase.recordedInCurrentSession) {
+    return "category-phrase-card__status category-phrase-card__status--current";
+  }
+
+  if (phrase.recordedPreviouslyOnDevice) {
+    return "category-phrase-card__status category-phrase-card__status--previous";
+  }
+
+  return "category-phrase-card__status";
+}
+
 function App() {
   const {
     sessionToken,
     participantMetadata,
-    currentTask,
-    progress,
     applySession,
     clearSession,
     setCurrentTask,
@@ -51,7 +202,10 @@ function App() {
   const [phase, setPhase] = useState<Phase>("bootstrapping");
   const [metadataMode, setMetadataMode] = useState<MetadataMode>("required");
   const [message, setMessage] = useState<string>("");
-  const [taskLoading, setTaskLoading] = useState<boolean>(false);
+  const [categoryState, setCategoryState] = useState<CategoryStateResponse | null>(null);
+  const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
+  const [selectedPhraseId, setSelectedPhraseId] = useState<string | null>(null);
+  const [categoryLoading, setCategoryLoading] = useState<boolean>(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
   const hasBootstrapped = useRef(false);
 
@@ -64,12 +218,47 @@ function App() {
     [participantMetadata]
   );
 
+  const selectedCategory = useMemo(
+    () => getCategoryById(categoryState, selectedCategoryId),
+    [categoryState, selectedCategoryId]
+  );
+
+  const selectedPhrase = useMemo(() => {
+    if (!selectedCategory || !selectedPhraseId) {
+      return null;
+    }
+
+    return selectedCategory.phrases.find((phrase) => phrase.phraseId === selectedPhraseId) || null;
+  }, [selectedCategory, selectedPhraseId]);
+
+  const nextCategory = useMemo(
+    () => getNextCategory(categoryState, selectedCategoryId),
+    [categoryState, selectedCategoryId]
+  );
+
+  const previousCategory = useMemo(
+    () => getPreviousCategory(categoryState, selectedCategoryId),
+    [categoryState, selectedCategoryId]
+  );
+
+  const canMoveToNextCategory = Boolean(
+    nextCategory && (nextCategory.unlocked || isCategoryEligibleForNext(selectedCategory))
+  );
+
+  const allCategoryMinimumsCovered = Boolean(
+    categoryState?.categories.length &&
+      categoryState.categories.every((category) => isCategoryEligibleForNext(category))
+  );
+
   const moveToTerminalPhase = useCallback(
     (
       nextPhase: Extract<Phase, "completed" | "abandoned" | "declined" | "unavailable" | "error">,
       nextMessage: string
     ) => {
       setCurrentTask(null);
+      setCategoryState(null);
+      setSelectedCategoryId(null);
+      setSelectedPhraseId(null);
       clearSession();
       setPhase(nextPhase);
       setMessage(nextMessage);
@@ -121,19 +310,19 @@ function App() {
     [apiUrl, moveToTerminalPhase]
   );
 
-  const loadTask = useCallback(
+  const loadCategoryState = useCallback(
     async (tokenOverride?: string | null) => {
       const activeToken = tokenOverride ?? sessionToken;
       if (!activeToken) {
-        moveToTerminalPhase("error", "A session token is required before loading prompts.");
-        return;
+        moveToTerminalPhase("error", "A session token is required before loading categories.");
+        return null;
       }
 
-      setTaskLoading(true);
+      setCategoryLoading(true);
       setMessage("");
 
       try {
-        const response = await fetch(`${apiUrl}/api/get-task`, {
+        const response = await fetch(`${apiUrl}/api/category-state`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
@@ -141,14 +330,24 @@ function App() {
           body: JSON.stringify({ sessionToken: activeToken }),
         });
 
-        const data = await response.json();
+        const data = (await response.json()) as CategoryStateApiResponse;
         if (!data.success) {
-          if (data.code === "invalid_session") {
-            moveToTerminalPhase("error", "The previous session could not be resumed.");
-            return;
+          if (data.code === "session_metadata_required") {
+            if (data.session) {
+              syncSession(data.session);
+            }
+            setMetadataMode("required");
+            setPhase("metadata");
+            setMessage(data.message || "Complete the session details before recording.");
+            return null;
           }
 
-          throw new Error(data.message || "Could not load the next prompt.");
+          if (data.code === "invalid_session") {
+            moveToTerminalPhase("error", "The previous session could not be resumed.");
+            return null;
+          }
+
+          throw new Error(data.message || "Could not load category progress.");
         }
 
         if (data.session) {
@@ -156,28 +355,41 @@ function App() {
         }
 
         if (data.sessionStatus === "completed") {
-          moveToTerminalPhase("completed", data.message || "Thank you for completing the session.");
-          return;
+          moveToTerminalPhase(
+            "completed",
+            data.message ||
+              "Thank you. Your recordings were saved. You can come back later on the same browser/device to record more phrases."
+          );
+          return null;
         }
 
         if (data.sessionStatus === "abandoned") {
-          moveToTerminalPhase("abandoned", data.message || "This session has been closed.");
-          return;
+          moveToTerminalPhase(
+            "abandoned",
+            data.message ||
+              "Your submitted recordings were saved. You can come back later on the same browser/device to record more phrases."
+          );
+          return null;
         }
 
-        setCurrentTask((data.task as SessionTask | null) ?? null);
-        setProgress(data.progress);
-        setPhase("task");
+        setCategoryState(data);
+        const nextCategoryId = getInitialCategoryId(data, selectedCategoryId);
+        const nextSelectedCategory = getCategoryById(data, nextCategoryId);
+        setSelectedCategoryId(nextCategoryId);
+        setSelectedPhraseId(getInitialPhraseId(nextSelectedCategory, selectedPhraseId));
+        setPhase("categoryRecording");
+        return data;
       } catch (error) {
         moveToTerminalPhase(
           "error",
-          error instanceof Error ? error.message : "Could not load the next prompt."
+          error instanceof Error ? error.message : "Could not load category progress."
         );
+        return null;
       } finally {
-        setTaskLoading(false);
+        setCategoryLoading(false);
       }
     },
-    [apiUrl, moveToTerminalPhase, sessionToken, setCurrentTask, setProgress, syncSession]
+    [apiUrl, moveToTerminalPhase, selectedCategoryId, selectedPhraseId, sessionToken, syncSession]
   );
 
   const startOrResumeSession = useCallback(
@@ -185,6 +397,9 @@ function App() {
       setPhase("bootstrapping");
       setMessage("");
       setCurrentTask(null);
+      setCategoryState(null);
+      setSelectedCategoryId(null);
+      setSelectedPhraseId(null);
 
       try {
         const activeTurnstileToken = turnstileTokenOverride ?? turnstileToken;
@@ -232,7 +447,8 @@ function App() {
           return;
         }
 
-        await loadTask(data.session.sessionToken);
+        setMetadataMode("edit");
+        setPhase("categoryIntro");
       } catch (error) {
         moveToTerminalPhase(
           "error",
@@ -243,7 +459,6 @@ function App() {
     [
       apiUrl,
       closeSession,
-      loadTask,
       moveToTerminalPhase,
       sessionToken,
       setCurrentTask,
@@ -288,21 +503,30 @@ function App() {
       }
 
       setMetadataMode("edit");
-      await loadTask(session.sessionToken);
+      setMessage("");
+      if (categoryState) {
+        await loadCategoryState(session.sessionToken);
+        return;
+      }
+
+      setPhase("categoryIntro");
     },
-    [closeSession, loadTask, syncSession]
+    [categoryState, closeSession, loadCategoryState, syncSession]
   );
 
   const handleExitSession = useCallback(async () => {
     await closeSession(
       sessionToken,
       "abandoned",
-      "Your submitted recordings were saved. You can safely leave now."
+      "Thank you. Your submitted recordings were saved. You can come back later on the same browser/device to record more phrases."
     );
   }, [closeSession, sessionToken]);
 
   const handleRestart = useCallback(async () => {
     clearSession();
+    setCategoryState(null);
+    setSelectedCategoryId(null);
+    setSelectedPhraseId(null);
     setMetadataMode("required");
     setMessage("");
     if (turnstileSiteKey) {
@@ -313,6 +537,91 @@ function App() {
 
     await startOrResumeSession(null);
   }, [clearSession, startOrResumeSession, turnstileSiteKey]);
+
+  const handleSelectCategory = useCallback((category: CategoryStateCategory) => {
+    if (!category.unlocked) {
+      return;
+    }
+
+    setMessage("");
+    setSelectedCategoryId(category.id);
+    setSelectedPhraseId(getInitialPhraseId(category, null));
+  }, []);
+
+  const handleMoveToPreviousCategory = useCallback(() => {
+    if (!previousCategory?.unlocked) {
+      return;
+    }
+
+    setMessage("");
+    setSelectedCategoryId(previousCategory.id);
+    setSelectedPhraseId(getInitialPhraseId(previousCategory, null));
+  }, [previousCategory]);
+
+  const handleMoveToNextCategory = useCallback(() => {
+    if (!nextCategory || !canMoveToNextCategory) {
+      return;
+    }
+
+    setMessage("");
+    setSelectedCategoryId(nextCategory.id);
+    setSelectedPhraseId(getInitialPhraseId(nextCategory, null));
+  }, [canMoveToNextCategory, nextCategory]);
+
+  const handleRecordingUploaded = useCallback(
+    async (result: { session?: SessionState; sessionStatus?: string }) => {
+      if (result.session) {
+        syncSession(result.session);
+      }
+
+      if (result.sessionStatus === "completed") {
+        moveToTerminalPhase(
+          "completed",
+          "Thank you. Your recordings were saved. You can come back later on the same browser/device to record more phrases."
+        );
+        return;
+      }
+
+      const uploadedCategoryId = selectedCategoryId;
+      const uploadedPhraseId = selectedPhraseId;
+      const refreshedState = await loadCategoryState();
+
+      if (!refreshedState || !uploadedCategoryId) {
+        return;
+      }
+
+      const refreshedCategory = getCategoryById(refreshedState, uploadedCategoryId);
+      if (!refreshedCategory) {
+        return;
+      }
+
+      const nextUnrecordedPhrase =
+        refreshedCategory.phrases.find(
+          (phrase) =>
+            phrase.phraseId !== uploadedPhraseId && !phraseHasBackendRecordedState(phrase)
+        ) || refreshedCategory.phrases.find((phrase) => !phraseHasBackendRecordedState(phrase));
+
+      if (nextUnrecordedPhrase) {
+        setSelectedCategoryId(refreshedCategory.id);
+        setSelectedPhraseId(nextUnrecordedPhrase.phraseId);
+      }
+
+      if (refreshedCategory.complete) {
+        setMessage("Recording saved. All phrases in this category have been recorded.");
+      } else if (isCategoryEligibleForNext(refreshedCategory)) {
+        setMessage("Recording saved. You can continue here or move to the next category.");
+      } else {
+        setMessage("Recording saved. Choose another phrase in this category.");
+      }
+    },
+    [
+      loadCategoryState,
+      moveToTerminalPhase,
+      selectedCategoryId,
+      selectedPhraseId,
+      syncSession,
+    ]
+  );
 
   if (phase === "bootstrapping") {
     return (
@@ -375,14 +684,57 @@ function App() {
       <main className="app-shell">
         <InfoForm
           message={
-            metadataMode === "required"
+            message ||
+            (metadataMode === "required"
               ? "Tell us a little about the recording conditions and confirm consent before you begin."
-              : "Update the session details if something changed."
+              : "Update the session details if something changed.")
           }
           canCancel={metadataMode === "edit" && metadataComplete}
-          onCancel={() => setPhase("task")}
+          onCancel={() => setPhase(categoryState ? "categoryRecording" : "categoryIntro")}
           onSaved={handleMetadataSaved}
         />
+      </main>
+    );
+  }
+
+  if (phase === "categoryIntro") {
+    return (
+      <main className="app-shell">
+        <section className="app-panel app-panel--narrow">
+          <span className="app-eyebrow">{appName}</span>
+          <h1 className="app-title">Category recording</h1>
+          <div className="category-intro-copy">
+            <p>
+              Thank you for helping us collect Finnish short speech samples.
+            </p>
+            <p>
+              The task is divided into categories such as Yes, No, Maybe, Not sure, Correct,
+              and Numbers.
+            </p>
+            <p>
+              Please record at least 3 different phrases from each category when possible.
+              Recording more phrases is very helpful, and recording all phrases is even better.
+            </p>
+            <p>
+              You can listen to each recording before submitting, re-record if needed, and stop
+              the session at any time.
+            </p>
+          </div>
+          <div className="category-intro-actions">
+            <button
+              type="button"
+              className="app-primary-button"
+              onClick={() => void loadCategoryState()}
+              disabled={categoryLoading}
+            >
+              {categoryLoading ? "Loading..." : "Start recording"}
+            </button>
+            <button type="button" className="app-secondary-button" onClick={handleExitSession}>
+              Finish for now
+            </button>
+          </div>
+          {message && <p className="app-inline-message app-inline-message--error">{message}</p>}
+        </section>
       </main>
     );
   }
@@ -458,9 +810,9 @@ function App() {
         <header className="app-header">
           <div className="app-header__content">
             <span className="app-eyebrow">{appName}</span>
-            <h1 className="app-session-title">Current session</h1>
+            <h1 className="app-session-title">Record category phrases</h1>
             <p className="app-copy">
-              {progress.completedTasks} of {progress.totalTasks} prompts saved.
+              Pick a phrase, record it, listen back, and submit it when you are happy with it.
             </p>
           </div>
           <div className="app-header-actions">
@@ -475,50 +827,169 @@ function App() {
               Update details
             </button>
             <button type="button" className="app-secondary-button" onClick={handleExitSession}>
-              Exit
+              Finish for now
             </button>
           </div>
         </header>
 
-        <div className="app-progress" aria-hidden="true">
-          <div
-            className="app-progress__bar"
-            style={{
-              width: progress.totalTasks
-                ? `${(progress.completedTasks / progress.totalTasks) * 100}%`
-                : "0%",
-            }}
-          />
-        </div>
+        {categoryLoading && <p className="app-copy">Loading category progress.</p>}
 
-        {taskLoading && <p className="app-copy">Loading the next prompt.</p>}
-        {!taskLoading && currentTask && <TextContainer task={currentTask} />}
-        {!taskLoading && !currentTask && (
-          <p className="app-copy">No prompt is ready yet. Try refreshing the session.</p>
+        {categoryState && (
+          <>
+            <nav className="category-stepper" aria-label="Recording categories">
+              {categoryState.categories.map((category, index) => {
+                const selected = category.id === selectedCategoryId;
+                const categoryEligible = isCategoryEligibleForNext(category);
+                return (
+                  <button
+                    key={category.id}
+                    type="button"
+                    className={
+                      selected
+                        ? "category-stepper__item category-stepper__item--selected"
+                        : "category-stepper__item"
+                    }
+                    onClick={() => handleSelectCategory(category)}
+                    disabled={!category.unlocked}
+                    aria-current={selected ? "step" : undefined}
+                  >
+                    <span className="category-stepper__number">{index + 1}</span>
+                    <span className="category-stepper__body">
+                      <span className="category-stepper__title">{category.title}</span>
+                      <span className="category-stepper__meta">
+                        {category.progress.uniqueRecordedCount} / {category.totalPhrases} phrases
+                        {categoryEligible ? " covered" : category.unlocked ? " open" : " locked"}
+                      </span>
+                    </span>
+                  </button>
+                );
+              })}
+            </nav>
+
+            {selectedCategory ? (
+              <section className="category-workspace" aria-labelledby="category-title">
+                <div className="category-summary">
+                  <div>
+                    <span className="app-eyebrow">Current category</span>
+                    <h2 id="category-title" className="category-summary__title">
+                      {selectedCategory.title}
+                    </h2>
+                    <p className="app-copy">{getCategoryHelpText(selectedCategory)}</p>
+                  </div>
+                  <div className="category-summary__counter">
+                    Recorded {selectedCategory.progress.uniqueRecordedCount} /{" "}
+                    {selectedCategory.totalPhrases} phrases
+                  </div>
+                </div>
+
+                <div className="category-progress">
+                  <div className="category-progress__bar" aria-hidden="true">
+                    <div
+                      className="category-progress__fill"
+                      style={{ width: `${getProgressPercent(selectedCategory)}%` }}
+                    />
+                  </div>
+                  <div className="category-progress__labels">
+                    <span>{getRequirementText(selectedCategory)}</span>
+                    <span>
+                      {selectedCategory.complete
+                        ? "All phrases recorded"
+                        : `${Math.max(
+                            selectedCategory.requiredCount -
+                              selectedCategory.progress.uniqueRecordedCount,
+                            0
+                          )} more for next category`}
+                    </span>
+                  </div>
+                </div>
+
+                <div className="category-layout">
+                  <div className="category-phrase-list" aria-label="Phrases in this category">
+                    {selectedCategory.phrases.map((phrase) => {
+                      const selected = phrase.phraseId === selectedPhraseId;
+                      return (
+                        <button
+                          key={phrase.phraseId}
+                          type="button"
+                          className={
+                            selected
+                              ? "category-phrase-card category-phrase-card--selected"
+                              : "category-phrase-card"
+                          }
+                          onClick={() => {
+                            setMessage("");
+                            setSelectedPhraseId(phrase.phraseId);
+                          }}
+                        >
+                          <span className="category-phrase-card__text">{phrase.text}</span>
+                          <span className={getPhraseStatusClassName(phrase)}>
+                            {getPhraseStatusLabel(phrase)}
+                          </span>
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  <div className="selected-phrase-panel">
+                    {selectedPhrase ? (
+                      <>
+                        <span className="app-eyebrow">Selected phrase</span>
+                        <h3 className="selected-phrase-panel__text">{selectedPhrase.text}</h3>
+                        <p className="app-copy">
+                          Record this phrase naturally. You can record it again even if it was
+                          already submitted.
+                        </p>
+                        <SoundRecorder
+                          sessionToken={sessionToken}
+                          taskId={selectedPhrase.taskId}
+                          promptedWord={selectedPhrase.text}
+                          onUploadComplete={handleRecordingUploaded}
+                        />
+                      </>
+                    ) : (
+                      <p className="app-copy">Choose a phrase to start recording.</p>
+                    )}
+                  </div>
+                </div>
+
+                <div className="category-navigation">
+                  <button
+                    type="button"
+                    className="app-secondary-button"
+                    onClick={handleMoveToPreviousCategory}
+                    disabled={!previousCategory?.unlocked}
+                  >
+                    Previous category
+                  </button>
+                  <button
+                    type="button"
+                    className="app-primary-button"
+                    onClick={handleMoveToNextCategory}
+                    disabled={!canMoveToNextCategory}
+                  >
+                    Next category
+                  </button>
+                  <button type="button" className="app-secondary-button" onClick={handleExitSession}>
+                    Finish for now
+                  </button>
+                </div>
+
+                {allCategoryMinimumsCovered && (
+                  <div className="category-complete-note">
+                    <strong>All category minimums are covered.</strong>
+                    <span>You can keep recording more phrases or finish for now.</span>
+                  </div>
+                )}
+              </section>
+            ) : (
+              <p className="app-copy">No category is ready yet. Try refreshing the session.</p>
+            )}
+          </>
         )}
 
-        {currentTask && (
-          <SoundRecorder
-            sessionToken={sessionToken}
-            taskId={currentTask.id}
-            promptedWord={currentTask.text}
-            onUploadComplete={(result) => {
-              if (result.session) {
-                syncSession(result.session as SessionState);
-              }
-
-              if (result.sessionStatus === "completed") {
-                moveToTerminalPhase("completed", "Thank you. Your recordings were saved.");
-                return;
-              }
-
-              setMessage("Recording saved. Continue when you are ready for the next prompt.");
-            }}
-            onNextTask={loadTask}
-          />
+        {message && phase === "categoryRecording" && (
+          <p className="app-inline-message">{message}</p>
         )}
-
-        {message && phase === "task" && <p className="app-inline-message">{message}</p>}
       </section>
     </main>
   );

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -702,18 +702,15 @@ function App() {
       <main className="app-shell">
         <section className="app-panel app-panel--narrow">
           <span className="app-eyebrow">{appName}</span>
-          <h1 className="app-title">Category recording</h1>
+          <h1 className="app-title">Record Finnish short responses</h1>
           <div className="category-intro-copy">
             <p>
-              Thank you for helping us collect Finnish short speech samples.
-            </p>
-            <p>
-              The task is divided into categories such as Yes, No, Maybe, Not sure, Correct,
-              and Numbers.
+              You will see short Finnish response phrases grouped by meaning, such as Yes, No,
+              Maybe, Not sure, Correct, and Numbers.
             </p>
             <p>
               Please record at least 3 different phrases from each category when possible.
-              Recording more phrases is very helpful, and recording all phrases is even better.
+              Recording more phrases helps us build a more balanced dataset.
             </p>
             <p>
               You can listen to each recording before submitting, re-record if needed, and stop

--- a/frontend/types/session.ts
+++ b/frontend/types/session.ts
@@ -28,3 +28,42 @@ export interface SessionState {
   completedAt?: string | null;
   exitedAt?: string | null;
 }
+
+export interface CategoryPhraseState {
+  taskId: string;
+  phraseId: string;
+  text: string;
+  category: string;
+  semanticLabel: string | null;
+  normalizedLabel: string | null;
+  recordedInCurrentSession: boolean;
+  recordedPreviouslyOnDevice: boolean;
+  recordingCountCurrentSession: number;
+}
+
+export interface CategoryProgressState {
+  currentSessionUniqueCount: number;
+  previousSameDeviceUniqueCount: number;
+  uniqueRecordedCount: number;
+  totalPhrases: number;
+}
+
+export interface CategoryStateCategory {
+  id: string;
+  title: string;
+  totalPhrases: number;
+  requiredCount: number;
+  unlocked: boolean;
+  complete: boolean;
+  progress: CategoryProgressState;
+  phrases: CategoryPhraseState[];
+}
+
+export interface CategoryStateResponse {
+  success: boolean;
+  sessionStatus?: SessionStatus;
+  session?: SessionState;
+  categoryOrder: string[];
+  activeCategoryId: string | null;
+  categories: CategoryStateCategory[];
+}

--- a/frontend/utils/sessionMetadata.ts
+++ b/frontend/utils/sessionMetadata.ts
@@ -127,11 +127,12 @@ export function getConsentDeclineMessage(metadata: Record<string, unknown> | nul
 export function buildV1SessionMetadata(values: FormValues) {
   const nativeLanguage = normalizeMetadataValue(values.native_language);
   const dialectRegion = normalizeMetadataValue(values.dialect_region);
+  const consentResponse = normalizeMetadataValue(values.consent_response);
 
   return {
     schema_version: 'v1',
-    device_id: getOrCreateDeviceId(),
-    consent_response: normalizeMetadataValue(values.consent_response),
+    device_id: consentResponse === 'yes' ? getOrCreateDeviceId() : null,
+    consent_response: consentResponse,
     demographics: {
       age_group: normalizeMetadataValue(values.age_group),
       gender: normalizeMetadataValue(values.gender),

--- a/infoFormConfig.json
+++ b/infoFormConfig.json
@@ -118,7 +118,7 @@
     "type": "consent_markdown_yes_no",
     "id": "consent_response",
     "required": true,
-    "markdown": "### Consent to participate\nBy choosing **Yes**, you confirm that:\n\n- these recordings are collected for a speech-classifier project\n- your recordings and session details may be stored, reviewed, and exported for research and model development\n- an anonymous browser ID may be stored in this browser to group recordings from the same device\n- basic browser, device, and microphone information may be collected automatically to understand recording quality\n- no name, email, phone number, or real hardware serial number is collected\n- participation is voluntary and you may stop at any time",
+    "markdown": "### Consent to participate\nBy choosing **Yes**, you confirm that:\n\n- these recordings are collected for a speech-classifier project\n- your recordings and session details may be stored, reviewed, and exported for research and model development\n- an anonymous random browser ID is stored in this browser so we can resume an active session and show which phrases this browser has already recorded\n- the browser ID is not a hardware serial number and does not include your name, email, or phone number\n- clearing browser storage removes this ID from this browser, but recordings already submitted remain stored under the previous anonymous ID\n- basic browser, device, and microphone information may be collected automatically to understand recording quality\n- participation is voluntary and you may stop at any time",
     "options": [
       {
         "value": "yes",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dev:frontend": "dotenv -e ./.env -- pnpm --filter sound-collector-frontend dev",
     "dev": "concurrently \"pnpm run dev:backend\" \"pnpm run dev:frontend\"",
     "build": "dotenv -e ./.env -- pnpm --filter sound-collector-frontend build",
-    "test:backend": "dotenv -e ./.env -- node --test backend/src/config.test.js backend/src/taskProvider.test.js backend/src/fileStorage.test.js backend/src/index.test.js scripts/aina/exportDataset.test.js scripts/aina/exportDatabuilderDataset.test.js",
+    "test:backend": "dotenv -e ./.env -- node --test backend/src/config.test.js backend/src/taskProvider.test.js backend/src/fileStorage.test.js backend/src/index.test.js scripts/aina/pushPrompts.test.js scripts/aina/exportDataset.test.js scripts/aina/exportDatabuilderDataset.test.js",
     "serve": "concurrently \"pnpm run dev:backend\" \"pnpm --filter sound-collector-frontend serve\"",
     "aina:seed": "dotenv -e ./.env -- node scripts/aina/pushPrompts.js scripts/aina/short_finnish_prompts.json",
     "aina:export": "dotenv -e ./.env -- node scripts/aina/exportDataset.js",

--- a/scripts/aina/exportDatabuilderDataset.js
+++ b/scripts/aina/exportDatabuilderDataset.js
@@ -13,6 +13,8 @@ import {
   filterRowsForActiveStorage,
   getActiveStorageType,
   getDurationSec,
+  getPhraseId,
+  getSemanticLabel,
   pseudonymizeDeviceId,
   pseudonymizeSpeaker,
 } from './exportDataset.js';
@@ -23,7 +25,7 @@ import {
 } from '../../backend/src/config.js';
 import { FileStorage } from '../../backend/src/fileStorage.js';
 
-const DEFAULT_DATABUILDER_OUTPUT_DIR = './exports/short-finnish-responses/v1/databuilder';
+const DEFAULT_DATABUILDER_OUTPUT_DIR = './exports/short-finnish-responses/v2/databuilder';
 const DEFAULT_DATABUILDER_MANIFEST_VERSION = '20260501001';
 export const NO_CLASSIFIER_READY_RECORDINGS_MESSAGE =
   'No classifier-ready recordings found. Record fresh samples after the 16 kHz processed-audio fix or reprocess legacy audio.';
@@ -200,6 +202,8 @@ export function buildDatabuilderSidecar(row) {
   const category =
     normalizeOptionalString(recordingMetadata.category) ||
     normalizeOptionalString(row.category);
+  const phraseId = getPhraseId(row);
+  const semanticLabel = getSemanticLabel(row);
   const submittedAt = normalizeTimestamp(row.submitted_at || recordingMetadata.timestamp);
 
   if (!normalizedLabel) {
@@ -210,6 +214,8 @@ export function buildDatabuilderSidecar(row) {
     sample_id: sampleId,
     timestamp: submittedAt,
     prompted_word: promptedWord,
+    phrase_id: phraseId,
+    semantic_label: semanticLabel,
     normalized_label: normalizedLabel,
     literal_transcript: recordingMetadata.literal_transcript ?? null,
     label_source: recordingMetadata.label_source || 'prompt_assumed',
@@ -237,6 +243,8 @@ export function buildDatabuilderSidecar(row) {
       submitted_at: submittedAt,
       storage_type: row.storage_type,
       category: category || null,
+      phrase_id: phraseId,
+      semantic_label: semanticLabel,
     },
     storage: getDatabuilderStorageInfo(row),
   };

--- a/scripts/aina/exportDatabuilderDataset.test.js
+++ b/scripts/aina/exportDatabuilderDataset.test.js
@@ -86,6 +86,8 @@ function makeRow(overrides = {}) {
     recording_metadata: {
       schema_version: 'v1',
       prompted_word: 'Kylla',
+      phrase_id: 'yes_kylla',
+      semantic_label: 'yes',
       normalized_label: 'kylla',
       literal_transcript: 'kyl',
       label_source: 'user_confirmed',
@@ -124,6 +126,8 @@ test('buildDatabuilderSidecar creates root-level databuilder fields', () => {
   assert.equal(sidecar.sample_id, '11111111-1111-4111-8111-111111111111');
   assert.equal(sidecar.timestamp, '2026-04-22T10:00:00.000Z');
   assert.equal(sidecar.prompted_word, 'Kylla');
+  assert.equal(sidecar.phrase_id, 'yes_kylla');
+  assert.equal(sidecar.semantic_label, 'yes');
   assert.equal(sidecar.normalized_label, 'kylla');
   assert.equal(sidecar.literal_transcript, 'kyl');
   assert.equal(sidecar.label_source, 'user_confirmed');
@@ -143,6 +147,8 @@ test('buildDatabuilderSidecar creates root-level databuilder fields', () => {
     encoding: 'pcm_s16le',
   });
   assert.equal(sidecar.collection.session_id, 'session-123');
+  assert.equal(sidecar.collection.phrase_id, 'yes_kylla');
+  assert.equal(sidecar.collection.semantic_label, 'yes');
   assert.equal(sidecar.storage.storage_key, 'session-123/short_finnish_responses_v1_0001_kylla.wav');
   assert.equal(Object.hasOwn(sidecar, 'metadata'), false);
 });
@@ -172,6 +178,10 @@ test('required sidecar keys always exist for original recordings', () => {
   assert.equal(Object.hasOwn(sidecar, 'storage'), true);
   assert.equal(Object.hasOwn(sidecar, 'speaker_id'), true);
   assert.equal(Object.hasOwn(sidecar, 'device_id'), true);
+  assert.equal(Object.hasOwn(sidecar, 'phrase_id'), true);
+  assert.equal(Object.hasOwn(sidecar, 'semantic_label'), true);
+  assert.equal(sidecar.phrase_id, null);
+  assert.equal(sidecar.semantic_label, null);
 });
 
 test('exportDatabuilderRows copies local audio as sample_id.wav', async () => {

--- a/scripts/aina/exportDataset.js
+++ b/scripts/aina/exportDataset.js
@@ -107,10 +107,23 @@ export function getDurationSec(row) {
   return 0.001;
 }
 
+export function getPhraseId(row) {
+  return (
+    row.recording_metadata?.phrase_id ||
+    row.task_metadata?.phrase_id ||
+    row.task_metadata?.prompt_id ||
+    null
+  );
+}
+
+export function getSemanticLabel(row) {
+  return row.recording_metadata?.semantic_label || row.task_metadata?.semantic_label || null;
+}
+
 export function buildDatasetMetadata(rows, labels, audioRoot) {
   return {
     dataset_id: configValue('DATASET_ID', 'short_finnish_responses'),
-    version: configValue('DATASET_VERSION', 'v1'),
+    version: configValue('DATASET_VERSION', 'v2'),
     language: configValue('DATASET_LANGUAGE', 'fi'),
     description: configValue(
       'DATASET_DESCRIPTION',
@@ -138,6 +151,8 @@ export function buildSample(row, index, dataset) {
   const promptedWord = recordingMetadata.prompted_word || row.transcript;
   const language = recordingMetadata.language || row.language || dataset.language;
   const category = recordingMetadata.category || row.category || null;
+  const phraseId = getPhraseId(row);
+  const semanticLabel = getSemanticLabel(row);
   const sessionTechnical =
     sessionMetadata.technical && typeof sessionMetadata.technical === 'object'
       ? sessionMetadata.technical
@@ -151,6 +166,8 @@ export function buildSample(row, index, dataset) {
     sample_id: sampleId,
     audio_path: row.storage_key,
     prompted_word: promptedWord,
+    phrase_id: phraseId,
+    semantic_label: semanticLabel,
     normalized_label: normalizedLabel,
     label: normalizedLabel,
     transcript: promptedWord,
@@ -179,6 +196,8 @@ export function buildSample(row, index, dataset) {
         submitted_at: row.submitted_at,
         storage_type: row.storage_type,
         category,
+        phrase_id: phraseId,
+        semantic_label: semanticLabel,
       },
       storage: {
         storage_type: row.storage_type,
@@ -300,7 +319,7 @@ export function buildStorageFilterSummary({
 export async function exportDataset() {
   config();
   const outputDir = path.resolve(
-    configValue('DATASET_OUTPUT_DIR', './exports/short-finnish-responses/v1')
+    configValue('DATASET_OUTPUT_DIR', './exports/short-finnish-responses/v2')
   );
   const metadataDir = path.join(outputDir, 'metadata');
   ensureDirectory(metadataDir);

--- a/scripts/aina/exportDataset.test.js
+++ b/scripts/aina/exportDataset.test.js
@@ -183,6 +183,8 @@ test('buildSample uses recording id and v1 labels in the manifest row', () => {
       recording_metadata: {
         schema_version: 'v1',
         prompted_word: 'Kyllä',
+        phrase_id: 'yes_kylla',
+        semantic_label: 'yes',
         normalized_label: 'kylla',
         literal_transcript: 'kyl',
         label_source: 'user_confirmed',
@@ -206,6 +208,8 @@ test('buildSample uses recording id and v1 labels in the manifest row', () => {
   assert.equal(sample.sample_id, 'recording-123');
   assert.equal(sample.audio_path, 'session-123/short_finnish_responses_v1_0001_kylla.wav');
   assert.equal(sample.prompted_word, 'Kyllä');
+  assert.equal(sample.phrase_id, 'yes_kylla');
+  assert.equal(sample.semantic_label, 'yes');
   assert.equal(sample.normalized_label, 'kylla');
   assert.equal(sample.label, 'kylla');
   assert.equal(sample.literal_transcript, 'kyl');
@@ -222,6 +226,39 @@ test('buildSample uses recording id and v1 labels in the manifest row', () => {
     encoding: 'pcm_s16le',
   });
   assert.equal(sample.metadata.collection.session_status, 'completed');
+  assert.equal(sample.metadata.collection.phrase_id, 'yes_kylla');
+  assert.equal(sample.metadata.collection.semantic_label, 'yes');
+});
+
+test('buildSample keeps legacy semantic fields nullable', () => {
+  const dataset = buildDatasetMetadata([], ['kylla'], 'local-root');
+  const sample = buildSample(
+    {
+      recording_id: 'recording-legacy',
+      session_id: 'session-legacy',
+      session_status: 'abandoned',
+      session_metadata: {},
+      topic_id: 'short_finnish_responses_v1_0001',
+      task_id: 'short_finnish_responses_v1_0001_kylla',
+      storage_type: 'local',
+      storage_key: 'session-legacy/short_finnish_responses_v1_0001_kylla.wav',
+      transcript: 'Kylla',
+      label: 'kylla',
+      language: 'fi',
+      category: 'affirmative',
+      duration_sec: 0.82,
+      submitted_at: '2026-04-22T10:00:00.000Z',
+      recording_metadata: {},
+      task_metadata: {},
+    },
+    0,
+    dataset
+  );
+
+  assert.equal(sample.phrase_id, null);
+  assert.equal(sample.semantic_label, null);
+  assert.equal(sample.metadata.collection.phrase_id, null);
+  assert.equal(sample.metadata.collection.semantic_label, null);
 });
 
 test('speaker id is stable for the same device id across sessions', () => {

--- a/scripts/aina/migration.sql
+++ b/scripts/aina/migration.sql
@@ -58,8 +58,18 @@ CREATE TABLE IF NOT EXISTS recordings (
     metadata JSONB NOT NULL DEFAULT '{}'::jsonb
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS recordings_session_task_idx
+DROP INDEX IF EXISTS recordings_session_task_idx;
+
+CREATE INDEX IF NOT EXISTS recordings_session_task_lookup_idx
     ON recordings(session_id, task_id);
 
 CREATE INDEX IF NOT EXISTS recordings_session_submitted_idx
     ON recordings(session_id, submitted_at);
+
+CREATE INDEX IF NOT EXISTS participant_sessions_device_id_idx
+    ON participant_sessions ((metadata->>'device_id'))
+    WHERE metadata ? 'device_id';
+
+CREATE INDEX IF NOT EXISTS recordings_phrase_id_idx
+    ON recordings ((metadata->>'phrase_id'))
+    WHERE metadata ? 'phrase_id';

--- a/scripts/aina/pushPrompts.js
+++ b/scripts/aina/pushPrompts.js
@@ -8,14 +8,14 @@ const { Client } = pkg;
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 const migrationFilePath = path.join(currentDir, 'migration.sql');
 
-function createDbClient() {
+export function createDbClient() {
   config();
   const password = encodeURIComponent(process.env.PG_PASSWORD || '');
   const connString = `postgresql://${process.env.PG_USER}:${password}@${process.env.PG_HOST}:${process.env.PG_PORT}/${process.env.PG_DATABASE}`;
   return new Client({ connectionString: connString });
 }
 
-async function createTables() {
+export async function createTables() {
   const client = createDbClient();
   try {
     await client.connect();
@@ -25,25 +25,205 @@ async function createTables() {
   }
 }
 
-function padTopicIndex(value) {
+export function padTopicIndex(value) {
   return String(value).padStart(4, '0');
 }
 
-async function pushPrompts(filePath) {
-  const client = createDbClient();
-  const promptSet = JSON.parse(readFileSync(filePath, 'utf-8'));
-  const topicCopies = Number.parseInt(process.env.AINA_TOPIC_COPIES || '100', 10);
+function normalizeRequiredString(value, fieldName) {
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new Error(`Prompt file field ${fieldName} must be a non-empty string.`);
+  }
 
-  if (!Array.isArray(promptSet.prompts) || promptSet.prompts.length === 0) {
+  return value.trim();
+}
+
+function normalizeOptionalString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeArray(value, fieldName) {
+  if (value === undefined) {
+    return [];
+  }
+
+  if (!Array.isArray(value)) {
+    throw new Error(`Prompt file field ${fieldName} must be an array.`);
+  }
+
+  return value;
+}
+
+export function validatePromptSet(promptSet) {
+  if (!promptSet || typeof promptSet !== 'object' || Array.isArray(promptSet)) {
+    throw new Error('Prompt file must be a JSON object.');
+  }
+
+  const datasetId = normalizeRequiredString(promptSet.dataset_id, 'dataset_id');
+  const version = normalizeRequiredString(promptSet.version, 'version');
+  const language = normalizeRequiredString(promptSet.language, 'language');
+  const prompts = normalizeArray(promptSet.prompts, 'prompts');
+
+  if (prompts.length === 0) {
     throw new Error('Prompt file must contain a non-empty prompts array.');
   }
 
+  const seenPromptIds = new Set();
+  const seenPhraseIds = new Set();
+  for (const [index, prompt] of prompts.entries()) {
+    if (!prompt || typeof prompt !== 'object' || Array.isArray(prompt)) {
+      throw new Error(`Prompt at index ${index} must be an object.`);
+    }
+
+    const promptId = normalizeRequiredString(prompt.id, `prompts[${index}].id`);
+    const phraseId = normalizeRequiredString(
+      prompt.phrase_id || prompt.id,
+      `prompts[${index}].phrase_id`
+    );
+    normalizeRequiredString(prompt.label, `prompts[${index}].label`);
+    normalizeRequiredString(prompt.text, `prompts[${index}].text`);
+    normalizeRequiredString(prompt.category, `prompts[${index}].category`);
+
+    if (seenPromptIds.has(promptId)) {
+      throw new Error(`Duplicate prompt id in prompt file: ${promptId}`);
+    }
+    seenPromptIds.add(promptId);
+
+    if (seenPhraseIds.has(phraseId)) {
+      throw new Error(`Duplicate phrase_id in prompt file: ${phraseId}`);
+    }
+    seenPhraseIds.add(phraseId);
+  }
+
+  const categoryOrder = normalizeArray(promptSet.category_order, 'category_order').map((value, index) =>
+    normalizeRequiredString(value, `category_order[${index}]`)
+  );
+  const categories = normalizeArray(promptSet.categories, 'categories').map((category, index) => {
+    if (!category || typeof category !== 'object' || Array.isArray(category)) {
+      throw new Error(`Category at index ${index} must be an object.`);
+    }
+
+    return {
+      id: normalizeRequiredString(category.id, `categories[${index}].id`),
+      title: normalizeRequiredString(category.title, `categories[${index}].title`),
+      required_count:
+        Number.isFinite(Number(category.required_count)) && Number(category.required_count) > 0
+          ? Number(category.required_count)
+          : 3,
+    };
+  });
+
+  return {
+    ...promptSet,
+    dataset_id: datasetId,
+    version,
+    language,
+    category_order: categoryOrder,
+    categories,
+    prompts,
+    control_labels: normalizeArray(promptSet.control_labels, 'control_labels').map((value, index) =>
+      normalizeRequiredString(value, `control_labels[${index}]`)
+    ),
+  };
+}
+
+export function buildTopicId(promptSet, copyIndex) {
+  return `${promptSet.dataset_id}_${promptSet.version}_${padTopicIndex(copyIndex)}`;
+}
+
+export function buildTopicMetadata(promptSet) {
+  return {
+    dataset_id: promptSet.dataset_id,
+    dataset_version: promptSet.version,
+    language: promptSet.language,
+    prompt_count: promptSet.prompts.length,
+    category_order: promptSet.category_order,
+    categories: promptSet.categories,
+    control_labels: promptSet.control_labels,
+  };
+}
+
+export function buildTaskMetadata(promptSet, prompt) {
+  return {
+    prompt_id: prompt.id,
+    phrase_id: prompt.phrase_id || prompt.id,
+    label: prompt.label,
+    semantic_label: normalizeOptionalString(prompt.semantic_label),
+    language: promptSet.language,
+    category: prompt.category,
+    dataset_id: promptSet.dataset_id,
+    dataset_version: promptSet.version,
+  };
+}
+
+async function removeObsoleteTasks(client, topicId, desiredTaskIds) {
+  const obsoleteResult = await client.query(
+    `
+      SELECT
+        tk.id,
+        COUNT(r.id)::integer AS recording_count
+      FROM tasks tk
+      LEFT JOIN recordings r
+        ON r.task_id = tk.id
+      WHERE tk.topic_id = $1
+        AND NOT (tk.id = ANY($2::text[]))
+      GROUP BY tk.id
+      ORDER BY tk.id ASC
+    `,
+    [topicId, desiredTaskIds]
+  );
+
+  if (obsoleteResult.rowCount === 0) {
+    return 0;
+  }
+
+  const tasksWithRecordings = obsoleteResult.rows.filter((row) => row.recording_count > 0);
+  if (tasksWithRecordings.length > 0) {
+    throw new Error(
+      `Refusing to delete obsolete task(s) with recordings in ${topicId}: ` +
+        tasksWithRecordings.map((row) => row.id).join(', ') +
+        '. Reset or archive collection data before reseeding this prompt version.'
+    );
+  }
+
+  const deleteResult = await client.query(
+    `
+      DELETE FROM tasks
+      WHERE topic_id = $1
+        AND NOT (id = ANY($2::text[]))
+    `,
+    [topicId, desiredTaskIds]
+  );
+
+  return deleteResult.rowCount;
+}
+
+async function moveExistingTasksOutOfTaskIdxRange(client, topicId, desiredTaskIds) {
+  await client.query(
+    `
+      UPDATE tasks
+      SET task_idx = task_idx - 1000000
+      WHERE topic_id = $1
+        AND id = ANY($2::text[])
+    `,
+    [topicId, desiredTaskIds]
+  );
+}
+
+export async function pushPrompts(filePath) {
+  const client = createDbClient();
+  const promptSet = validatePromptSet(JSON.parse(readFileSync(filePath, 'utf-8')));
+  const topicCopies = Number.parseInt(process.env.AINA_TOPIC_COPIES || '100', 10);
+
   await client.connect();
+  let deletedObsoleteTaskCount = 0;
   try {
+    await client.query('BEGIN');
+
     for (let copyIndex = 1; copyIndex <= topicCopies; copyIndex += 1) {
       const topicSuffix = padTopicIndex(copyIndex);
-      const topicId = `${promptSet.dataset_id}_${promptSet.version}_${topicSuffix}`;
-      const topicName = `AINA ${promptSet.language.toUpperCase()} short responses ${topicSuffix}`;
+      const topicId = buildTopicId(promptSet, copyIndex);
+      const topicName = `AINA ${promptSet.language.toUpperCase()} short responses ${promptSet.version} ${topicSuffix}`;
+      const desiredTaskIds = promptSet.prompts.map((prompt) => `${topicId}_${prompt.id}`);
 
       await client.query(
         `
@@ -58,14 +238,12 @@ async function pushPrompts(filePath) {
           topicId,
           topicName,
           promptSet.prompts.length,
-          {
-            dataset_id: promptSet.dataset_id,
-            dataset_version: promptSet.version,
-            language: promptSet.language,
-            prompt_count: promptSet.prompts.length,
-          },
+          buildTopicMetadata(promptSet),
         ]
       );
+
+      deletedObsoleteTaskCount += await removeObsoleteTasks(client, topicId, desiredTaskIds);
+      await moveExistingTasksOutOfTaskIdxRange(client, topicId, desiredTaskIds);
 
       for (const [taskIdx, prompt] of promptSet.prompts.entries()) {
         const taskId = `${topicId}_${prompt.id}`;
@@ -83,33 +261,37 @@ async function pushPrompts(filePath) {
             topicId,
             taskIdx,
             prompt.text,
-            {
-              prompt_id: prompt.id,
-              label: prompt.label,
-              language: promptSet.language,
-              category: prompt.category,
-              dataset_id: promptSet.dataset_id,
-              dataset_version: promptSet.version,
-            },
+            buildTaskMetadata(promptSet, prompt),
           ]
         );
       }
     }
 
+    await client.query('COMMIT');
+
     console.log(
       `Seeded/upserted ${topicCopies} AINA topics with ${promptSet.prompts.length} prompts each. ` +
-      'Increase AINA_TOPIC_COPIES and rerun this command to create more topic copies.'
+        `${deletedObsoleteTaskCount} obsolete task(s) without recordings were removed. ` +
+        'Increase AINA_TOPIC_COPIES and rerun this command to create more topic copies.'
     );
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
   } finally {
     await client.end();
   }
 }
 
-const filePath = process.argv[2];
-if (!filePath) {
-  console.error('Usage: node scripts/aina/pushPrompts.js scripts/aina/short_finnish_prompts.json');
-  process.exit(1);
-}
+const currentPath = fileURLToPath(import.meta.url);
+const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
 
-await createTables();
-await pushPrompts(filePath);
+if (entryPath === currentPath) {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    console.error('Usage: node scripts/aina/pushPrompts.js scripts/aina/short_finnish_prompts.json');
+    process.exit(1);
+  }
+
+  await createTables();
+  await pushPrompts(filePath);
+}

--- a/scripts/aina/pushPrompts.test.js
+++ b/scripts/aina/pushPrompts.test.js
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+import {
+  buildTaskMetadata,
+  buildTopicId,
+  buildTopicMetadata,
+  validatePromptSet,
+} from './pushPrompts.js';
+
+const currentDir = path.dirname(fileURLToPath(import.meta.url));
+const promptFilePath = path.join(currentDir, 'short_finnish_prompts.json');
+
+test('v2 prompt seed contains category phrase metadata', () => {
+  const promptSet = validatePromptSet(JSON.parse(readFileSync(promptFilePath, 'utf-8')));
+  const yesPrompt = promptSet.prompts.find((prompt) => prompt.id === 'yes_kylla');
+  const numberPrompt = promptSet.prompts.find((prompt) => prompt.id === 'number_kaks');
+
+  assert.equal(promptSet.version, 'v2');
+  assert.deepEqual(promptSet.category_order, [
+    'yes',
+    'no',
+    'maybe',
+    'dont_know',
+    'correct',
+    'number',
+  ]);
+  assert.equal(promptSet.categories.find((category) => category.id === 'correct')?.required_count, 3);
+  assert.equal(yesPrompt.text, 'Kyllä');
+  assert.equal(yesPrompt.phrase_id, 'yes_kylla');
+  assert.equal(yesPrompt.label, 'kylla');
+  assert.equal(yesPrompt.semantic_label, 'yes');
+  assert.equal(numberPrompt.label, 'kaks');
+  assert.equal(numberPrompt.semantic_label, 'number_2');
+  assert.deepEqual(promptSet.control_labels, ['unknown', 'silence', 'noise']);
+});
+
+test('topic metadata stores category order and categories', () => {
+  const promptSet = validatePromptSet(JSON.parse(readFileSync(promptFilePath, 'utf-8')));
+  const topicMetadata = buildTopicMetadata(promptSet);
+
+  assert.equal(buildTopicId(promptSet, 1), 'short_finnish_responses_v2_0001');
+  assert.equal(topicMetadata.dataset_version, 'v2');
+  assert.equal(topicMetadata.prompt_count, promptSet.prompts.length);
+  assert.deepEqual(topicMetadata.category_order, promptSet.category_order);
+  assert.equal(topicMetadata.categories.find((category) => category.id === 'number')?.title, 'Numbers');
+});
+
+test('task metadata stores phrase_id and semantic_label from prompt rows', () => {
+  const promptSet = validatePromptSet(JSON.parse(readFileSync(promptFilePath, 'utf-8')));
+  const prompt = promptSet.prompts.find((entry) => entry.id === 'dont_know_en_tiia');
+  const taskMetadata = buildTaskMetadata(promptSet, prompt);
+
+  assert.deepEqual(taskMetadata, {
+    prompt_id: 'dont_know_en_tiia',
+    phrase_id: 'dont_know_en_tiia',
+    label: 'en_tiia',
+    semantic_label: 'dont_know',
+    language: 'fi',
+    category: 'dont_know',
+    dataset_id: 'short_finnish_responses',
+    dataset_version: 'v2',
+  });
+});
+
+test('validatePromptSet rejects duplicate phrase IDs', () => {
+  assert.throws(
+    () =>
+      validatePromptSet({
+        dataset_id: 'short_finnish_responses',
+        version: 'v2',
+        language: 'fi',
+        prompts: [
+          {
+            id: 'first',
+            phrase_id: 'duplicate',
+            label: 'first',
+            text: 'First',
+            category: 'yes',
+          },
+          {
+            id: 'second',
+            phrase_id: 'duplicate',
+            label: 'second',
+            text: 'Second',
+            category: 'yes',
+          },
+        ],
+      }),
+    /Duplicate phrase_id/
+  );
+});

--- a/scripts/aina/short_finnish_prompts.json
+++ b/scripts/aina/short_finnish_prompts.json
@@ -1,29 +1,369 @@
 {
   "dataset_id": "short_finnish_responses",
-  "version": "v1",
+  "version": "v2",
   "language": "fi",
+  "category_order": ["yes", "no", "maybe", "dont_know", "correct", "number"],
+  "categories": [
+    { "id": "yes", "title": "Yes", "required_count": 3 },
+    { "id": "no", "title": "No", "required_count": 3 },
+    { "id": "maybe", "title": "Maybe", "required_count": 3 },
+    { "id": "dont_know", "title": "Don't know / Not sure", "required_count": 3 },
+    { "id": "correct", "title": "That's correct", "required_count": 3 },
+    { "id": "number", "title": "Numbers", "required_count": 3 }
+  ],
   "prompts": [
-    { "id": "kylla", "label": "kylla", "text": "Kyllä", "category": "affirmative" },
-    { "id": "joo", "label": "joo", "text": "Joo", "category": "affirmative" },
-    { "id": "niin", "label": "niin", "text": "Niin", "category": "affirmative" },
-    { "id": "on", "label": "on", "text": "On", "category": "affirmative" },
-    { "id": "okei", "label": "okei", "text": "Okei", "category": "affirmative" },
-    { "id": "ei", "label": "ei", "text": "Ei", "category": "negative" },
-    { "id": "en", "label": "en", "text": "En", "category": "negative" },
-    { "id": "eipa", "label": "eipa", "text": "Eipä", "category": "negative" },
-    { "id": "yksi", "label": "1", "text": "Yksi", "category": "number" },
-    { "id": "kaksi", "label": "2", "text": "Kaksi", "category": "number" },
-    { "id": "kolme", "label": "3", "text": "Kolme", "category": "number" },
-    { "id": "nelja", "label": "4", "text": "Neljä", "category": "number" },
-    { "id": "viisi", "label": "5", "text": "Viisi", "category": "number" },
-    { "id": "kuusi", "label": "6", "text": "Kuusi", "category": "number" },
-    { "id": "seitseman", "label": "7", "text": "Seitsemän", "category": "number" },
-    { "id": "kahdeksan", "label": "8", "text": "Kahdeksan", "category": "number" },
-    { "id": "yhdeksan", "label": "9", "text": "Yhdeksän", "category": "number" },
-    { "id": "kymmenen", "label": "10", "text": "Kymmenen", "category": "number" },
-    { "id": "kiitos", "label": "kiitos", "text": "Kiitos", "category": "common" },
-    { "id": "anteeksi", "label": "anteeksi", "text": "Anteeksi", "category": "common" },
-    { "id": "hei", "label": "hei", "text": "Hei", "category": "common" }
+    {
+      "id": "yes_kylla",
+      "phrase_id": "yes_kylla",
+      "label": "kylla",
+      "semantic_label": "yes",
+      "text": "Kyllä",
+      "category": "yes"
+    },
+    {
+      "id": "yes_kyl",
+      "phrase_id": "yes_kyl",
+      "label": "kyl",
+      "semantic_label": "yes",
+      "text": "Kyl",
+      "category": "yes"
+    },
+    {
+      "id": "yes_joo",
+      "phrase_id": "yes_joo",
+      "label": "joo",
+      "semantic_label": "yes",
+      "text": "Joo",
+      "category": "yes"
+    },
+    {
+      "id": "yes_juu",
+      "phrase_id": "yes_juu",
+      "label": "juu",
+      "semantic_label": "yes",
+      "text": "Juu",
+      "category": "yes"
+    },
+    {
+      "id": "yes_on",
+      "phrase_id": "yes_on",
+      "label": "on",
+      "semantic_label": "yes",
+      "text": "On",
+      "category": "yes"
+    },
+    {
+      "id": "yes_on_ollut",
+      "phrase_id": "yes_on_ollut",
+      "label": "on_ollut",
+      "semantic_label": "yes",
+      "text": "On ollut",
+      "category": "yes"
+    },
+    {
+      "id": "yes_olen",
+      "phrase_id": "yes_olen",
+      "label": "olen",
+      "semantic_label": "yes",
+      "text": "Olen",
+      "category": "yes"
+    },
+    {
+      "id": "yes_olen_ollut",
+      "phrase_id": "yes_olen_ollut",
+      "label": "olen_ollut",
+      "semantic_label": "yes",
+      "text": "Olen ollut",
+      "category": "yes"
+    },
+    {
+      "id": "no_ei",
+      "phrase_id": "no_ei",
+      "label": "ei",
+      "semantic_label": "no",
+      "text": "Ei",
+      "category": "no"
+    },
+    {
+      "id": "no_ei_ole",
+      "phrase_id": "no_ei_ole",
+      "label": "ei_ole",
+      "semantic_label": "no",
+      "text": "Ei ole",
+      "category": "no"
+    },
+    {
+      "id": "no_ei_oo",
+      "phrase_id": "no_ei_oo",
+      "label": "ei_oo",
+      "semantic_label": "no",
+      "text": "Ei oo",
+      "category": "no"
+    },
+    {
+      "id": "no_en",
+      "phrase_id": "no_en",
+      "label": "en",
+      "semantic_label": "no",
+      "text": "En",
+      "category": "no"
+    },
+    {
+      "id": "no_en_ole",
+      "phrase_id": "no_en_ole",
+      "label": "en_ole",
+      "semantic_label": "no",
+      "text": "En ole",
+      "category": "no"
+    },
+    {
+      "id": "no_en_oo",
+      "phrase_id": "no_en_oo",
+      "label": "en_oo",
+      "semantic_label": "no",
+      "text": "En oo",
+      "category": "no"
+    },
+    {
+      "id": "maybe_ehka",
+      "phrase_id": "maybe_ehka",
+      "label": "ehka",
+      "semantic_label": "maybe",
+      "text": "Ehkä",
+      "category": "maybe"
+    },
+    {
+      "id": "maybe_mahdollisesti",
+      "phrase_id": "maybe_mahdollisesti",
+      "label": "mahdollisesti",
+      "semantic_label": "maybe",
+      "text": "Mahdollisesti",
+      "category": "maybe"
+    },
+    {
+      "id": "maybe_kai",
+      "phrase_id": "maybe_kai",
+      "label": "kai",
+      "semantic_label": "maybe",
+      "text": "Kai",
+      "category": "maybe"
+    },
+    {
+      "id": "dont_know_en_tieda",
+      "phrase_id": "dont_know_en_tieda",
+      "label": "en_tieda",
+      "semantic_label": "dont_know",
+      "text": "En tiedä",
+      "category": "dont_know"
+    },
+    {
+      "id": "dont_know_en_tiia",
+      "phrase_id": "dont_know_en_tiia",
+      "label": "en_tiia",
+      "semantic_label": "dont_know",
+      "text": "En tiiä",
+      "category": "dont_know"
+    },
+    {
+      "id": "dont_know_emma_tiia",
+      "phrase_id": "dont_know_emma_tiia",
+      "label": "emma_tiia",
+      "semantic_label": "dont_know",
+      "text": "Emmä tiiä",
+      "category": "dont_know"
+    },
+    {
+      "id": "dont_know_emt",
+      "phrase_id": "dont_know_emt",
+      "label": "emt",
+      "semantic_label": "dont_know",
+      "text": "EMT",
+      "category": "dont_know"
+    },
+    {
+      "id": "dont_know_en_osaa_sanoa",
+      "phrase_id": "dont_know_en_osaa_sanoa",
+      "label": "en_osaa_sanoa",
+      "semantic_label": "dont_know",
+      "text": "En osaa sanoa",
+      "category": "dont_know"
+    },
+    {
+      "id": "dont_know_en_osaa_sanoo",
+      "phrase_id": "dont_know_en_osaa_sanoo",
+      "label": "en_osaa_sanoo",
+      "semantic_label": "dont_know",
+      "text": "En osaa sanoo",
+      "category": "dont_know"
+    },
+    {
+      "id": "dont_know_en_ole_varma",
+      "phrase_id": "dont_know_en_ole_varma",
+      "label": "en_ole_varma",
+      "semantic_label": "dont_know",
+      "text": "En ole varma",
+      "category": "dont_know"
+    },
+    {
+      "id": "dont_know_en_oo_varma",
+      "phrase_id": "dont_know_en_oo_varma",
+      "label": "en_oo_varma",
+      "semantic_label": "dont_know",
+      "text": "En oo varma",
+      "category": "dont_know"
+    },
+    {
+      "id": "correct_niin",
+      "phrase_id": "correct_niin",
+      "label": "niin",
+      "semantic_label": "correct",
+      "text": "Niin",
+      "category": "correct"
+    },
+    {
+      "id": "number_yksi",
+      "phrase_id": "number_yksi",
+      "label": "yksi",
+      "semantic_label": "number_1",
+      "text": "Yksi",
+      "category": "number"
+    },
+    {
+      "id": "number_yks",
+      "phrase_id": "number_yks",
+      "label": "yks",
+      "semantic_label": "number_1",
+      "text": "Yks",
+      "category": "number"
+    },
+    {
+      "id": "number_kaksi",
+      "phrase_id": "number_kaksi",
+      "label": "kaksi",
+      "semantic_label": "number_2",
+      "text": "Kaksi",
+      "category": "number"
+    },
+    {
+      "id": "number_kaks",
+      "phrase_id": "number_kaks",
+      "label": "kaks",
+      "semantic_label": "number_2",
+      "text": "Kaks",
+      "category": "number"
+    },
+    {
+      "id": "number_kolme",
+      "phrase_id": "number_kolme",
+      "label": "kolme",
+      "semantic_label": "number_3",
+      "text": "Kolme",
+      "category": "number"
+    },
+    {
+      "id": "number_nelja",
+      "phrase_id": "number_nelja",
+      "label": "nelja",
+      "semantic_label": "number_4",
+      "text": "Neljä",
+      "category": "number"
+    },
+    {
+      "id": "number_viisi",
+      "phrase_id": "number_viisi",
+      "label": "viisi",
+      "semantic_label": "number_5",
+      "text": "Viisi",
+      "category": "number"
+    },
+    {
+      "id": "number_viis",
+      "phrase_id": "number_viis",
+      "label": "viis",
+      "semantic_label": "number_5",
+      "text": "Viis",
+      "category": "number"
+    },
+    {
+      "id": "number_kuusi",
+      "phrase_id": "number_kuusi",
+      "label": "kuusi",
+      "semantic_label": "number_6",
+      "text": "Kuusi",
+      "category": "number"
+    },
+    {
+      "id": "number_kuus",
+      "phrase_id": "number_kuus",
+      "label": "kuus",
+      "semantic_label": "number_6",
+      "text": "Kuus",
+      "category": "number"
+    },
+    {
+      "id": "number_seitseman",
+      "phrase_id": "number_seitseman",
+      "label": "seitseman",
+      "semantic_label": "number_7",
+      "text": "Seitsemän",
+      "category": "number"
+    },
+    {
+      "id": "number_seitteman",
+      "phrase_id": "number_seitteman",
+      "label": "seitteman",
+      "semantic_label": "number_7",
+      "text": "Seittemän",
+      "category": "number"
+    },
+    {
+      "id": "number_kahdeksan",
+      "phrase_id": "number_kahdeksan",
+      "label": "kahdeksan",
+      "semantic_label": "number_8",
+      "text": "Kahdeksan",
+      "category": "number"
+    },
+    {
+      "id": "number_kasi",
+      "phrase_id": "number_kasi",
+      "label": "kasi",
+      "semantic_label": "number_8",
+      "text": "Kasi",
+      "category": "number"
+    },
+    {
+      "id": "number_yhdeksan",
+      "phrase_id": "number_yhdeksan",
+      "label": "yhdeksan",
+      "semantic_label": "number_9",
+      "text": "Yhdeksän",
+      "category": "number"
+    },
+    {
+      "id": "number_ysi",
+      "phrase_id": "number_ysi",
+      "label": "ysi",
+      "semantic_label": "number_9",
+      "text": "Ysi",
+      "category": "number"
+    },
+    {
+      "id": "number_kymmenen",
+      "phrase_id": "number_kymmenen",
+      "label": "kymmenen",
+      "semantic_label": "number_10",
+      "text": "Kymmenen",
+      "category": "number"
+    },
+    {
+      "id": "number_kymppi",
+      "phrase_id": "number_kymppi",
+      "label": "kymppi",
+      "semantic_label": "number_10",
+      "text": "Kymppi",
+      "category": "number"
+    }
   ],
   "control_labels": ["unknown", "silence", "noise"]
 }

--- a/scripts/aina/verify_v2_exports.py
+++ b/scripts/aina/verify_v2_exports.py
@@ -1,0 +1,530 @@
+#!/usr/bin/env python3
+"""
+Verify Speech Collector v2 normal export + databuilder export.
+
+Run from:
+  apps/speech-collector/
+
+Examples:
+  python scripts/aina/verify_v2_exports.py
+  python scripts/aina/verify_v2_exports.py --run-exports
+  python scripts/aina/verify_v2_exports.py --strict-v2-paths
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import wave
+from pathlib import Path
+from typing import Any
+
+
+APP_ROOT = Path(__file__).resolve().parents[2]
+ENV_PATH = APP_ROOT / ".env"
+
+
+def ok(message: str) -> None:
+    print(f"[OK] {message}")
+
+
+def warn(message: str) -> None:
+    print(f"[WARN] {message}")
+
+
+def fail(message: str) -> None:
+    print(f"[FAIL] {message}")
+
+
+def read_env(path: Path) -> dict[str, str]:
+    values: dict[str, str] = {}
+    if not path.exists():
+        warn(f".env not found at {path}")
+        return values
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        values[key.strip()] = value.strip().strip('"').strip("'")
+    return values
+
+
+def resolve_app_path(value: str | None, default: str) -> Path:
+    raw = value or default
+    path = Path(raw)
+    if path.is_absolute():
+        return path
+    return APP_ROOT / path
+
+
+def load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    with path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"Invalid JSONL at {path}:{line_no}: {exc}") from exc
+    return rows
+
+
+def md5_file(path: Path) -> str:
+    digest = hashlib.md5()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def is_processed_audio_valid(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    return (
+        value.get("sample_rate_hz") == 16000
+        and value.get("channel_count") == 1
+        and value.get("encoding") == "pcm_s16le"
+    )
+
+
+def inspect_wav(path: Path) -> tuple[int, int, int]:
+    with wave.open(str(path), "rb") as wav:
+        channels = wav.getnchannels()
+        sample_rate = wav.getframerate()
+        sample_width = wav.getsampwidth()
+    return sample_rate, channels, sample_width
+
+
+def run_command(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        cwd=str(cwd),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+    )
+
+def find_corepack() -> str | None:
+    candidates = [
+        shutil.which("corepack.cmd"),
+        shutil.which("corepack.exe"),
+        shutil.which("corepack"),
+    ]
+
+    for candidate in candidates:
+        if candidate and Path(candidate).suffix.lower() in {".cmd", ".exe", ".bat"}:
+            return candidate
+
+    return next((candidate for candidate in candidates if candidate), None)
+
+
+def run_command(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    # On Windows, .cmd shims are more reliable with shell=True.
+    use_shell = os.name == "nt"
+    return subprocess.run(
+        " ".join(f'"{part}"' if " " in part else part for part in command) if use_shell else command,
+        cwd=str(cwd),
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=False,
+        shell=use_shell,
+    )
+
+
+def run_exports() -> bool:
+    corepack = find_corepack()
+    if not corepack:
+        fail("corepack not found on PATH. Set your portable Node path first.")
+        return False
+
+    commands = [
+        [corepack, "pnpm", "run", "aina:export"],
+        [corepack, "pnpm", "run", "aina:export:databuilder"],
+    ]
+
+    all_ok = True
+    for command in commands:
+        print(f"\nRunning: {' '.join(command)}")
+        result = run_command(command, APP_ROOT)
+        print(result.stdout)
+        if result.returncode != 0:
+            fail(f"Command failed: {' '.join(command)}")
+            all_ok = False
+        else:
+            ok(f"Command passed: {' '.join(command)}")
+    return all_ok
+
+def verify_env_paths(env: dict[str, str], strict_v2_paths: bool) -> bool:
+    passed = True
+
+    dataset_version = env.get("DATASET_VERSION", "")
+    dataset_output_dir = env.get("DATASET_OUTPUT_DIR", "")
+    databuilder_output_dir = env.get("DATABUILDER_OUTPUT_DIR", "")
+    audio_prefix = env.get("COLLECTION_AUDIO_PREFIX", "")
+
+    print("\nEnvironment path summary")
+    print("========================")
+    print(f"DATASET_VERSION={dataset_version}")
+    print(f"DATASET_OUTPUT_DIR={dataset_output_dir}")
+    print(f"DATABUILDER_OUTPUT_DIR={databuilder_output_dir}")
+    print(f"COLLECTION_AUDIO_PREFIX={audio_prefix}")
+
+    if dataset_version == "v2":
+        if "v1" in dataset_output_dir.replace("\\", "/"):
+            warn("DATASET_VERSION is v2 but DATASET_OUTPUT_DIR contains v1.")
+            if strict_v2_paths:
+                passed = False
+
+        if "v1" in audio_prefix:
+            warn("DATASET_VERSION is v2 but COLLECTION_AUDIO_PREFIX contains v1.")
+            if strict_v2_paths:
+                passed = False
+
+        if "v1" in databuilder_output_dir.replace("\\", "/"):
+            warn("DATASET_VERSION is v2 but DATABUILDER_OUTPUT_DIR contains v1.")
+            if strict_v2_paths:
+                passed = False
+
+    return passed
+
+
+def verify_normal_export(dataset_output_dir: Path) -> tuple[bool, set[str]]:
+    print("\nNormal export verification")
+    print("==========================")
+
+    dataset_json = dataset_output_dir / "metadata" / "dataset.json"
+    samples_jsonl = dataset_output_dir / "metadata" / "samples.jsonl"
+
+    passed = True
+    sample_ids: set[str] = set()
+
+    if not dataset_json.exists():
+        fail(f"Missing dataset.json: {dataset_json}")
+        return False, sample_ids
+
+    if not samples_jsonl.exists():
+        fail(f"Missing samples.jsonl: {samples_jsonl}")
+        return False, sample_ids
+
+    dataset = load_json(dataset_json)
+    samples = load_jsonl(samples_jsonl)
+
+    ok(f"dataset.json exists: {dataset_json}")
+    ok(f"samples.jsonl exists with {len(samples)} row(s)")
+
+    if not samples:
+        fail("samples.jsonl has no rows")
+        return False, sample_ids
+
+    if dataset.get("version") != "v2":
+        warn(f"dataset.json version is {dataset.get('version')!r}, expected 'v2' for this new flow")
+
+    required_root_keys = [
+        "sample_id",
+        "audio_path",
+        "prompted_word",
+        "normalized_label",
+        "label",
+        "literal_transcript",
+        "label_source",
+        "language",
+        "duration_sec",
+        "speaker_id",
+    ]
+
+    semantic_missing = 0
+    phrase_missing = 0
+    processed_invalid = 0
+
+    for index, sample in enumerate(samples, start=1):
+        sample_id = sample.get("sample_id")
+        if isinstance(sample_id, str):
+            sample_ids.add(sample_id)
+
+        for key in required_root_keys:
+            if key not in sample:
+                fail(f"Sample {index} missing root key: {key}")
+                passed = False
+
+        if "phrase_id" not in sample or not sample.get("phrase_id"):
+            phrase_missing += 1
+
+        if "semantic_label" not in sample or not sample.get("semantic_label"):
+            semantic_missing += 1
+
+        metadata = sample.get("metadata")
+        if not isinstance(metadata, dict):
+            fail(f"Sample {sample_id or index} metadata is missing/not object")
+            passed = False
+            continue
+
+        collection = metadata.get("collection")
+        if not isinstance(collection, dict):
+            fail(f"Sample {sample_id or index} metadata.collection missing/not object")
+            passed = False
+        else:
+            if "phrase_id" not in collection:
+                fail(f"Sample {sample_id or index} metadata.collection.phrase_id missing")
+                passed = False
+            if "semantic_label" not in collection:
+                fail(f"Sample {sample_id or index} metadata.collection.semantic_label missing")
+                passed = False
+
+        processed_audio = metadata.get("processed_audio")
+        technical = metadata.get("technical", {})
+        if not is_processed_audio_valid(processed_audio):
+            processed_invalid += 1
+            warn(
+                f"Sample {sample_id or index} processed_audio is not strict-valid: "
+                f"{processed_audio!r}"
+            )
+
+        if isinstance(technical, dict) and technical.get("sample_rate_hz") == 48000:
+            # This is okay. It is browser capture metadata, not saved training audio.
+            pass
+
+    if phrase_missing:
+        warn(f"{phrase_missing} normal-export sample(s) missing phrase_id or have null phrase_id")
+    else:
+        ok("All normal-export samples include phrase_id")
+
+    if semantic_missing:
+        warn(f"{semantic_missing} normal-export sample(s) missing semantic_label or have null semantic_label")
+    else:
+        ok("All normal-export samples include semantic_label")
+
+    if processed_invalid:
+        warn(f"{processed_invalid} normal-export sample(s) have invalid/missing processed_audio")
+    else:
+        ok("All normal-export samples have valid processed_audio metadata")
+
+    ok(f"Normal export sample IDs found: {len(sample_ids)}")
+    return passed, sample_ids
+
+
+def verify_databuilder_export(databuilder_output_dir: Path) -> tuple[bool, set[str]]:
+    print("\nDatabuilder export verification")
+    print("===============================")
+
+    passed = True
+    sample_ids: set[str] = set()
+
+    manifest_path = databuilder_output_dir / "manifest.json"
+    if not manifest_path.exists():
+        fail(f"Missing manifest.json: {manifest_path}")
+        return False, sample_ids
+
+    manifest = load_json(manifest_path)
+    samples = manifest.get("samples")
+
+    if manifest.get("hash_algorithm") != "md5":
+        fail(f"manifest.hash_algorithm is {manifest.get('hash_algorithm')!r}, expected 'md5'")
+        passed = False
+    else:
+        ok("manifest.hash_algorithm is md5")
+
+    if not isinstance(samples, dict) or not samples:
+        fail("manifest.samples missing or empty")
+        return False, sample_ids
+
+    ok(f"manifest contains {len(samples)} sample(s)")
+
+    required_sidecar_keys = [
+        "sample_id",
+        "prompted_word",
+        "normalized_label",
+        "literal_transcript",
+        "label_source",
+        "language",
+        "category",
+        "augmentation_strategy",
+        "augmentations",
+        "device_id",
+        "speaker_id",
+        "duration_sec",
+        "demographics",
+        "environment",
+        "technical",
+        "processed_audio",
+        "collection",
+        "storage",
+    ]
+
+    semantic_missing = 0
+    phrase_missing = 0
+
+    for sample_id, hash_info in samples.items():
+        sample_ids.add(sample_id)
+
+        wav_path = databuilder_output_dir / f"{sample_id}.wav"
+        json_path = databuilder_output_dir / f"{sample_id}.json"
+
+        if not wav_path.exists():
+            fail(f"Missing WAV for {sample_id}: {wav_path}")
+            passed = False
+            continue
+
+        if not json_path.exists():
+            fail(f"Missing JSON sidecar for {sample_id}: {json_path}")
+            passed = False
+            continue
+
+        expected_wav_hash = hash_info.get("wav_hash")
+        expected_json_hash = hash_info.get("json_hash")
+        actual_wav_hash = md5_file(wav_path)
+        actual_json_hash = md5_file(json_path)
+
+        if expected_wav_hash != actual_wav_hash:
+            fail(f"{sample_id} wav_hash mismatch")
+            passed = False
+
+        if expected_json_hash != actual_json_hash:
+            fail(f"{sample_id} json_hash mismatch")
+            passed = False
+
+        sidecar = load_json(json_path)
+
+        if sidecar.get("sample_id") != sample_id:
+            fail(f"{sample_id} sidecar sample_id does not match manifest key")
+            passed = False
+
+        for key in required_sidecar_keys:
+            if key not in sidecar:
+                fail(f"{sample_id} sidecar missing key: {key}")
+                passed = False
+
+        if "phrase_id" not in sidecar or not sidecar.get("phrase_id"):
+            phrase_missing += 1
+
+        if "semantic_label" not in sidecar or not sidecar.get("semantic_label"):
+            semantic_missing += 1
+
+        if sidecar.get("augmentation_strategy") is not None:
+            fail(f"{sample_id} augmentation_strategy should be null for original recording")
+            passed = False
+
+        if sidecar.get("augmentations") != []:
+            fail(f"{sample_id} augmentations should be [] for original recording")
+            passed = False
+
+        processed_audio = sidecar.get("processed_audio")
+        if not is_processed_audio_valid(processed_audio):
+            fail(f"{sample_id} processed_audio invalid: {processed_audio!r}")
+            passed = False
+
+        try:
+            sample_rate, channels, sample_width = inspect_wav(wav_path)
+            if sample_rate != 16000 or channels != 1 or sample_width != 2:
+                fail(
+                    f"{sample_id}.wav invalid audio format: "
+                    f"{sample_rate} Hz, {channels} channel(s), {sample_width * 8}-bit"
+                )
+                passed = False
+        except wave.Error as exc:
+            fail(f"{sample_id}.wav could not be inspected as WAV: {exc}")
+            passed = False
+
+    if phrase_missing:
+        warn(f"{phrase_missing} databuilder sample(s) missing phrase_id or have null phrase_id")
+    else:
+        ok("All databuilder sidecars include phrase_id")
+
+    if semantic_missing:
+        warn(f"{semantic_missing} databuilder sample(s) missing semantic_label or have null semantic_label")
+    else:
+        ok("All databuilder sidecars include semantic_label")
+
+    if passed:
+        ok("Databuilder manifest hashes, sidecars, and WAV formats are valid")
+
+    return passed, sample_ids
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--run-exports",
+        action="store_true",
+        help="Run pnpm aina:export and aina:export:databuilder before verifying output",
+    )
+    parser.add_argument(
+        "--strict-v2-paths",
+        action="store_true",
+        help="Fail if DATASET_VERSION=v2 but output/audio paths still contain v1",
+    )
+    args = parser.parse_args()
+
+    env = read_env(ENV_PATH)
+
+    dataset_version = env.get("DATASET_VERSION", "v1") or "v1"
+
+    dataset_output_dir = resolve_app_path(
+        env.get("DATASET_OUTPUT_DIR"),
+        f"./exports/short-finnish-responses/{dataset_version}",
+)
+
+    databuilder_output_dir = resolve_app_path(
+        env.get("DATABUILDER_OUTPUT_DIR"),
+        f"./exports/short-finnish-responses/{dataset_version}/databuilder",
+)
+
+    checks: list[bool] = []
+
+    checks.append(verify_env_paths(env, args.strict_v2_paths))
+
+    if args.run_exports:
+        checks.append(run_exports())
+
+    normal_ok, normal_ids = verify_normal_export(dataset_output_dir)
+    databuilder_ok, databuilder_ids = verify_databuilder_export(databuilder_output_dir)
+
+    checks.extend([normal_ok, databuilder_ok])
+
+    print("\nCross-export comparison")
+    print("=======================")
+
+    if databuilder_ids and normal_ids:
+        missing_from_normal = databuilder_ids - normal_ids
+        if missing_from_normal:
+            fail(f"{len(missing_from_normal)} databuilder sample(s) missing from normal export")
+            checks.append(False)
+        else:
+            ok("All databuilder samples exist in normal export")
+
+        skipped_by_databuilder = normal_ids - databuilder_ids
+        if skipped_by_databuilder:
+            warn(
+                f"{len(skipped_by_databuilder)} normal-export sample(s) not in databuilder export. "
+                "This is okay if they were legacy/non-classifier-ready."
+            )
+        else:
+            ok("Normal export and databuilder export contain the same sample IDs")
+
+    print("\nSummary")
+    print("=======")
+
+    if all(checks):
+        ok("Export verification passed")
+        return 0
+
+    fail("Export verification failed or has strict-path mismatch")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary

Adds the v2 category-based phrase recording flow for the Speech Collector.

This changes the volunteer recording flow from a linear one-prompt-at-a-time flow to a category-based flow using backend-provided `/api/category-state`.

## What Changed

### Data / Backend Foundation

- Added v2 Finnish phrase bank grouped by:
  - yes
  - no
  - maybe
  - dont_know
  - correct
  - number
- Added `phrase_id` as stable phrase identity.
- Added `semantic_label` as extra metadata/future target.
- Kept `normalized_label` as the phrase-level classifier target.
- Added category state support for fixed category order, shuffled phrase order per session, unique phrase progress, previous same-device progress, and next-category unlock logic.
- Repeat recordings now insert separate samples instead of overwriting previous recordings.
- Audio storage keys include `recording_id`.
- Backend still derives trusted label/category fields from task rows, not frontend payloads.

### Frontend

- Added category intro screen.
- Added category recording screen.
- Added phrase cards with not recorded, recorded this session, and recorded before on this browser/device states.
- Added progress bar showing unique recorded phrases / total phrases.
- Added next-category unlock behavior.
- Preserved Turnstile, metadata form, 5-second recording auto-stop, playback before upload, re-record before upload, and stop/finish session.
- Updated literal transcript UX:
  - Same as shown sends `literal_transcript: null` and `label_source: prompt_assumed`.
  - Typed dialect/different form sends typed `literal_transcript` and `label_source: user_confirmed`.

### Export Compatibility

- Normal export includes `phrase_id` and `semantic_label`.
- Databuilder export sidecars include `phrase_id` and `semantic_label`.
- Existing strict processed-audio filtering remains.

### Responsive UI

- Category UI polished for mobile, tablet, and desktop layouts.
- Phrase cards and recorder controls wrap/stack on smaller screens.

## Validation

Personal repo validation:

```text
backend tests: passed, 57 tests
frontend build: passed
frontend lint: passed
verify_v2_exports.py --run-exports: passed
```

Export verification confirmed:

```text
normal export: samples include phrase_id, semantic_label, and valid processed_audio
databuilder export: manifest/sidecars/WAVs valid
databuilder samples match normal export sample IDs
```

Browser smoke test:

```text
Automated Chrome/CDP smoke passed for page load, metadata completion, category intro, category recording, category-state call, phrase cards, selected phrase panel, recorder UI, 5-second limit text, literal transcript controls, locked next-category state, and visible finish action.

Responsive viewport checks passed without horizontal overflow at 360x800, 390x844, 768x1024, and 1366x768.

Fake microphone upload succeeded. A follow-up category-state check showed the first category at uniqueRecordedCount=1/8 with the uploaded phrase marked recordedInCurrentSession.

Real human microphone smoke test is still recommended before production collection.
```

Company branch validation:

```text
corepack pnpm install: passed
corepack pnpm run test:backend: passed, 57 tests
corepack pnpm build: passed
corepack pnpm --filter sound-collector-frontend lint: passed
```

## Notes

- The current personal Supabase/S3 setup is experimental.
- Some local experimental `.env` paths may still contain `v1`; `.env` is not included in this PR.
- Company deployment can connect its own Supabase/S3 later.
- Generated exports, audio files, temp files, screenshots, traces, and credentials are not included.
