### PR TITLE
Add volunteer privacy and consent flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,16 +219,20 @@ There is no visible admin link in the volunteer UI.
 The main collection flow is:
 
 1. Volunteer opens the app.
-2. If Turnstile is configured, the volunteer completes the human verification gate.
-3. Backend starts or resumes an anonymous session.
-4. Volunteer sees the intro and metadata form.
-5. Volunteer records one prompt at a time in the current frontend; the backend also exposes category progress for the next UI.
-6. Each successful upload is stored and linked to the session.
-7. Volunteer can continue, refresh, or leave.
-8. Submitted recordings stay valid even if the session ends early.
-9. Completed sessions show a thank-you screen.
+2. Volunteer reads the welcome and consent screen with a short collection summary.
+3. A single small read-more link opens the full privacy and consent details.
+4. Volunteer must confirm they are 18 or older and consent to participate.
+5. If Turnstile is configured, the volunteer completes the human verification gate.
+6. Backend starts or resumes an anonymous session with consent metadata.
+7. Volunteer sees the intro and metadata form.
+8. Volunteer records category phrases.
+9. Each successful upload is stored and linked to the session.
+10. Volunteer can continue, refresh, or leave.
+11. Submitted recordings stay valid even if the session ends early.
+12. Completed sessions show a thank-you screen.
 
 The browser stores the active session token locally so an active session can resume automatically in the same browser.
+The full privacy and consent details are at `/#/privacy`. Compatibility route `/#/participant-info` renders the same full details page but is not linked from the normal volunteer flow. The internal admin UI remains at `/#/admin` and is not linked from the volunteer flow.
 
 ## Category Progress API
 
@@ -437,6 +441,7 @@ If you only need more test sessions and want to keep the existing prompt copies,
 - [docs/category-phrase-ui-plan.md](docs/category-phrase-ui-plan.md)
 - [docs/aina-s3-integration.md](docs/aina-s3-integration.md)
 - [docs/admin-validation-ui.md](docs/admin-validation-ui.md)
+- [docs/privacy-consent-flow.md](docs/privacy-consent-flow.md)
 - [docs/aina-data-contract.md](docs/aina-data-contract.md)
 - [docs/databuilder-export.md](docs/databuilder-export.md)
 - [docs/cloud-validation-session-2026-05-04.md](docs/cloud-validation-session-2026-05-04.md)

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,7 +5,7 @@ import { randomUUID } from 'crypto';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { TaskProvider } from './taskProvider.js';
+import { hasRequiredConsentMetadata, TaskProvider } from './taskProvider.js';
 import { FileStorage, RecordingTooLongError } from './fileStorage.js';
 import { createAdminRouter, createDefaultAdminService } from './admin.js';
 import {
@@ -246,7 +246,16 @@ export function createApp(options = {}) {
       }
 
       const sessionToken = normalizeSessionToken(req.body?.sessionToken);
-      const result = await provider.startSession(sessionToken);
+      const metadata = req.body?.metadata;
+      if (!hasRequiredConsentMetadata(metadata)) {
+        return res.status(400).json({
+          success: false,
+          code: 'consent_required',
+          message: 'Valid consent and 18+ confirmation are required before starting a session.',
+        });
+      }
+
+      const result = await provider.startSession(sessionToken, metadata);
       res.status(200).json(result);
     } catch (error) {
       console.error('Error in /api/start-session:', error);

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -11,14 +11,26 @@ import {
 } from './index.js';
 import { RecordingTooLongError } from './fileStorage.js';
 
+const validConsentMetadata = {
+  schema_version: 'v1',
+  device_id: 'browser-device-id',
+  consent_response: 'yes',
+  consent_version: '1.0',
+  privacy_notice_version: '1.0',
+  consent_accepted_at: '2026-06-03T12:00:00.000Z',
+  age_confirmed_18_or_over: true,
+  technical: {},
+};
+
 function createProvider(overrides = {}) {
   return {
     startSessionCalls: 0,
     getCategoryStateCalls: 0,
     getUploadTargetCalls: 0,
     submitRecordingCalls: 0,
-    async startSession() {
+    async startSession(_sessionToken, metadata) {
       this.startSessionCalls += 1;
+      this.lastStartSessionMetadata = metadata;
       return { success: true, session: { sessionToken: 'session-token' } };
     },
     async getUploadTarget() {
@@ -246,6 +258,51 @@ test('Turnstile failure rejects session start before creating a session', async 
     assert.equal(response.status, 400);
     assert.equal(body.code, 'turnstile_failed');
     assert.equal(provider.startSessionCalls, 0);
+  });
+});
+
+test('start-session rejects missing consent metadata before provider start', async () => {
+  const provider = createProvider();
+  const app = createApp({
+    provider,
+    fileStorage: createFileStorage(),
+    turnstileSecretKey: '',
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/start-session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, 'consent_required');
+    assert.equal(provider.startSessionCalls, 0);
+  });
+});
+
+test('start-session passes valid consent metadata to provider', async () => {
+  const provider = createProvider();
+  const app = createApp({
+    provider,
+    fileStorage: createFileStorage(),
+    turnstileSecretKey: '',
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/start-session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ metadata: validConsentMetadata }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.equal(provider.startSessionCalls, 1);
+    assert.deepEqual(provider.lastStartSessionMetadata, validConsentMetadata);
   });
 });
 

--- a/backend/src/taskProvider.js
+++ b/backend/src/taskProvider.js
@@ -9,6 +9,9 @@ export const SESSION_STATUS = {
   ABANDONED: 'abandoned',
 };
 
+export const CONSENT_VERSION = '1.0';
+export const PRIVACY_NOTICE_VERSION = '1.0';
+
 export function calculateProgress(totalTasks, completedTasks) {
   const total = Number.parseInt(totalTasks, 10) || 0;
   const completed = Number.parseInt(completedTasks, 10) || 0;
@@ -35,12 +38,31 @@ function hasNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function isValidIsoTimestamp(value) {
+  if (!hasNonEmptyString(value)) {
+    return false;
+  }
+
+  return Number.isFinite(Date.parse(value));
+}
+
+export function hasRequiredConsentMetadata(metadata) {
+  return (
+    isPlainObject(metadata) &&
+    metadata.consent_response === 'yes' &&
+    metadata.consent_version === CONSENT_VERSION &&
+    metadata.privacy_notice_version === PRIVACY_NOTICE_VERSION &&
+    isValidIsoTimestamp(metadata.consent_accepted_at) &&
+    metadata.age_confirmed_18_or_over === true
+  );
+}
+
 export function hasRequiredSessionMetadata(metadata) {
   return (
     isPlainObject(metadata) &&
     metadata.schema_version === 'v1' &&
     hasNonEmptyString(metadata.device_id) &&
-    metadata.consent_response === 'yes' &&
+    hasRequiredConsentMetadata(metadata) &&
     isPlainObject(metadata.demographics) &&
     isPlainObject(metadata.environment) &&
     isPlainObject(metadata.technical)
@@ -501,13 +523,30 @@ export class TaskProvider {
     );
   }
 
-  async startSession(existingToken = null) {
+  async startSession(existingToken = null, metadata = {}) {
     return this.withClient(async (client) => {
       await this.expireStaleSessions(client);
+      const consentMetadata = normalizeMetadata(metadata);
 
       if (existingToken) {
         const existingSession = await this.getSessionSummaryByToken(client, existingToken);
         if (existingSession?.status === SESSION_STATUS.ACTIVE) {
+          if (!hasRequiredConsentMetadata(existingSession.metadata)) {
+            if (!hasRequiredConsentMetadata(consentMetadata)) {
+              return {
+                success: false,
+                code: 'consent_required',
+                message:
+                  'Valid consent and 18+ confirmation are required before starting a session.',
+              };
+            }
+
+            await this.updateSessionMetadataDocument(client, existingSession.id, {
+              ...existingSession.metadata,
+              ...consentMetadata,
+            });
+          }
+
           await this.touchSession(client, existingSession.id);
           return {
             success: true,
@@ -515,6 +554,14 @@ export class TaskProvider {
             session: await this.getSessionSummaryByToken(client, existingToken),
           };
         }
+      }
+
+      if (!hasRequiredConsentMetadata(consentMetadata)) {
+        return {
+          success: false,
+          code: 'consent_required',
+          message: 'Valid consent and 18+ confirmation are required before starting a session.',
+        };
       }
 
       const sessionToken = randomUUID();
@@ -561,10 +608,10 @@ export class TaskProvider {
         const topicId = topicResult.rows[0].id;
         await client.query(
           `
-            INSERT INTO participant_sessions (session_token, topic_id, status)
-            VALUES ($1, $2, $3)
+            INSERT INTO participant_sessions (session_token, topic_id, status, metadata)
+            VALUES ($1, $2, $3, $4::jsonb)
           `,
-          [sessionToken, topicId, SESSION_STATUS.ACTIVE]
+          [sessionToken, topicId, SESSION_STATUS.ACTIVE, consentMetadata]
         );
 
         await client.query('COMMIT');
@@ -848,6 +895,20 @@ export class TaskProvider {
           success: false,
           code: 'session_not_active',
           message: 'Only active sessions can be updated.',
+          session,
+        };
+      }
+
+      const nextMetadata = {
+        ...normalizeMetadata(session.metadata),
+        ...normalizeMetadata(metadata),
+      };
+
+      if (!hasRequiredConsentMetadata(nextMetadata)) {
+        return {
+          success: false,
+          code: 'consent_required',
+          message: 'Valid consent and 18+ confirmation are required before updating session details.',
           session,
         };
       }

--- a/backend/src/taskProvider.test.js
+++ b/backend/src/taskProvider.test.js
@@ -13,6 +13,10 @@ const validV1SessionMetadata = {
   schema_version: 'v1',
   device_id: 'browser-device-id',
   consent_response: 'yes',
+  consent_version: '1.0',
+  privacy_notice_version: '1.0',
+  consent_accepted_at: '2026-06-03T12:00:00.000Z',
+  age_confirmed_18_or_over: true,
   demographics: {},
   environment: {},
   technical: {},
@@ -92,6 +96,20 @@ test('hasRequiredSessionMetadata rejects missing or incomplete metadata', () => 
   assert.equal(
     hasRequiredSessionMetadata({
       ...validV1SessionMetadata,
+      age_confirmed_18_or_over: false,
+    }),
+    false
+  );
+  assert.equal(
+    hasRequiredSessionMetadata({
+      ...validV1SessionMetadata,
+      consent_accepted_at: '',
+    }),
+    false
+  );
+  assert.equal(
+    hasRequiredSessionMetadata({
+      ...validV1SessionMetadata,
       technical: null,
     }),
     false
@@ -100,6 +118,26 @@ test('hasRequiredSessionMetadata rejects missing or incomplete metadata', () => 
 
 test('hasRequiredSessionMetadata accepts valid v1 metadata shape', () => {
   assert.equal(hasRequiredSessionMetadata(validV1SessionMetadata), true);
+});
+
+test('startSession rejects missing consent metadata before topic allocation', async () => {
+  const provider = new TaskProvider('postgresql://example');
+  let queryCount = 0;
+
+  provider.withClient = async (run) =>
+    run({
+      query: async () => {
+        queryCount += 1;
+        return { rowCount: 0, rows: [] };
+      },
+    });
+  provider.expireStaleSessions = async () => {};
+
+  const result = await provider.startSession(null, {});
+
+  assert.equal(result.success, false);
+  assert.equal(result.code, 'consent_required');
+  assert.equal(queryCount, 0);
 });
 
 test('getUploadTarget rejects sessions without completed v1 metadata before task lookup', async () => {

--- a/docs/aina-data-contract.md
+++ b/docs/aina-data-contract.md
@@ -27,6 +27,10 @@ Required v1 shape:
   "schema_version": "v1",
   "device_id": "anonymous-browser-uuid",
   "consent_response": "yes",
+  "consent_version": "1.0",
+  "privacy_notice_version": "1.0",
+  "consent_accepted_at": "2026-06-03T12:00:00.000Z",
+  "age_confirmed_18_or_over": true,
   "demographics": {
     "age_group": "26-35",
     "gender": "prefer_not_to_say",
@@ -49,6 +53,8 @@ Required v1 shape:
 ```
 
 The volunteer does not type `device_id`, ISO language codes, browser user agent, OS, browser, or device type. `device_id` is an anonymous browser UUID stored in `localStorage` under `aina.speechCollector.deviceId` after consent is accepted; it is not a real hardware ID or serial number. It is used to resume an active session and show which phrases this browser has already recorded.
+
+`consent_response`, `consent_version`, `privacy_notice_version`, `consent_accepted_at`, and `age_confirmed_18_or_over` are required before the backend creates or resumes a volunteer collection session. The current consent and privacy notice versions are both `1.0`. Under-18 participation is blocked in the app by requiring `age_confirmed_18_or_over: true` before session creation.
 
 `native_language_other` is only shown and stored when `native_language` is `other`; otherwise it is `null`. `dialect_region_other` behaves the same way for `dialect_region = "other"`.
 
@@ -245,13 +251,21 @@ Example exported row:
       "storage_type": "local",
       "category": "yes",
       "phrase_id": "yes_kylla",
-      "semantic_label": "yes"
+      "semantic_label": "yes",
+      "consent": {
+        "consent_response": "yes",
+        "consent_version": "1.0",
+        "privacy_notice_version": "1.0",
+        "consent_accepted_at": "2026-06-03T12:00:00.000Z",
+        "age_confirmed_18_or_over": true
+      }
     }
   }
 }
 ```
 
 `label` remains an alias of `normalized_label` for the current audio-classifier loader. `speaker_id` is stable for the same browser `device_id` and is hashed with `DATASET_SPEAKER_HASH_SALT` during export.
+Consent fields are exported under `metadata.collection.consent` as governance metadata. They are not classifier labels and do not change `normalized_label`, `semantic_label`, `phrase_id`, or validation filtering.
 
 ## Databuilder Compatibility Export
 
@@ -324,7 +338,15 @@ Each `<sample_id>.json` sidecar is root-level for fields used by classifier filt
     "channel_count": 1,
     "encoding": "pcm_s16le"
   },
-  "collection": {},
+  "collection": {
+    "consent": {
+      "consent_response": "yes",
+      "consent_version": "1.0",
+      "privacy_notice_version": "1.0",
+      "consent_accepted_at": "2026-06-03T12:00:00.000Z",
+      "age_confirmed_18_or_over": true
+    }
+  },
   "storage": {}
 }
 ```

--- a/docs/database-structure.md
+++ b/docs/database-structure.md
@@ -56,6 +56,8 @@ Status values:
 
 `metadata.ui.category_phrase_v1` stores the shuffled phrase order for the category UI. The order is created once per session and reused on refresh. If newly seeded phrases appear later, missing phrase IDs are appended in stable `task_idx` order.
 
+Consent governance fields are also stored in `metadata`: `consent_response`, `consent_version`, `privacy_notice_version`, `consent_accepted_at`, and `age_confirmed_18_or_over`. These fields are required before a volunteer session is created or updated for recording, but they do not require a database schema migration because `metadata` is JSONB.
+
 ### `recordings`
 
 One saved recording row per upload. Repeat recordings for the same `(session_id, task_id)` are separate valid samples.

--- a/docs/databuilder-export.md
+++ b/docs/databuilder-export.md
@@ -105,7 +105,15 @@ Each `<sample_id>.json` sidecar is root-level:
     "channel_count": 1,
     "encoding": "pcm_s16le"
   },
-  "collection": {},
+  "collection": {
+    "consent": {
+      "consent_response": "yes",
+      "consent_version": "1.0",
+      "privacy_notice_version": "1.0",
+      "consent_accepted_at": "2026-06-03T12:00:00.000Z",
+      "age_confirmed_18_or_over": true
+    }
+  },
   "storage": {}
 }
 ```
@@ -116,7 +124,7 @@ It is flat because audio-classifier filters use dotted paths like `demographics.
 
 Older recordings collected before the processed-audio fix may not contain `processed_audio`; those sidecars keep the root-level key with `null`. Legacy recordings without `phrase_id` or `semantic_label` keep those keys as `null`; missing semantic metadata does not make an otherwise classifier-ready recording invalid.
 
-The same `phrase_id` and `semantic_label` values are also included under `collection.phrase_id` and `collection.semantic_label`. `normalized_label` remains the phrase-level classifier target.
+The same `phrase_id` and `semantic_label` values are also included under `collection.phrase_id` and `collection.semantic_label`. `collection.consent` carries consent governance metadata only. `normalized_label` remains the phrase-level classifier target.
 
 ## Manifest
 

--- a/docs/privacy-consent-flow.md
+++ b/docs/privacy-consent-flow.md
@@ -1,0 +1,132 @@
+# Privacy Consent Flow
+
+Date: 03.06.2026
+
+## Goal
+
+The volunteer-facing Speech Collector app shows a simple, friendly welcome and consent screen before any collection session is created unless the same browser already has valid stored consent for the current policy versions. The main screen explains the project, what the volunteer will do, a short privacy/consent summary, and one small read-more link to the full details page at `/#/privacy`.
+
+## Source Content
+
+Source document: `Linnea_tietosuoja_ja_suostumus (1).docx`.
+
+The full `/#/privacy` page consolidates the document sections:
+
+- `Tietosuojaseloste`
+- `Tietoon perustuva suostumus`
+- `Ikärajahuomio - alle 18-vuotiaat`
+- `Tutkimustiedote`
+
+The Finnish text is the official volunteer-facing content. English text in the app is helper translation for review and non-Finnish team members.
+
+## Filled Values
+
+- Company: Linnea Technologies Oy
+- Y-tunnus: 3571288-4
+- Address: Kulmalantie 11 as. 2, 28130 Pori, Finland
+- Contact: Ollipekka Kivin
+- Contact email: ollipekka@hellolinnea.com
+- Policy date: 03.06.2026
+- Consent version: 1.0
+- Privacy notice version: 1.0
+- Minimum age: 18+
+- English purpose wording: AI-based phone service
+- Finnish purpose wording: tekoälypohjainen puhelinpalvelu
+
+The contact title and phone placeholders from the source document are not published in the UI.
+
+## Volunteer Flow
+
+1. Main route opens at `/#/`.
+2. If valid same-browser consent is stored and the consent/privacy versions match, the app skips the welcome and consent screen.
+3. If no valid stored consent exists, the simple welcome and consent screen appears first.
+4. The main screen shows the welcome title, short project purpose, what-volunteers-will-do steps, and a short privacy/consent summary.
+5. One small read-more link points to `/#/privacy`: `Lue tietosuoja- ja suostumustiedot kokonaan / Read full privacy and consent details`.
+6. Continue stays disabled until both required checkboxes are checked.
+7. Decline shows the bilingual blocked message, clears any stored accepted consent, and does not start a backend session.
+8. Accepted consent is stored in browser localStorage and proceeds to Turnstile if configured.
+9. `/api/start-session` receives consent metadata, including reused stored consent when available, and creates or resumes the session.
+10. Metadata form appears without exposing the internal participant/device code.
+11. Category phrase recording starts only after metadata is complete.
+
+The normal volunteer flow does not show participant code, deletion-request instructions, technical identifier explanation, persistent footer policy links, or multiple legal-looking cards.
+
+## Routes
+
+- `/#/privacy`: full privacy, consent, age restriction, and study information page.
+- `/#/participant-info`: compatibility route that renders the same full details page as `/#/privacy`.
+- `/#/admin`: unchanged internal admin validation route.
+
+The normal UI links only to `/#/privacy` through the single small read-more link on the main consent screen. `/#/participant-info` is kept for compatibility but is not shown as a normal volunteer-flow link.
+
+## Session Metadata
+
+The consent gate sends these fields when a session is created. Returning same-browser volunteers reuse the original `consent_accepted_at` timestamp from browser storage when the stored versions still match.
+
+```json
+{
+  "consent_response": "yes",
+  "consent_version": "1.0",
+  "privacy_notice_version": "1.0",
+  "consent_accepted_at": "ISO timestamp",
+  "age_confirmed_18_or_over": true
+}
+```
+
+The same metadata also includes `schema_version`, browser technical metadata, and the anonymous internal `device_id`. The metadata form preserves these consent fields when it saves demographics and recording-environment metadata, but the normal volunteer flow does not display the identifier.
+
+## Browser Consent Storage
+
+Accepted consent is stored locally in `localStorage` under `speechCollectorConsent`:
+
+```json
+{
+  "consent_response": "yes",
+  "consent_version": "1.0",
+  "privacy_notice_version": "1.0",
+  "consent_accepted_at": "ISO timestamp",
+  "age_confirmed_18_or_over": true
+}
+```
+
+Stored consent is valid only when:
+
+- `consent_response` is `yes`
+- `age_confirmed_18_or_over` is `true`
+- `consent_version` matches `CONSENT_VERSION`
+- `privacy_notice_version` matches `PRIVACY_NOTICE_VERSION`
+- `consent_accepted_at` is a valid timestamp
+
+If `CONSENT_VERSION` or `PRIVACY_NOTICE_VERSION` changes in code, the stored consent no longer matches and the volunteer is asked to consent again. Malformed or stale stored consent is removed locally and the welcome/consent screen is shown again.
+
+Only the consent decision is stored in this key. When starting a backend session, the frontend rebuilds the full session metadata with the stored consent timestamp, the current anonymous browser `device_id`, and current browser technical metadata.
+
+## Backend Enforcement
+
+`POST /api/start-session` rejects missing or invalid consent metadata with `consent_required` before calling the provider. `TaskProvider.startSession()` also validates consent before allocating a topic copy or inserting `participant_sessions`.
+
+`TaskProvider.updateSessionMetadata()` rejects updates that would remove or invalidate required consent fields. Upload and category-state guards still require complete v1 session metadata before recording.
+
+Backend consent enforcement remains active even when consent is reused from browser storage. If the backend rejects reused consent, the frontend clears the stored browser consent and shows the consent screen again.
+
+## Export Compatibility
+
+Normal export and databuilder export include consent only as governance metadata under `collection.consent`.
+
+Consent metadata does not change:
+
+- `normalized_label`
+- `semantic_label`
+- `phrase_id`
+- `category`
+- admin validation status
+- validation filtering
+- classifier label behavior
+
+The audio-classifier package is not changed.
+
+## Remaining TODOs
+
+- Manual browser smoke test should be run before push or PR.
+- Confirm final legal wording with Linnea before production deployment.
+- No production deployment has been performed for this implementation.

--- a/docs/session-logs/2026-06-03-privacy-consent-flow.md
+++ b/docs/session-logs/2026-06-03-privacy-consent-flow.md
@@ -1,0 +1,86 @@
+# 2026-06-03 Privacy Consent Flow
+
+## Goal
+
+Implement the volunteer-facing privacy, participant information, and consent flow for the Speech Collector app without production deployment, commit, push, or audio-classifier changes.
+
+## Source Document
+
+Used `d:\downloads from chrome\Linnea_tietosuoja_ja_suostumus (1).docx` as the policy source. It contains the privacy notice, informed consent, age restriction notice, and research information.
+
+## Filled Placeholder Values
+
+- Company: Linnea Technologies Oy
+- Y-tunnus: 3571288-4
+- Corrected address: Kulmalantie 11 as. 2, 28130 Pori, Finland
+- Contact person: Ollipekka Kivin
+- Contact email: ollipekka@hellolinnea.com
+- Policy date: 03.06.2026
+- Consent version: 1.0
+- Privacy notice version: 1.0
+- Purpose wording: AI-based phone service / tekoälypohjainen puhelinpalvelu
+- Minimum age: 18+
+
+The contact title and phone placeholders were removed from published UI/content.
+
+## Audit Findings
+
+- Frontend routing is lightweight hash routing in `frontend/src/App.tsx`; `/#/admin` already routes to `AdminValidationApp`.
+- The volunteer flow previously bootstrapped `/api/start-session` immediately, then showed intro, metadata, and category recording.
+- The metadata form previously included an older consent yes/no field from `infoFormConfig.json`.
+- Session metadata is built in `frontend/utils/sessionMetadata.ts` and persisted in `participant_sessions.metadata`.
+- Device ID already exists in `frontend/utils/deviceId.ts` as a localStorage UUID.
+- Backend upload/category guards already required v1 metadata before recording, but session creation did not require the new consent fields.
+- Normal export and databuilder export already preserve session metadata-derived governance-like data without changing classifier label fields.
+- Admin validation displays session metadata but does not depend on consent fields.
+
+## Implementation Notes
+
+- Added a main-route consent gate before Turnstile, metadata, or recording.
+- Polished the gate into a friendly welcome and consent screen with a short purpose summary, what-to-expect steps, and a short privacy/consent summary.
+- Removed the large privacy, participant information, and age detail cards from the main volunteer screen.
+- Added one small read-more link from the main consent screen to `/#/privacy`.
+- Consolidated the full privacy notice, informed consent, age restriction, and study information under `/#/privacy`.
+- Kept `/#/participant-info` as a compatibility route that renders the same full details page as `/#/privacy`, but removed it from the normal volunteer UI.
+- Kept `/#/admin` behavior unchanged and outside the volunteer flow.
+- Removed the old metadata-form consent field and the under-18 age option.
+- Removed the participant code display from the normal metadata step after manual review; the internal `device_id` remains in session metadata.
+- Removed persistent volunteer footer policy links after manual review.
+- Added version-aware local consent persistence under browser localStorage key `speechCollectorConsent`.
+- Returning same-browser volunteers with valid stored consent now skip the welcome/consent screen and continue to the metadata or recording flow.
+- Reused stored consent is still sent to `/api/start-session`; backend consent enforcement remains active.
+- Malformed, stale, declined, or backend-rejected stored consent is cleared so the volunteer must consent again.
+- Added consent metadata fields to session creation.
+- Backend rejects direct session starts without valid consent and 18+ confirmation.
+- Backend rejects metadata updates that would invalidate consent.
+- Normal export and databuilder export include consent under `collection.consent` only.
+
+## Compatibility Notes
+
+- Turnstile remains after consent and before backend session creation when configured.
+- Metadata form still stores demographics, environment, and browser technical metadata.
+- Metadata form no longer displays the internal participant/device code.
+- The current consent and privacy versions remain `1.0`; changing either frontend constant forces returning users to consent again.
+- Accepted consent stores only the consent decision and original `consent_accepted_at`; full session metadata is rebuilt with the anonymous `device_id` and current technical metadata when a session starts.
+- Normal volunteer screens do not show the internal participant code, save-code instructions, deletion-request instructions, technical identifier explanation, persistent policy footer links, separate privacy/participant route buttons, or multiple legal-looking cards.
+- Category phrase UI, phrase IDs, semantic labels, normalized labels, and validation filtering were not changed.
+- Admin validation route and behavior were not intentionally changed.
+- No database migration was required because consent fields are stored in JSONB metadata.
+- Databuilder export does not require consent fields for classifier loading.
+- Audio-classifier was not touched.
+
+## Safety
+
+- No production server changes.
+- No production deployment.
+- No commit.
+- No push.
+- No generated exports, audio, temp files, screenshots, traces, or browser artifacts intentionally committed.
+- `.env` was not modified by this implementation.
+
+## Remaining TODOs
+
+- Run the full command checklist.
+- Run browser smoke if browser automation is available; otherwise provide manual steps.
+- Avishek manual review before commit/push.
+- Legal/content review before production deployment.

--- a/frontend/components/ConsentGate.tsx
+++ b/frontend/components/ConsentGate.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import { WelcomeInformationSummary } from "./ConsentInformation";
+
+interface ConsentGateProps {
+  message?: string;
+  onAccepted: () => Promise<void> | void;
+  onDeclined: () => void;
+}
+
+const ConsentGate = ({ message, onAccepted, onDeclined }: ConsentGateProps) => {
+  const [ageConfirmed, setAgeConfirmed] = useState(false);
+  const [consentConfirmed, setConsentConfirmed] = useState(false);
+  const canContinue = ageConfirmed && consentConfirmed;
+
+  return (
+    <section className="app-panel app-panel--narrow consent-panel">
+      <span className="app-eyebrow">Linnea Technologies Oy</span>
+      <h1 className="app-title">
+        Tervetuloa osallistumaan suomenkieliseen puheaineiston keruuseen
+      </h1>
+      <p className="consent-title-translation">Welcome to the Finnish speech collection</p>
+
+      <WelcomeInformationSummary />
+
+      {message && <p className="app-inline-message app-inline-message--error">{message}</p>}
+
+      <div className="consent-checks">
+        <label className="consent-check">
+          <input
+            type="checkbox"
+            checked={ageConfirmed}
+            onChange={(event) => setAgeConfirmed(event.target.checked)}
+          />
+          <span>
+            <strong>Vahvistan, että olen täysi-ikäinen (18 vuotta tai vanhempi).</strong>
+            <span>I confirm that I am 18 years or older.</span>
+          </span>
+        </label>
+
+        <label className="consent-check">
+          <input
+            type="checkbox"
+            checked={consentConfirmed}
+            onChange={(event) => setConsentConfirmed(event.target.checked)}
+          />
+          <span>
+            <strong>
+              Olen lukenut osallistumista ja tietosuojaa koskevat tiedot, ja annan
+              suostumukseni osallistua.
+            </strong>
+            <span>
+              I have read the participation and privacy information, and I consent to
+              participate.
+            </span>
+          </span>
+        </label>
+      </div>
+
+      <div className="consent-actions">
+        <button
+          type="button"
+          className="app-primary-button"
+          disabled={!canContinue}
+          onClick={() => void onAccepted()}
+        >
+          Jatka / Continue
+        </button>
+        <button type="button" className="app-secondary-button" onClick={onDeclined}>
+          En osallistu / Decline
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default ConsentGate;

--- a/frontend/components/ConsentInformation.tsx
+++ b/frontend/components/ConsentInformation.tsx
@@ -1,0 +1,58 @@
+export function WelcomeInformationSummary() {
+  return (
+    <>
+      <div className="consent-purpose">
+        <p>
+          Keräämme lyhyitä suomenkielisiä ääninäytteitä kehittääksemme lyhytvastausten
+          puheentunnistusta Linnean tekoälypohjaista puhelinpalvelua varten.
+        </p>
+        <p>
+          We collect short Finnish voice samples to improve short-response speech
+          recognition for Linnea's AI-based phone service.
+        </p>
+      </div>
+
+      <section className="consent-steps" aria-labelledby="consent-steps-title-fi">
+        <div>
+          <h2 id="consent-steps-title-fi">Mitä osallistuminen tarkoittaa?</h2>
+          <ol>
+            <li>Vastaat muutamaan lyhyeen taustakysymykseen tallennusolosuhteista.</li>
+            <li>Nauhoitat lyhyitä suomenkielisiä sanoja tai vastauksia.</li>
+            <li>
+              Osallistuminen vie yleensä vain muutaman minuutin, ja voit lopettaa
+              milloin tahansa.
+            </li>
+          </ol>
+        </div>
+
+        <div>
+          <h2>What will you do?</h2>
+          <ol>
+            <li>Answer a few short background questions about the recording conditions.</li>
+            <li>Record short Finnish words or responses.</li>
+            <li>Participation usually takes only a few minutes, and you can stop at any time.</li>
+          </ol>
+        </div>
+      </section>
+
+      <section className="consent-summary-note" aria-labelledby="consent-summary-title">
+        <h2 id="consent-summary-title">Tietosuoja ja suostumus / Privacy and consent</h2>
+        <p>
+          Osallistuminen on vapaaehtoista. Emme pyydä nimeäsi, sähköpostiosoitettasi
+          tai puhelinnumeroasi osallistumisen aikana. Jatkamalla vahvistat, että olet
+          vähintään 18-vuotias ja annat suostumuksesi ääninäytteiden käyttämiseen yllä
+          kuvattuun tarkoitukseen.
+        </p>
+        <p>
+          Participation is voluntary. We do not ask for your name, email address, or
+          phone number during participation. By continuing, you confirm that you are at
+          least 18 years old and consent to the use of your voice samples for the
+          purpose described above.
+        </p>
+        <a className="consent-read-more-link" href="/#/privacy">
+          Lue tietosuoja- ja suostumustiedot kokonaan / Read full privacy and consent details
+        </a>
+      </section>
+    </>
+  );
+}

--- a/frontend/components/InfoForm.tsx
+++ b/frontend/components/InfoForm.tsx
@@ -137,7 +137,7 @@ const InfoForm = ({ message, canCancel = false, onCancel, onSaved }: InfoFormPro
 
     try {
       setFormMessage("");
-      const metadata = buildV1SessionMetadata(data);
+      const metadata = buildV1SessionMetadata(data, participantMetadata);
       const response = await fetch(`${apiUrl}/api/update-session-metadata`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/frontend/components/PolicyPages.tsx
+++ b/frontend/components/PolicyPages.tsx
@@ -1,0 +1,374 @@
+const CONTACT_EMAIL = "ollipekka@hellolinnea.com";
+
+function PolicyHeader({ compatibilityNote }: { compatibilityNote?: string }) {
+  return (
+    <header className="policy-header">
+      <span className="app-eyebrow">Linnea Technologies Oy</span>
+      <h1 className="app-title">Tietosuoja- ja suostumustiedot</h1>
+      <p className="consent-title-translation">Privacy and consent details</p>
+      <p className="app-copy">
+        Päivitetty 03.06.2026. Suomenkielinen teksti on virallinen osallistujille
+        näytettävä sisältö; englanninkielinen teksti on apukäännös.
+      </p>
+      {compatibilityNote && <p className="policy-route-note">{compatibilityNote}</p>}
+      <a className="policy-back-link" href="#/">
+        Back to participation
+      </a>
+    </header>
+  );
+}
+
+function FullPrivacyDetailsPage({ compatibilityNote }: { compatibilityNote?: string }) {
+  return (
+    <section className="app-panel app-panel--wide policy-page">
+      <PolicyHeader compatibilityNote={compatibilityNote} />
+
+      <div className="policy-language-block">
+        <h2>Suomi</h2>
+
+        <section>
+          <h3>Tietosuojaseloste</h3>
+          <p>Linnea Technologies Oy - Puheentunnistuksen kehittämistutkimus</p>
+          <p>Päivitetty: 03.06.2026</p>
+        </section>
+
+        <section>
+          <h3>1. Rekisterinpitäjä</h3>
+          <p>
+            Linnea Technologies Oy
+            <br />
+            Y-tunnus: 3571288-4
+            <br />
+            Kulmalantie 11 as. 2
+            <br />
+            28130 Pori
+            <br />
+            Finland
+            <br />
+            Sähköposti: <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+          </p>
+        </section>
+
+        <section>
+          <h3>2. Yhteyshenkilö rekisteriasioissa</h3>
+          <p>
+            Ollipekka Kivin
+            <br />
+            Sähköposti: <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+          </p>
+        </section>
+
+        <section>
+          <h3>3. Rekisterin nimi</h3>
+          <p>Puheentunnistuksen kehittämistutkimuksen ääniaineisto.</p>
+        </section>
+
+        <section>
+          <h3>4. Henkilötietojen käsittelyn tarkoitus ja oikeusperuste</h3>
+          <p>
+            Keräämme ääninäytteitä suomenkielisten lyhytvastauksien puheentunnistuksen
+            kehittämistä varten. Aineistoa käytetään Linnea Technologies Oy:n
+            kehittämän tekoälypohjaisen puhelinpalvelun kehittämiseen.
+          </p>
+          <p>
+            GDPR:n mukainen käsittelyperuste on rekisteröidyn antama suostumus (GDPR
+            6 artikla 1 kohta a).
+          </p>
+        </section>
+
+        <section>
+          <h3>5. Kerättävät tiedot</h3>
+          <p>Kerätään seuraavat tiedot:</p>
+          <ul>
+            <li>Ääninäytteet, kuten lyhyet sanavastauksien toistot.</li>
+            <li>
+              Tekninen tunnistekoodi, joka yhdistää saman käyttäjän eri nauhoitukset
+              toisiinsa pseudonyymisti.
+            </li>
+            <li>Vapaaehtoisesti annetut taustatiedot ja tallennusolosuhteiden tiedot.</li>
+            <li>
+              Perustason selain-, laite- ja mikrofonitiedot tallennuksen laadun
+              arvioimiseksi.
+            </li>
+          </ul>
+          <p>
+            Ääninäytteisiin ei yhdistetä nimeä, sähköpostiosoitetta tai muita suoria
+            tunnistetietoja. Tekninen tunnistekoodi ei itsessään paljasta
+            henkilöllisyyttä.
+          </p>
+        </section>
+
+        <section>
+          <h3>6. Tietojen säilytysaika</h3>
+          <p>
+            Ääninäytteitä ja niihin liittyviä tietoja säilytetään toistaiseksi
+            tutkimus- ja kehityskäyttöä varten. Aineisto poistetaan, jos organisaatio
+            lakkaa toimintansa tai rekisteröity peruuttaa suostumuksensa.
+          </p>
+          <p>
+            Pseudonyymiä tunnistekoodia käyttäen rekisteröity voi pyytää omien
+            tietojensa poistamista.
+          </p>
+        </section>
+
+        <section>
+          <h3>7. Tietojen vastaanottajat ja siirrot</h3>
+          <p>
+            Tietoja ei luovuteta kolmansille osapuolille kaupallisiin tarkoituksiin.
+            Aineistoa saatetaan käsitellä alihankkijana toimivien teknisten
+            palveluntarjoajien järjestelmissä, kuten pilvipalvelussa,
+            tietosuojasopimuksen nojalla.
+          </p>
+          <p>
+            Tietoja käsitellään ainoastaan EU- tai ETA-alueella. Tietoja ei siirretä
+            EU:n tai ETA:n ulkopuolelle.
+          </p>
+        </section>
+
+        <section>
+          <h3>8. Tekniset ja organisatoriset suojatoimet</h3>
+          <ul>
+            <li>Tiedot siirretään ja tallennetaan salattuna HTTPS/TLS-yhteydellä.</li>
+            <li>Pääsy aineistoon on rajattu Linnea Technologies Oy:n kehitystiimille.</li>
+            <li>
+              Teknistä tunnistekoodia ja mahdollisia taustatietoja käsitellään
+              pseudonyymisti.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h3>9. Rekisteröidyn oikeudet</h3>
+          <p>Rekisteröidyllä on GDPR:n nojalla seuraavat oikeudet:</p>
+          <ul>
+            <li>Oikeus saada vahvistus siitä, käsitelläänkö häntä koskevia tietoja.</li>
+            <li>Oikeus saada pääsy omiin tietoihinsa.</li>
+            <li>Oikeus pyytää tietojen oikaisemista tai poistamista.</li>
+            <li>
+              Oikeus peruuttaa suostumus milloin tahansa. Tämä ei vaikuta ennen
+              peruuttamista suoritetun käsittelyn lainmukaisuuteen.
+            </li>
+            <li>Oikeus tehdä valitus valvontaviranomaiselle.</li>
+          </ul>
+          <p>
+            Koska tietoja käsitellään pseudonyymisti teknisen tunnistekoodin avulla,
+            rekisteröidyltä voidaan pyytää riittävät tiedot oman aineistonsa
+            löytämiseksi. Oikeuksien käyttämistä koskevat pyynnöt lähetetään
+            osoitteeseen <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+          </p>
+        </section>
+
+        <section>
+          <h3>10. Valvontaviranomainen</h3>
+          <p>
+            Rekisteröidyllä on oikeus tehdä valitus tietosuojavaltuutetulle, jos hän
+            katsoo, että häntä koskevien henkilötietojen käsittelyssä on rikottu
+            tietosuoja-asetusta.
+          </p>
+          <p>
+            Tietosuojavaltuutetun toimisto
+            <br />
+            PL 800, 00521 Helsinki
+            <br />
+            tietosuoja@om.fi
+            <br />
+            <a href="https://tietosuoja.fi">https://tietosuoja.fi</a>
+          </p>
+        </section>
+
+        <section>
+          <h3>Tietoon perustuva suostumus</h3>
+          <p>
+            Osallistut tutkimukseen, jossa kerätään ääninäytteitä suomenkielisten
+            lyhytvastausten tunnistamisen kehittämistä varten. Nauhoituksia käytetään
+            Linnea Technologies Oy:n tekoälypohjaisen puhelinpalvelun kehittämiseen.
+          </p>
+        </section>
+
+        <section>
+          <h3>Mitä osallistuminen tarkoittaa?</h3>
+          <p>
+            Sinulle näytetään näytöllä lyhyitä sanoja, kuten "joo", "ei" tai
+            "kyllä". Sinua pyydetään toistamaan ja nauhoittamaan nämä sanat
+            mikrofonin kautta. Nauhoittaminen vie yleensä vain muutaman minuutin.
+          </p>
+        </section>
+
+        <section>
+          <h3>Mitä tietoja kerätään?</h3>
+          <ul>
+            <li>Ääninäytteet.</li>
+            <li>Tekninen tunnistekoodi, joka käsitellään pseudonyymisti.</li>
+            <li>Vapaaehtoisesti annetut taustatiedot ja tallennusolosuhteiden tiedot.</li>
+          </ul>
+          <p>
+            Nauhoituksia ei yhdistetä nimeesi tai sähköpostiisi. Tietoja käsitellään
+            EU/ETA-alueella.
+          </p>
+        </section>
+
+        <section>
+          <h3>Osallistuminen on vapaaehtoista</h3>
+          <p>
+            Voit keskeyttää osallistumisen milloin tahansa sulkemalla selaimen. Voit
+            myös myöhemmin pyytää tietojesi poistamista tai peruuttaa suostumuksesi
+            ottamalla yhteyttä osoitteeseen{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+          </p>
+        </section>
+
+        <section>
+          <h3>Vahvistus</h3>
+          <p>Jatkamalla osallistumista vahvistat, että:</p>
+          <ul>
+            <li>Olet lukenut kuvauksen tutkimuksesta.</li>
+            <li>Ymmärrät, mitä tietoja kerätään ja mihin niitä käytetään.</li>
+            <li>Osallistut vapaaehtoisesti.</li>
+            <li>Olet täysi-ikäinen eli 18 vuotta tai vanhempi.</li>
+            <li>Olet lukenut tietosuojaselosteen ja hyväksyt tietojen keräämisen kuvatulla tavalla.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h3>Ikärajahuomio - alle 18-vuotiaat</h3>
+          <p>
+            Tämä tutkimus on tarkoitettu vain täysi-ikäisille eli 18 vuotta
+            täyttäneille. Jos et ole vielä 18-vuotias, et voi osallistua tutkimukseen.
+          </p>
+          <p>
+            Tämä ikärajaehto on pakollinen, koska emme kerää alaikäisten ääninäytteitä
+            ilman vanhemman tai huoltajan nimenomaista kirjallista suostumusta.
+          </p>
+        </section>
+
+        <section>
+          <h3>Tutkimustiedote</h3>
+          <p>
+            Linnea Technologies Oy kehittää tekoälypohjaista puhelinpalvelua, joka
+            auttaa organisaatioita vastaamaan asiakaspuheluihin. Järjestelmä tunnistaa
+            asiakkaan vastauksia, kuten "kyllä" tai "ei", ja tarvitsee harjoitusdataa
+            toimiakseen luotettavasti.
+          </p>
+          <p>
+            Tutkimuksen tavoitteena on kerätä laaja ja monimuotoinen kokoelma
+            suomenkielisiä lyhyitä äänivastauksia, joita käytetään puheentunnistuksen
+            kehittämiseen.
+          </p>
+        </section>
+
+        <section>
+          <h3>Kuka voi osallistua?</h3>
+          <ul>
+            <li>Täysi-ikäiset henkilöt eli 18-vuotiaat tai vanhemmat.</li>
+            <li>Suomen kielen puhujat.</li>
+            <li>Henkilöt, joilla on pääsy mikrofonilla varustettuun laitteeseen.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h3>Miten osallistuminen tapahtuu?</h3>
+          <p>
+            Osallistuminen tapahtuu selaimen kautta tutkimussivustolla. Sinulle
+            näytetään lyhyitä suomenkielisiä sanoja, jotka toistat ääneen.
+            Nauhoittaminen vie yleensä vain muutaman minuutin.
+          </p>
+        </section>
+
+        <section>
+          <h3>Onko osallistuminen anonyymia?</h3>
+          <p>
+            Osallistuminen on pseudonyymistä. Sisäinen tekninen tunniste yhdistää omat
+            nauhoituksesi toisiinsa, mutta ei paljasta henkilöllisyyttäsi meille. Emme
+            kerää nimeäsi tai sähköpostiosoitettasi. Voit antaa vapaaehtoisesti
+            taustatietoja tutkimusdatan laadun parantamiseksi.
+          </p>
+        </section>
+
+        <section>
+          <h3>Yhteystiedot</h3>
+          <p>
+            Lisätietoja tutkimuksesta antaa Ollipekka Kivin, Linnea Technologies Oy,{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>. Tietosuojaseloste
+            on saatavilla tutkimussivustolla.
+          </p>
+        </section>
+      </div>
+
+      <div className="policy-language-block policy-language-block--helper">
+        <h2>English Helper Translation</h2>
+
+        <section>
+          <h3>Privacy Notice</h3>
+          <p>
+            Linnea Technologies Oy is the data controller for the speech-recognition
+            development study. The company collects short Finnish voice samples to
+            improve short-response speech recognition for Linnea's AI-based phone
+            service.
+          </p>
+          <p>
+            The legal basis is consent under GDPR Article 6(1)(a). The collection does
+            not ask for a participant's name, email address, or phone number during the
+            volunteer flow.
+          </p>
+        </section>
+
+        <section>
+          <h3>Controller And Contact</h3>
+          <p>
+            Linnea Technologies Oy, business ID 3571288-4, Kulmalantie 11 as. 2, 28130
+            Pori, Finland. Contact person: Ollipekka Kivin,{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+          </p>
+        </section>
+
+        <section>
+          <h3>Data Collected</h3>
+          <ul>
+            <li>Short voice samples.</li>
+            <li>A pseudonymous technical identifier for grouping recordings.</li>
+            <li>Voluntary background and recording-environment information.</li>
+            <li>Basic browser, device, and microphone information for quality review.</li>
+          </ul>
+          <p>
+            Recordings are not connected to a name or email address. Data is processed
+            in the EU/EEA and is not disclosed to third parties for commercial purposes.
+          </p>
+        </section>
+
+        <section>
+          <h3>Participation And Consent</h3>
+          <p>
+            Participation is voluntary. Participants record short Finnish words or
+            responses in the browser and may stop at any time. Only people who are 18
+            years or older may participate in this app version.
+          </p>
+          <p>
+            Participants may request access, correction, deletion, or withdrawal of
+            consent by contacting{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>. Withdrawal does not
+            affect processing that happened lawfully before withdrawal.
+          </p>
+        </section>
+
+        <section>
+          <h3>Research Information</h3>
+          <p>
+            Linnea Technologies Oy develops an AI-based phone service that helps
+            organizations handle customer calls. The study collects a broad and varied
+            set of short Finnish spoken responses to improve speech recognition.
+          </p>
+        </section>
+      </div>
+    </section>
+  );
+}
+
+export function PrivacyPolicyPage() {
+  return <FullPrivacyDetailsPage />;
+}
+
+export function ParticipantInfoPage() {
+  return (
+    <FullPrivacyDetailsPage compatibilityNote="This compatibility route shows the same full privacy and consent details as /#/privacy." />
+  );
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -173,6 +173,212 @@
   margin-top: 20px;
 }
 
+.policy-back-link,
+.policy-page a {
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.policy-back-link:hover,
+.policy-page a:hover {
+  text-decoration: underline;
+}
+
+.consent-panel {
+  display: grid;
+  gap: 18px;
+}
+
+.consent-title-translation {
+  margin: -4px 0 0;
+  color: #4d677a;
+  font-size: 18px;
+  line-height: 1.35;
+}
+
+.consent-purpose {
+  display: grid;
+  gap: 10px;
+  color: #36556f;
+  line-height: 1.55;
+}
+
+.consent-purpose p {
+  margin: 0;
+}
+
+.consent-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.consent-actions > button {
+  flex: 1 1 220px;
+}
+
+.consent-steps {
+  display: grid;
+  gap: 16px;
+  border-top: 1px solid #d7e2ea;
+  border-bottom: 1px solid #d7e2ea;
+  padding: 16px 0;
+  min-width: 0;
+}
+
+.consent-steps h2 {
+  margin: 0 0 8px;
+  color: #12324a;
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.consent-steps ol {
+  margin: 0;
+  padding-left: 20px;
+  color: #36556f;
+  line-height: 1.5;
+}
+
+.consent-steps li + li {
+  margin-top: 6px;
+}
+
+.consent-summary-note {
+  display: grid;
+  gap: 10px;
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  padding: 14px;
+  background: #f7fafc;
+  color: #36556f;
+  line-height: 1.55;
+  min-width: 0;
+}
+
+.consent-summary-note h2 {
+  margin: 0;
+  color: #12324a;
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.consent-summary-note p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.consent-read-more-link {
+  justify-self: start;
+  max-width: 100%;
+  color: #0f766e;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  text-decoration: none;
+}
+
+.consent-read-more-link:hover {
+  text-decoration: underline;
+}
+
+.consent-checks {
+  display: grid;
+  gap: 12px;
+}
+
+.consent-check {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  border: 1px solid #c6d4de;
+  border-radius: 8px;
+  padding: 12px;
+  color: #12324a;
+  background: #f7fafc;
+  cursor: pointer;
+}
+
+.consent-check input {
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  accent-color: #0f766e;
+}
+
+.consent-check span {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.policy-page {
+  display: grid;
+  gap: 24px;
+}
+
+.policy-header {
+  display: grid;
+  gap: 8px;
+}
+
+.policy-back-link {
+  justify-self: start;
+}
+
+.policy-route-note {
+  margin: 0;
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #f7fafc;
+  color: #36556f;
+}
+
+.policy-language-block {
+  display: grid;
+  gap: 18px;
+  color: #36556f;
+  line-height: 1.58;
+}
+
+.policy-language-block--helper {
+  border-top: 1px solid #d7e2ea;
+  padding-top: 20px;
+}
+
+.policy-language-block h2,
+.policy-language-block h3 {
+  margin: 0;
+  color: #12324a;
+}
+
+.policy-language-block h2 {
+  font-size: 22px;
+}
+
+.policy-language-block h3 {
+  font-size: 17px;
+}
+
+.policy-language-block section {
+  display: grid;
+  gap: 8px;
+}
+
+.policy-language-block p,
+.policy-language-block ul {
+  margin: 0;
+}
+
+.policy-language-block ul {
+  padding-left: 20px;
+}
+
 .category-intro-copy {
   display: grid;
   gap: 12px;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,23 @@
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 
 import SessionContext from "../contexts/SessionProvider";
+import ConsentGate from "../components/ConsentGate";
 import InfoForm from "../components/InfoForm";
+import { ParticipantInfoPage, PrivacyPolicyPage } from "../components/PolicyPages";
 import SessionIntro from "../components/SessionIntro";
 import SessionEndScreen from "../components/SessionEndScreen";
 import SoundRecorder from "../components/SoundRecorder";
 import TurnstileGate from "../components/TurnstileGate";
 import AdminValidationApp from "../components/AdminValidation";
 import {
+  buildConsentSessionMetadata,
+  clearStoredConsentSessionMetadata,
   getConsentDeclineMessage,
+  getStoredConsentSessionMetadata,
   hasDeclinedConsent,
   isMetadataComplete,
+  storeConsentSessionMetadata,
 } from "../utils/sessionMetadata";
 import type {
   CategoryPhraseState,
@@ -23,6 +30,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "./App.css";
 
 type Phase =
+  | "consent"
   | "bootstrapping"
   | "verification"
   | "intro"
@@ -49,6 +57,10 @@ const CATEGORY_HELPER_TEXT: Record<string, string> = {
   correct: "Record short confirmation phrases.",
   number: "Record number words in a clear, natural voice.",
 };
+
+function VolunteerShell({ children }: { children: ReactNode }) {
+  return <main className="app-shell">{children}</main>;
+}
 
 function getVolunteerAppTitle(value: unknown) {
   const title = typeof value === "string" ? value.replace(/\bAINA\s*/gi, "").trim() : "";
@@ -201,7 +213,7 @@ function App() {
     setProgress,
   } = useContext(SessionContext);
 
-  const [phase, setPhase] = useState<Phase>("bootstrapping");
+  const [phase, setPhase] = useState<Phase>("consent");
   const [metadataMode, setMetadataMode] = useState<MetadataMode>("required");
   const [message, setMessage] = useState<string>("");
   const [categoryState, setCategoryState] = useState<CategoryStateResponse | null>(null);
@@ -209,7 +221,9 @@ function App() {
   const [selectedPhraseId, setSelectedPhraseId] = useState<string | null>(null);
   const [categoryLoading, setCategoryLoading] = useState<boolean>(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
-  const hasBootstrapped = useRef(false);
+  const [pendingConsentMetadata, setPendingConsentMetadata] = useState<Record<string, unknown> | null>(
+    null
+  );
 
   const apiUrl = import.meta.env.VITE_API_URL;
   const appName = getVolunteerAppTitle(import.meta.env.VITE_APP_TITLE);
@@ -401,7 +415,11 @@ function App() {
   );
 
   const startOrResumeSession = useCallback(
-    async (tokenOverride?: string | null, turnstileTokenOverride?: string | null) => {
+    async (
+      tokenOverride?: string | null,
+      turnstileTokenOverride?: string | null,
+      consentMetadataOverride?: Record<string, unknown> | null
+    ) => {
       setPhase("bootstrapping");
       setMessage("");
       setCurrentTask(null);
@@ -411,6 +429,7 @@ function App() {
 
       try {
         const activeTurnstileToken = turnstileTokenOverride ?? turnstileToken;
+        const activeConsentMetadata = consentMetadataOverride ?? pendingConsentMetadata;
         const response = await fetch(`${apiUrl}/api/start-session`, {
           method: "POST",
           headers: {
@@ -419,6 +438,7 @@ function App() {
           body: JSON.stringify({
             sessionToken: tokenOverride === undefined ? sessionToken : tokenOverride,
             turnstileToken: activeTurnstileToken || undefined,
+            metadata: activeConsentMetadata || undefined,
           }),
         });
 
@@ -433,6 +453,14 @@ function App() {
 
           if (data.sessionStatus === "unavailable" || data.code === "no_topics") {
             moveToTerminalPhase("unavailable", data.message || "No prompt sets are available right now.");
+            return;
+          }
+
+          if (data.code === "consent_required") {
+            clearStoredConsentSessionMetadata();
+            setPendingConsentMetadata(null);
+            setPhase("consent");
+            setMessage(data.message || "Consent is required before a session can be started.");
             return;
           }
 
@@ -451,7 +479,7 @@ function App() {
 
         if (!isMetadataComplete(data.session?.metadata)) {
           setMetadataMode("required");
-          setPhase("intro");
+          setPhase("metadata");
           return;
         }
 
@@ -468,6 +496,7 @@ function App() {
       apiUrl,
       closeSession,
       moveToTerminalPhase,
+      pendingConsentMetadata,
       sessionToken,
       setCurrentTask,
       syncSession,
@@ -476,30 +505,65 @@ function App() {
   );
 
   useEffect(() => {
-    if (hashRoute.startsWith("#/admin")) {
+    if (
+      hashRoute.startsWith("#/admin") ||
+      hashRoute.startsWith("#/privacy") ||
+      hashRoute.startsWith("#/participant-info") ||
+      phase !== "consent"
+    ) {
       return;
     }
 
-    if (hasBootstrapped.current) {
+    const storedConsentMetadata = getStoredConsentSessionMetadata();
+    if (!storedConsentMetadata) {
       return;
     }
 
-    hasBootstrapped.current = true;
+    setPendingConsentMetadata(storedConsentMetadata);
+    setMessage("");
+
     if (turnstileSiteKey && !turnstileToken) {
       setPhase("verification");
       return;
     }
 
-    void startOrResumeSession(sessionToken, turnstileToken);
-  }, [hashRoute, sessionToken, startOrResumeSession, turnstileSiteKey, turnstileToken]);
+    void startOrResumeSession(sessionToken, turnstileToken, storedConsentMetadata);
+  }, [hashRoute, phase, sessionToken, startOrResumeSession, turnstileSiteKey, turnstileToken]);
 
   const handleTurnstileVerified = useCallback(
     async (token: string) => {
       setTurnstileToken(token);
-      await startOrResumeSession(sessionToken, token);
+      const consentMetadata =
+        pendingConsentMetadata || getStoredConsentSessionMetadata() || buildConsentSessionMetadata();
+      setPendingConsentMetadata(consentMetadata);
+      await startOrResumeSession(sessionToken, token, consentMetadata);
     },
-    [sessionToken, startOrResumeSession]
+    [pendingConsentMetadata, sessionToken, startOrResumeSession]
   );
+
+  const handleConsentAccepted = useCallback(async () => {
+    const consentMetadata = buildConsentSessionMetadata();
+    storeConsentSessionMetadata(consentMetadata);
+    setPendingConsentMetadata(consentMetadata);
+    setMessage("");
+
+    if (turnstileSiteKey && !turnstileToken) {
+      setPhase("verification");
+      return;
+    }
+
+    await startOrResumeSession(sessionToken, turnstileToken, consentMetadata);
+  }, [sessionToken, startOrResumeSession, turnstileSiteKey, turnstileToken]);
+
+  const handleConsentDeclined = useCallback(() => {
+    clearStoredConsentSessionMetadata();
+    setPendingConsentMetadata(null);
+    clearSession();
+    setMessage(
+      "Et voi jatkaa osallistumista ilman suostumusta. Voit sulkea tämän sivun. You cannot continue without consent. You may close this page."
+    );
+    setPhase("declined");
+  }, [clearSession]);
 
   const handleMetadataSaved = useCallback(
     async (session: SessionState) => {
@@ -540,15 +604,11 @@ function App() {
     setSelectedCategoryId(null);
     setSelectedPhraseId(null);
     setMetadataMode("required");
+    setPendingConsentMetadata(null);
+    setTurnstileToken(null);
     setMessage("");
-    if (turnstileSiteKey) {
-      setTurnstileToken(null);
-      setPhase("verification");
-      return;
-    }
-
-    await startOrResumeSession(null);
-  }, [clearSession, startOrResumeSession, turnstileSiteKey]);
+    setPhase("consent");
+  }, [clearSession]);
 
   const handleSelectCategory = useCallback((category: CategoryStateCategory) => {
     if (!category.unlocked) {
@@ -639,22 +699,50 @@ function App() {
     return <AdminValidationApp />;
   }
 
+  if (hashRoute.startsWith("#/privacy")) {
+    return (
+      <VolunteerShell>
+        <PrivacyPolicyPage />
+      </VolunteerShell>
+    );
+  }
+
+  if (hashRoute.startsWith("#/participant-info")) {
+    return (
+      <VolunteerShell>
+        <ParticipantInfoPage />
+      </VolunteerShell>
+    );
+  }
+
+  if (phase === "consent") {
+    return (
+      <VolunteerShell>
+        <ConsentGate
+          message={message}
+          onAccepted={handleConsentAccepted}
+          onDeclined={handleConsentDeclined}
+        />
+      </VolunteerShell>
+    );
+  }
+
   if (phase === "bootstrapping") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <section className="app-panel app-panel--narrow">
           <span className="app-eyebrow">Speech Collector</span>
           <h1 className="app-title">Preparing your session</h1>
           <p className="app-copy">Connecting to the next available prompt set.</p>
         </section>
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "verification") {
     if (!turnstileSiteKey) {
       return (
-        <main className="app-shell">
+        <VolunteerShell>
           <section className="app-panel app-panel--narrow">
             <span className="app-eyebrow">Speech Collector</span>
             <h1 className="app-title">Verification unavailable</h1>
@@ -662,24 +750,24 @@ function App() {
               Human verification is required, but the Turnstile site key is not configured.
             </p>
           </section>
-        </main>
+        </VolunteerShell>
       );
     }
 
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <TurnstileGate
           siteKey={turnstileSiteKey}
           message={message}
           onVerified={handleTurnstileVerified}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "intro") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionIntro
           title="Short Finnish response collection"
           summary="This session records short spoken answers for phone-quality speech classification."
@@ -691,31 +779,31 @@ function App() {
           actionLabel="Continue"
           onContinue={() => setPhase("metadata")}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "metadata") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <InfoForm
           message={
             message ||
             (metadataMode === "required"
-              ? "Tell us a little about the recording conditions and confirm consent before you begin."
+              ? "Tell us a little about the recording conditions before you begin."
               : "Update the session details if something changed.")
           }
           canCancel={metadataMode === "edit" && metadataComplete}
           onCancel={() => setPhase(categoryState ? "categoryRecording" : "categoryIntro")}
           onSaved={handleMetadataSaved}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "categoryIntro") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <section className="app-panel app-panel--narrow">
           <span className="app-eyebrow">{appName}</span>
           <h1 className="app-title">Record Finnish short responses</h1>
@@ -748,77 +836,77 @@ function App() {
           </div>
           {message && <p className="app-inline-message app-inline-message--error">{message}</p>}
         </section>
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "completed") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="Session complete"
           message={message || "Thank you. Your recordings were saved."}
           actionLabel="Start a new session"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "abandoned") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="Session closed"
           message={message || "Your submitted recordings were saved."}
           actionLabel="Start a new session"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "declined") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="Thanks for your response"
           message={message || "This session has been closed and no prompts were shown."}
           actionLabel="Start over"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "unavailable") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="No prompts available"
           message={message || "There are no prompt sets available right now."}
           actionLabel="Try again"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "error") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="Something went wrong"
           message={message || "The session could not continue."}
           actionLabel="Start over"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   return (
-    <main className="app-shell">
+    <VolunteerShell>
       <section className="app-panel app-panel--wide">
         <header className="app-header">
           <div className="app-header__content">
@@ -1004,7 +1092,7 @@ function App() {
           <p className="app-inline-message">{message}</p>
         )}
       </section>
-    </main>
+    </VolunteerShell>
   );
 }
 

--- a/frontend/utils/sessionMetadata.ts
+++ b/frontend/utils/sessionMetadata.ts
@@ -9,7 +9,11 @@ import {
 import { getBrowserTechnicalMetadata } from './technicalMetadata';
 
 const DEFAULT_CONSENT_DECLINE_MESSAGE =
-  'Thank you for your response. This session has been closed and no prompts will be shown.';
+  'Et voi jatkaa osallistumista ilman suostumusta. Voit sulkea tämän sivun. You cannot continue without consent. You may close this page.';
+
+export const CONSENT_VERSION = '1.0';
+export const PRIVACY_NOTICE_VERSION = '1.0';
+export const CONSENT_STORAGE_KEY = 'speechCollectorConsent';
 
 type FormValues = Record<string, string | number | null | undefined>;
 type MetadataObject = Record<string, unknown>;
@@ -31,6 +35,32 @@ function normalizeMetadataValue(value: unknown) {
 function optionalText(value: unknown) {
   const normalized = normalizeMetadataValue(value);
   return normalized || null;
+}
+
+function getLocalStorage() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isValidIsoTimestamp(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0 && Number.isFinite(Date.parse(value));
+}
+
+function hasValidStoredConsent(metadata: MetadataObject) {
+  return (
+    metadata.consent_response === 'yes' &&
+    metadata.consent_version === CONSENT_VERSION &&
+    metadata.privacy_notice_version === PRIVACY_NOTICE_VERSION &&
+    metadata.age_confirmed_18_or_over === true &&
+    isValidIsoTimestamp(metadata.consent_accepted_at)
+  );
 }
 
 export function flattenSessionMetadata(
@@ -57,6 +87,68 @@ export function flattenSessionMetadata(
     audio_hardware: normalizeMetadataValue(environment.audio_hardware ?? root.audio_hardware),
     consent_response: normalizeMetadataValue(root.consent_response),
   };
+}
+
+export function buildConsentSessionMetadata(acceptedAt = new Date().toISOString()) {
+  return {
+    schema_version: 'v1',
+    device_id: getOrCreateDeviceId(),
+    consent_response: 'yes',
+    consent_version: CONSENT_VERSION,
+    privacy_notice_version: PRIVACY_NOTICE_VERSION,
+    consent_accepted_at: acceptedAt,
+    age_confirmed_18_or_over: true,
+    technical: getBrowserTechnicalMetadata(),
+  };
+}
+
+export function getStoredConsentSessionMetadata() {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return null;
+  }
+
+  const storedValue = storage.getItem(CONSENT_STORAGE_KEY);
+  if (!storedValue) {
+    return null;
+  }
+
+  try {
+    const storedConsent = asRecord(JSON.parse(storedValue));
+    if (!hasValidStoredConsent(storedConsent)) {
+      storage.removeItem(CONSENT_STORAGE_KEY);
+      return null;
+    }
+
+    return buildConsentSessionMetadata(String(storedConsent.consent_accepted_at));
+  } catch {
+    storage.removeItem(CONSENT_STORAGE_KEY);
+    return null;
+  }
+}
+
+export function storeConsentSessionMetadata(metadata: Record<string, unknown>) {
+  const storage = getLocalStorage();
+  const consentMetadata = asRecord(metadata);
+
+  if (!storage || !hasValidStoredConsent(consentMetadata)) {
+    return;
+  }
+
+  storage.setItem(
+    CONSENT_STORAGE_KEY,
+    JSON.stringify({
+      consent_response: 'yes',
+      consent_version: CONSENT_VERSION,
+      privacy_notice_version: PRIVACY_NOTICE_VERSION,
+      consent_accepted_at: consentMetadata.consent_accepted_at,
+      age_confirmed_18_or_over: true,
+    })
+  );
+}
+
+export function clearStoredConsentSessionMetadata() {
+  getLocalStorage()?.removeItem(CONSENT_STORAGE_KEY);
 }
 
 function isAllowedSelectValue(field: InfoFormField, value: unknown) {
@@ -102,6 +194,11 @@ export function hasDeclinedConsent(metadata: Record<string, unknown> | null | un
     return false;
   }
 
+  const root = asRecord(metadata);
+  if (root.consent_response === 'no') {
+    return true;
+  }
+
   const values = flattenSessionMetadata(metadata);
 
   return infoFormConfig.some(
@@ -124,15 +221,30 @@ export function getConsentDeclineMessage(metadata: Record<string, unknown> | nul
     : DEFAULT_CONSENT_DECLINE_MESSAGE;
 }
 
-export function buildV1SessionMetadata(values: FormValues) {
+export function buildV1SessionMetadata(
+  values: FormValues,
+  existingMetadata: Record<string, unknown> | null | undefined = {}
+) {
+  const existing = asRecord(existingMetadata);
   const nativeLanguage = normalizeMetadataValue(values.native_language);
   const dialectRegion = normalizeMetadataValue(values.dialect_region);
-  const consentResponse = normalizeMetadataValue(values.consent_response);
+  const consentResponse =
+    normalizeMetadataValue(existing.consent_response) ||
+    normalizeMetadataValue(values.consent_response);
+  const deviceId =
+    normalizeMetadataValue(existing.device_id) ||
+    (consentResponse === 'yes' ? getOrCreateDeviceId() : '');
+  const existingTechnical = asRecord(existing.technical);
 
   return {
     schema_version: 'v1',
-    device_id: consentResponse === 'yes' ? getOrCreateDeviceId() : null,
+    device_id: deviceId || null,
     consent_response: consentResponse,
+    consent_version: normalizeMetadataValue(existing.consent_version) || CONSENT_VERSION,
+    privacy_notice_version:
+      normalizeMetadataValue(existing.privacy_notice_version) || PRIVACY_NOTICE_VERSION,
+    consent_accepted_at: normalizeMetadataValue(existing.consent_accepted_at) || null,
+    age_confirmed_18_or_over: existing.age_confirmed_18_or_over === true,
     demographics: {
       age_group: normalizeMetadataValue(values.age_group),
       gender: normalizeMetadataValue(values.gender),
@@ -147,6 +259,9 @@ export function buildV1SessionMetadata(values: FormValues) {
       noise_level: normalizeMetadataValue(values.noise_level),
       audio_hardware: normalizeMetadataValue(values.audio_hardware),
     },
-    technical: getBrowserTechnicalMetadata(),
+    technical: {
+      ...existingTechnical,
+      ...getBrowserTechnicalMetadata(),
+    },
   };
 }

--- a/infoFormConfig.json
+++ b/infoFormConfig.json
@@ -5,7 +5,6 @@
     "id": "age_group",
     "required": true,
     "options": [
-      { "value": "under_18", "label": "Under 18" },
       { "value": "18-25", "label": "18-25" },
       { "value": "26-35", "label": "26-35" },
       { "value": "36-50", "label": "36-50" },
@@ -112,23 +111,5 @@
         "label": "Not sure / I don't know"
       }
     ]
-  },
-  {
-    "label": "Consent",
-    "type": "consent_markdown_yes_no",
-    "id": "consent_response",
-    "required": true,
-    "markdown": "### Consent to participate\nBy choosing **Yes**, you confirm that:\n\n- these recordings are collected for a speech-classifier project\n- your recordings and session details may be stored, reviewed, and exported for research and model development\n- an anonymous random browser ID is stored in this browser so we can resume an active session and show which phrases this browser has already recorded\n- the browser ID is not a hardware serial number and does not include your name, email, or phone number\n- clearing browser storage removes this ID from this browser, but recordings already submitted remain stored under the previous anonymous ID\n- basic browser, device, and microphone information may be collected automatically to understand recording quality\n- participation is voluntary and you may stop at any time",
-    "options": [
-      {
-        "value": "yes",
-        "label": "Yes, I consent"
-      },
-      {
-        "value": "no",
-        "label": "No, I do not consent"
-      }
-    ],
-    "declineMessage": "Thank you for your response. This session has been closed and no prompts were shown."
   }
 ]

--- a/scripts/aina/exportDatabuilderDataset.js
+++ b/scripts/aina/exportDatabuilderDataset.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import {
+  buildConsentGovernanceMetadata,
   configValue,
   createDbClient,
   ensureDirectory,
@@ -256,6 +257,7 @@ export function buildDatabuilderSidecar(row) {
       category: category || null,
       phrase_id: phraseId,
       semantic_label: semanticLabel,
+      consent: buildConsentGovernanceMetadata(sessionMetadata),
     },
     storage: getDatabuilderStorageInfo(row),
   };

--- a/scripts/aina/exportDatabuilderDataset.test.js
+++ b/scripts/aina/exportDatabuilderDataset.test.js
@@ -59,6 +59,11 @@ function makeRow(overrides = {}) {
     session_metadata: {
       schema_version: 'v1',
       device_id: 'device-123',
+      consent_response: 'yes',
+      consent_version: '1.0',
+      privacy_notice_version: '1.0',
+      consent_accepted_at: '2026-06-03T12:00:00.000Z',
+      age_confirmed_18_or_over: true,
       demographics: {
         age_group: '26-35',
         gender: 'prefer_not_to_say',
@@ -160,6 +165,13 @@ test('buildDatabuilderSidecar creates root-level databuilder fields', () => {
   assert.equal(sidecar.collection.session_id, 'session-123');
   assert.equal(sidecar.collection.phrase_id, 'yes_kylla');
   assert.equal(sidecar.collection.semantic_label, 'yes');
+  assert.deepEqual(sidecar.collection.consent, {
+    consent_response: 'yes',
+    consent_version: '1.0',
+    privacy_notice_version: '1.0',
+    consent_accepted_at: '2026-06-03T12:00:00.000Z',
+    age_confirmed_18_or_over: true,
+  });
   assert.equal(sidecar.storage.storage_key, 'session-123/short_finnish_responses_v1_0001_kylla.wav');
   assert.equal(
     sidecar.storage.metadata_object_key,
@@ -195,6 +207,7 @@ test('required sidecar keys always exist for original recordings', () => {
   assert.equal(Object.hasOwn(sidecar, 'environment'), true);
   assert.equal(Object.hasOwn(sidecar, 'technical'), true);
   assert.equal(Object.hasOwn(sidecar, 'collection'), true);
+  assert.equal(Object.hasOwn(sidecar.collection, 'consent'), true);
   assert.equal(Object.hasOwn(sidecar, 'storage'), true);
   assert.equal(Object.hasOwn(sidecar, 'speaker_id'), true);
   assert.equal(Object.hasOwn(sidecar, 'device_id'), true);

--- a/scripts/aina/exportDataset.js
+++ b/scripts/aina/exportDataset.js
@@ -208,6 +208,21 @@ export function buildDatasetMetadata(rows, labels, audioRoot) {
   };
 }
 
+export function buildConsentGovernanceMetadata(sessionMetadata = {}) {
+  return {
+    consent_response: sessionMetadata.consent_response || null,
+    consent_version: sessionMetadata.consent_version || null,
+    privacy_notice_version: sessionMetadata.privacy_notice_version || null,
+    consent_accepted_at: sessionMetadata.consent_accepted_at || null,
+    age_confirmed_18_or_over:
+      sessionMetadata.age_confirmed_18_or_over === true
+        ? true
+        : sessionMetadata.age_confirmed_18_or_over === false
+          ? false
+          : null,
+  };
+}
+
 export function buildSample(row, index, dataset) {
   const sampleId = getSampleId(row, index);
   const recordingMetadata = row.recording_metadata || {};
@@ -268,6 +283,7 @@ export function buildSample(row, index, dataset) {
         category,
         phrase_id: phraseId,
         semantic_label: semanticLabel,
+        consent: buildConsentGovernanceMetadata(sessionMetadata),
       },
       storage: {
         storage_type: row.storage_type,

--- a/scripts/aina/exportDataset.test.js
+++ b/scripts/aina/exportDataset.test.js
@@ -218,6 +218,11 @@ test('buildSample uses recording id and v1 labels in the manifest row', () => {
       session_metadata: {
         schema_version: 'v1',
         device_id: 'device-123',
+        consent_response: 'yes',
+        consent_version: '1.0',
+        privacy_notice_version: '1.0',
+        consent_accepted_at: '2026-06-03T12:00:00.000Z',
+        age_confirmed_18_or_over: true,
         demographics: {
           age_group: '26-35',
           gender: 'prefer_not_to_say',
@@ -295,6 +300,13 @@ test('buildSample uses recording id and v1 labels in the manifest row', () => {
   assert.equal(sample.metadata.collection.session_status, 'completed');
   assert.equal(sample.metadata.collection.phrase_id, 'yes_kylla');
   assert.equal(sample.metadata.collection.semantic_label, 'yes');
+  assert.deepEqual(sample.metadata.collection.consent, {
+    consent_response: 'yes',
+    consent_version: '1.0',
+    privacy_notice_version: '1.0',
+    consent_accepted_at: '2026-06-03T12:00:00.000Z',
+    age_confirmed_18_or_over: true,
+  });
 });
 
 test('buildSample keeps legacy semantic fields nullable', () => {
@@ -326,6 +338,13 @@ test('buildSample keeps legacy semantic fields nullable', () => {
   assert.equal(sample.semantic_label, null);
   assert.equal(sample.metadata.collection.phrase_id, null);
   assert.equal(sample.metadata.collection.semantic_label, null);
+  assert.deepEqual(sample.metadata.collection.consent, {
+    consent_response: null,
+    consent_version: null,
+    privacy_notice_version: null,
+    consent_accepted_at: null,
+    age_confirmed_18_or_over: null,
+  });
 });
 
 test('speaker id is stable for the same device id across sessions', () => {


### PR DESCRIPTION

## Summary

Adds a bilingual Finnish/English welcome, privacy, participant information, and consent flow for volunteers before metadata collection and recording.

The main route now shows a friendly welcome + consent gate first. Volunteers must confirm they are 18 or older and consent to the participation/privacy information before continuing to the metadata form and recording flow.

Returning volunteers on the same browser/device do not need to accept the same consent every time. Accepted consent is stored locally and version-checked using `CONSENT_VERSION` and `PRIVACY_NOTICE_VERSION`.

The normal volunteer flow stays simple and calm. Full privacy, consent, age-limit, and study details are consolidated under `/#/privacy`.

## UI Preview

## could not take the photo for some reason
## What Changed

- Added friendly volunteer welcome + consent gate before metadata collection.
- Added required 18+ confirmation.
- Added required participation/privacy consent confirmation.
- Added decline flow that blocks participation.
- Added local consent persistence using `speechCollectorConsent`.
- Added version-aware consent:
  - `CONSENT_VERSION = 1.0`
  - `PRIVACY_NOTICE_VERSION = 1.0`
- Returning same-browser/device volunteers skip the consent screen when stored consent is valid.
- Consolidated full privacy/consent details under:
  - `/#/privacy`
- Kept `/#/participant-info` compatible but not promoted in the normal UI.
- Removed visible participant code from normal volunteer flow.
- Removed deletion-request text from normal volunteer flow.
- Removed persistent footer policy links from normal volunteer screens.
- Added backend consent enforcement for session creation.
- Added consent metadata:
  - `consent_response`
  - `consent_version`
  - `privacy_notice_version`
  - `consent_accepted_at`
  - `age_confirmed_18_or_over`
- Updated data contract and docs.

## Policy Details

- Company: Linnea Technologies Oy
- Y-tunnus: 3571288-4
- Address: Kulmalantie 11 as. 2, 28130 Pori, Finland
- Contact: Ollipekka Kivin
- Email: ollipekka@hellolinnea.com
- Policy date: 03.06.2026
- Purpose wording: AI-based phone service
- Minimum age: 18+

## Compatibility

- Existing Turnstile flow preserved.
- Existing metadata form preserved.
- Existing category recording UI preserved.
- Existing recording upload preserved.
- Existing Admin UI route `/#/admin` preserved.
- Existing normal/databuilder export behavior preserved.
- Classifier labels are unchanged.
- Validation filtering is unchanged.
- Backend consent enforcement is active.

## Validation

- Backend tests passed.
- Frontend build passed.
- Frontend lint passed.
- Manual browser smoke passed locally by Avishek.

## Notes

No production deployment was performed.

The production server deployment still needs confirmation because `/var/www/speech-collector` is not currently a Git repository, so `git pull` does not work there. Deployment should use the confirmed `rsync`/copy workflow or be handled by the senior.