### PR TITLE
Fix iOS recording playback MIME handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,10 +21,22 @@ MAX_UPLOAD_BYTES=2000000
 MAX_RECORDING_DURATION_TOLERANCE_SECONDS=1
 TURNSTILE_SECRET_KEY=2x0000000000000000000000000000000AA
 
+# Internal admin validation UI. Generate ADMIN_PASSWORD_HASH with:
+# pnpm run admin:hash-password
+# If your dotenv loader expands $, escape each $ in the generated scrypt hash as \$.
+ADMIN_PASSWORD_HASH=
+ADMIN_SESSION_SECRET=
+ADMIN_SESSION_TTL_HOURS=12
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=eu-north-1
 AWS_BUCKET_NAME=
+
+CF_R2_ENDPOINT=
+CF_R2_ACCESS_KEY_ID=
+CF_R2_SECRET_ACCESS_KEY=
+CF_R2_BUCKET_NAME=
 
 # Create enough copies of the AINA prompt set for expected concurrent volunteers.
 # Increase this value and rerun `pnpm run aina:seed` to create more topic copies.
@@ -40,6 +52,8 @@ DATASET_OUTPUT_DIR=./exports/short-finnish-responses/v2
 # Optional override. Leave empty to derive from local storage or S3 config.
 DATASET_AUDIO_ROOT=
 DATASET_SPEAKER_HASH_SALT=change-me-before-real-export
+# validated, not_rejected, or all. Production/default should stay validated.
+DATASET_VALIDATION_FILTER=validated
 
 # Compatibility export for audio-classifier databuilder.
 DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v2/databuilder

--- a/README.md
+++ b/README.md
@@ -219,16 +219,20 @@ There is no visible admin link in the volunteer UI.
 The main collection flow is:
 
 1. Volunteer opens the app.
-2. If Turnstile is configured, the volunteer completes the human verification gate.
-3. Backend starts or resumes an anonymous session.
-4. Volunteer sees the intro and metadata form.
-5. Volunteer records one prompt at a time in the current frontend; the backend also exposes category progress for the next UI.
-6. Each successful upload is stored and linked to the session.
-7. Volunteer can continue, refresh, or leave.
-8. Submitted recordings stay valid even if the session ends early.
-9. Completed sessions show a thank-you screen.
+2. Volunteer reads the welcome and consent screen with a short collection summary.
+3. A single small read-more link opens the full privacy and consent details.
+4. Volunteer must confirm they are 18 or older and consent to participate.
+5. If Turnstile is configured, the volunteer completes the human verification gate.
+6. Backend starts or resumes an anonymous session with consent metadata.
+7. Volunteer sees the intro and metadata form.
+8. Volunteer records category phrases.
+9. Each successful upload is stored and linked to the session.
+10. Volunteer can continue, refresh, or leave.
+11. Submitted recordings stay valid even if the session ends early.
+12. Completed sessions show a thank-you screen.
 
 The browser stores the active session token locally so an active session can resume automatically in the same browser.
+The full privacy and consent details are at `/#/privacy`. Compatibility route `/#/participant-info` renders the same full details page but is not linked from the normal volunteer flow. The internal admin UI remains at `/#/admin` and is not linked from the volunteer flow.
 
 ## Category Progress API
 
@@ -437,6 +441,7 @@ If you only need more test sessions and want to keep the existing prompt copies,
 - [docs/category-phrase-ui-plan.md](docs/category-phrase-ui-plan.md)
 - [docs/aina-s3-integration.md](docs/aina-s3-integration.md)
 - [docs/admin-validation-ui.md](docs/admin-validation-ui.md)
+- [docs/privacy-consent-flow.md](docs/privacy-consent-flow.md)
 - [docs/aina-data-contract.md](docs/aina-data-contract.md)
 - [docs/databuilder-export.md](docs/databuilder-export.md)
 - [docs/cloud-validation-session-2026-05-04.md](docs/cloud-validation-session-2026-05-04.md)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ It is built for anonymous volunteer sessions:
 - exit anytime without losing submitted prompts
 - PostgreSQL for session/task/recording state
 - AWS S3 as the production audio store
+- internal `/#/admin` validation UI for project members
 
 ## Architecture
 
@@ -23,6 +24,8 @@ volunteer browser
   -> permanent audio storage
      - local path in development
      - AWS S3 in production-like mode
+  -> internal admin validation API under /api/admin/*
+  -> validation JSON sidecars beside audio files
   -> exportDataset.js
   -> metadata/dataset.json + metadata/samples.jsonl
   -> exportDatabuilderDataset.js
@@ -85,10 +88,19 @@ MAX_UPLOAD_BYTES=2000000
 MAX_RECORDING_DURATION_TOLERANCE_SECONDS=1
 TURNSTILE_SECRET_KEY=
 
+ADMIN_PASSWORD_HASH=
+ADMIN_SESSION_SECRET=
+ADMIN_SESSION_TTL_HOURS=12
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_REGION=eu-north-1
 AWS_BUCKET_NAME=
+
+CF_R2_ENDPOINT=
+CF_R2_ACCESS_KEY_ID=
+CF_R2_SECRET_ACCESS_KEY=
+CF_R2_BUCKET_NAME=
 
 AINA_TOPIC_COPIES=100
 
@@ -100,6 +112,7 @@ DATASET_TASK=short_response_classification
 DATASET_OUTPUT_DIR=./exports/short-finnish-responses/v2
 DATASET_AUDIO_ROOT=
 DATASET_SPEAKER_HASH_SALT=change-me-before-real-export
+DATASET_VALIDATION_FILTER=validated
 
 DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v2/databuilder
 DATABUILDER_MANIFEST_VERSION=20260501001
@@ -118,6 +131,16 @@ Notes:
 - `VITE_MAX_RECORDING_SECONDS` controls the frontend auto-stop timer. `MAX_RECORDING_SECONDS` plus `MAX_RECORDING_DURATION_TOLERANCE_SECONDS` is the backend duration limit.
 - `MAX_UPLOAD_BYTES` limits multipart audio upload size before storage.
 - Leave `VITE_TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` empty for local development. Configure both for public collection.
+- `ADMIN_PASSWORD_HASH`, `ADMIN_SESSION_SECRET`, and `ADMIN_SESSION_TTL_HOURS` enable the internal admin UI at `/#/admin`.
+- `DATASET_VALIDATION_FILTER` controls export eligibility. Missing or invalid values default to `validated`.
+
+Generate the shared admin password hash with:
+
+```bash
+pnpm run admin:hash-password
+```
+
+The command prints only the hash. Put the hash in `ADMIN_PASSWORD_HASH`; do not store a plaintext password in `.env`.
 
 ## Database Setup
 
@@ -183,6 +206,13 @@ Ports:
 
 - backend: `http://localhost:8000`
 - frontend: `http://localhost:5173`
+
+Internal admin URL:
+
+- local: `http://localhost:5173/#/admin`
+- production: `https://participate.hellolinnea.com/#/admin`
+
+There is no visible admin link in the volunteer UI.
 
 ## Volunteer Flow
 
@@ -318,6 +348,9 @@ Export behavior:
 - includes `completed` sessions
 - includes `abandoned` sessions
 - excludes still-`active` sessions
+- by default exports only recordings with `recordings.metadata.validation.status = "validated"`
+- `DATASET_VALIDATION_FILTER=not_rejected` exports pending, needs_review, and validated recordings while excluding rejected recordings
+- `DATASET_VALIDATION_FILTER=all` exports all otherwise eligible recordings
 - filters rows to the active `STORAGE` backend before building the manifest
 - uses `recordings.id` as `sample_id`
 - exports `normalized_label` and keeps `label` as its compatibility alias
@@ -348,6 +381,7 @@ exports/short-finnish-responses/v2/databuilder/
 Databuilder export behavior:
 
 - keeps `pnpm run aina:export` unchanged
+- respects `DATASET_VALIDATION_FILTER`, defaulting to validated-only recordings
 - filters rows to the active `STORAGE` backend, like the normal exporter
 - exports only classifier-ready recordings with `processed_audio` set to WAV PCM 16-bit, 16 kHz, mono
 - skips legacy recordings where `processed_audio` is missing, null, or different from the classifier-ready format
@@ -402,6 +436,7 @@ If you only need more test sessions and want to keep the existing prompt copies,
 - [docs/aina-refactor-plan.md](docs/aina-refactor-plan.md)
 - [docs/category-phrase-ui-plan.md](docs/category-phrase-ui-plan.md)
 - [docs/aina-s3-integration.md](docs/aina-s3-integration.md)
+- [docs/admin-validation-ui.md](docs/admin-validation-ui.md)
 - [docs/aina-data-contract.md](docs/aina-data-contract.md)
 - [docs/databuilder-export.md](docs/databuilder-export.md)
 - [docs/cloud-validation-session-2026-05-04.md](docs/cloud-validation-session-2026-05-04.md)

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node src/index.js",
-    "test": "node --test src/config.test.js src/taskProvider.test.js src/fileStorage.test.js src/index.test.js"
+    "test": "node --test src/config.test.js src/taskProvider.test.js src/fileStorage.test.js src/admin.test.js src/index.test.js"
   },
   "type": "module",
   "keywords": [],

--- a/backend/src/admin.js
+++ b/backend/src/admin.js
@@ -1,0 +1,1339 @@
+import { createHmac, randomBytes, scrypt, timingSafeEqual } from 'crypto';
+import { promisify } from 'util';
+
+import {
+  getAdminPasswordHash,
+  getAdminSessionSecret,
+  getAdminSessionTtlHours,
+  getDatasetValidationFilter,
+} from './config.js';
+import { buildDatabuilderSidecar } from '../../scripts/aina/exportDatabuilderDataset.js';
+import {
+  getRecordingValidationStatus,
+  isRowExportableByValidationFilter,
+} from '../../scripts/aina/exportDataset.js';
+
+const scryptAsync = promisify(scrypt);
+
+const ADMIN_COOKIE_NAME = 'aina_admin_session';
+const SESSION_ALGORITHM = 'sha256';
+const PASSWORD_HASH_ALGORITHM = 'scrypt';
+const DEFAULT_SCRYPT_OPTIONS = {
+  n: 16384,
+  r: 8,
+  p: 1,
+  keyLength: 64,
+};
+const MAX_ADMIN_LIMIT = 100;
+const DEFAULT_ADMIN_LIMIT = 25;
+
+export const ADMIN_VALIDATION_STATUSES = new Set([
+  'pending',
+  'validated',
+  'needs_review',
+  'rejected',
+]);
+export const ADMIN_LABEL_SOURCES = new Set(['prompt_assumed', 'user_confirmed', 'reviewed']);
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeOptionalString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizePlainObject(value) {
+  return isPlainObject(value) ? value : {};
+}
+
+function normalizeNullableString(value, fieldName) {
+  if (value === null || value === undefined) {
+    return { success: true, value: null };
+  }
+
+  if (typeof value !== 'string') {
+    return {
+      success: false,
+      code: 'invalid_validation_payload',
+      message: `${fieldName} must be a string or null.`,
+    };
+  }
+
+  const trimmed = value.trim();
+  return { success: true, value: trimmed || null };
+}
+
+function normalizeLimit(value) {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_ADMIN_LIMIT;
+  }
+
+  return Math.min(parsed, MAX_ADMIN_LIMIT);
+}
+
+function normalizeOffset(value) {
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+}
+
+function toBase64UrlJson(value) {
+  return Buffer.from(JSON.stringify(value), 'utf-8').toString('base64url');
+}
+
+function fromBase64UrlJson(value) {
+  return JSON.parse(Buffer.from(value, 'base64url').toString('utf-8'));
+}
+
+function getRequestIp(req) {
+  return (
+    normalizeOptionalString(req.headers['cf-connecting-ip']) ||
+    normalizeOptionalString(req.headers['x-forwarded-for'])?.split(',')[0]?.trim() ||
+    req.ip ||
+    req.socket?.remoteAddress ||
+    'unknown'
+  );
+}
+
+function delay(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+function safeTimingEqual(left, right) {
+  const leftBuffer = Buffer.isBuffer(left) ? left : Buffer.from(String(left));
+  const rightBuffer = Buffer.isBuffer(right) ? right : Buffer.from(String(right));
+
+  if (leftBuffer.length !== rightBuffer.length) {
+    return false;
+  }
+
+  return timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+function signSessionPayload(encodedPayload, secret) {
+  return createHmac(SESSION_ALGORITHM, secret).update(encodedPayload).digest('base64url');
+}
+
+function parseCookies(cookieHeader) {
+  const cookies = {};
+  if (!cookieHeader) {
+    return cookies;
+  }
+
+  for (const part of cookieHeader.split(';')) {
+    const [rawName, ...rawValue] = part.trim().split('=');
+    if (!rawName) {
+      continue;
+    }
+
+    cookies[decodeURIComponent(rawName)] = decodeURIComponent(rawValue.join('='));
+  }
+
+  return cookies;
+}
+
+function isSecureRequest(req) {
+  const forwardedProto = normalizeOptionalString(req.headers['x-forwarded-proto']);
+  return req.secure || forwardedProto === 'https' || process.env.NODE_ENV === 'production';
+}
+
+function serializeAdminCookie(value, req, options = {}) {
+  const parts = [
+    `${ADMIN_COOKIE_NAME}=${encodeURIComponent(value)}`,
+    'Path=/api/admin',
+    'HttpOnly',
+    'SameSite=Lax',
+  ];
+
+  if (Number.isFinite(options.maxAgeSeconds)) {
+    parts.push(`Max-Age=${Math.max(0, Math.floor(options.maxAgeSeconds))}`);
+  }
+
+  if (isSecureRequest(req)) {
+    parts.push('Secure');
+  }
+
+  return parts.join('; ');
+}
+
+function getAdminConfig(options = {}) {
+  const passwordHash =
+    options.passwordHash === undefined ? getAdminPasswordHash() : options.passwordHash;
+  const sessionSecret =
+    options.sessionSecret === undefined ? getAdminSessionSecret() : options.sessionSecret;
+  const ttlHours = options.sessionTtlHours || getAdminSessionTtlHours();
+
+  return {
+    passwordHash,
+    sessionSecret,
+    ttlHours,
+    configured: Boolean(passwordHash && sessionSecret),
+  };
+}
+
+function createAdminSessionToken(config, now = Date.now()) {
+  const ttlMs = config.ttlHours * 60 * 60 * 1000;
+  const payload = {
+    iat: now,
+    exp: now + ttlMs,
+    nonce: randomBytes(16).toString('base64url'),
+  };
+  const encodedPayload = toBase64UrlJson(payload);
+  const signature = signSessionPayload(encodedPayload, config.sessionSecret);
+  return `${encodedPayload}.${signature}`;
+}
+
+function verifyAdminSessionToken(token, config, now = Date.now()) {
+  if (!config.configured || !token || !token.includes('.')) {
+    return false;
+  }
+
+  const [encodedPayload, signature] = token.split('.');
+  const expectedSignature = signSessionPayload(encodedPayload, config.sessionSecret);
+  if (!safeTimingEqual(signature, expectedSignature)) {
+    return false;
+  }
+
+  try {
+    const payload = fromBase64UrlJson(encodedPayload);
+    return Number.isFinite(payload.exp) && payload.exp > now;
+  } catch (_error) {
+    return false;
+  }
+}
+
+export async function createAdminPasswordHash(password, options = {}) {
+  if (typeof password !== 'string' || password.length === 0) {
+    throw new Error('Admin password must be a non-empty string.');
+  }
+
+  const scryptOptions = {
+    ...DEFAULT_SCRYPT_OPTIONS,
+    ...options,
+  };
+  const salt = randomBytes(16).toString('base64url');
+  const derivedKey = await scryptAsync(password, salt, scryptOptions.keyLength, {
+    N: scryptOptions.n,
+    r: scryptOptions.r,
+    p: scryptOptions.p,
+  });
+
+  return [
+    PASSWORD_HASH_ALGORITHM,
+    scryptOptions.n,
+    scryptOptions.r,
+    scryptOptions.p,
+    scryptOptions.keyLength,
+    salt,
+    derivedKey.toString('base64url'),
+  ].join('$');
+}
+
+export async function verifyAdminPassword(password, passwordHash) {
+  if (typeof password !== 'string' || typeof passwordHash !== 'string') {
+    return false;
+  }
+
+  const [algorithm, rawN, rawR, rawP, rawKeyLength, salt, expectedHash] = passwordHash.split('$');
+  if (algorithm !== PASSWORD_HASH_ALGORITHM || !salt || !expectedHash) {
+    return false;
+  }
+
+  const n = Number.parseInt(rawN, 10);
+  const r = Number.parseInt(rawR, 10);
+  const p = Number.parseInt(rawP, 10);
+  const keyLength = Number.parseInt(rawKeyLength, 10);
+  if (![n, r, p, keyLength].every((value) => Number.isFinite(value) && value > 0)) {
+    return false;
+  }
+
+  try {
+    const derivedKey = await scryptAsync(password, salt, keyLength, { N: n, r, p });
+    return safeTimingEqual(derivedKey, Buffer.from(expectedHash, 'base64url'));
+  } catch (_error) {
+    return false;
+  }
+}
+
+export function getValidationStatusFromMetadata(metadata) {
+  const validation = normalizePlainObject(metadata?.validation);
+  const status = normalizeOptionalString(validation.status);
+  return ADMIN_VALIDATION_STATUSES.has(status) ? status : 'pending';
+}
+
+function getValidationFromMetadata(metadata) {
+  const validation = normalizePlainObject(metadata?.validation);
+  const status = getValidationStatusFromMetadata(metadata);
+  return {
+    status,
+    validated_at: normalizeOptionalString(validation.validated_at),
+    notes: normalizeOptionalString(validation.notes),
+  };
+}
+
+function getProcessedAudioStatus(processedAudio) {
+  if (!isPlainObject(processedAudio)) {
+    return 'missing';
+  }
+
+  if (
+    processedAudio.sample_rate_hz === 16000 &&
+    processedAudio.channel_count === 1 &&
+    processedAudio.encoding === 'pcm_s16le'
+  ) {
+    return 'ready';
+  }
+
+  return 'wrong_format';
+}
+
+function getRowNormalizedLabel(row, recordingMetadata, taskMetadata) {
+  return (
+    normalizeOptionalString(recordingMetadata.normalized_label) ||
+    normalizeOptionalString(taskMetadata.label) ||
+    normalizeOptionalString(row.label)
+  );
+}
+
+function getRowPhraseId(row, recordingMetadata, taskMetadata) {
+  return (
+    normalizeOptionalString(recordingMetadata.phrase_id) ||
+    normalizeOptionalString(taskMetadata.phrase_id) ||
+    normalizeOptionalString(taskMetadata.prompt_id) ||
+    normalizeOptionalString(row.task_id)
+  );
+}
+
+function getRowSemanticLabel(row, recordingMetadata, taskMetadata) {
+  return (
+    normalizeOptionalString(recordingMetadata.semantic_label) ||
+    normalizeOptionalString(taskMetadata.semantic_label) ||
+    normalizeOptionalString(row.semantic_label)
+  );
+}
+
+function getRowCategory(row, recordingMetadata, taskMetadata) {
+  return (
+    normalizeOptionalString(recordingMetadata.category) ||
+    normalizeOptionalString(taskMetadata.category) ||
+    normalizeOptionalString(row.category)
+  );
+}
+
+function getRowLanguage(row, recordingMetadata, taskMetadata) {
+  return (
+    normalizeOptionalString(recordingMetadata.language) ||
+    normalizeOptionalString(taskMetadata.language) ||
+    normalizeOptionalString(row.language)
+  );
+}
+
+function mapAdminSample(row, options = {}) {
+  const recordingMetadata = normalizePlainObject(row.recording_metadata);
+  const sessionMetadata = normalizePlainObject(row.session_metadata);
+  const taskMetadata = normalizePlainObject(row.task_metadata);
+  const topicMetadata = normalizePlainObject(row.topic_metadata);
+  const storageMetadata = normalizePlainObject(recordingMetadata.storage);
+  const validation = getValidationFromMetadata(recordingMetadata);
+  const processedAudio = isPlainObject(recordingMetadata.processed_audio)
+    ? recordingMetadata.processed_audio
+    : null;
+  const promptedWord =
+    normalizeOptionalString(recordingMetadata.prompted_word) ||
+    normalizeOptionalString(row.prompted_word) ||
+    normalizeOptionalString(row.transcript);
+  const phraseId = getRowPhraseId(row, recordingMetadata, taskMetadata);
+  const normalizedLabel = getRowNormalizedLabel(row, recordingMetadata, taskMetadata);
+  const semanticLabel = getRowSemanticLabel(row, recordingMetadata, taskMetadata);
+  const category = getRowCategory(row, recordingMetadata, taskMetadata);
+  const language = getRowLanguage(row, recordingMetadata, taskMetadata);
+
+  const sample = {
+    id: row.recording_id,
+    sample_id: row.recording_id,
+    recording_id: row.recording_id,
+    session_id: row.session_id,
+    task_id: row.task_id,
+    topic_id: row.topic_id,
+    submitted_at: row.submitted_at,
+    duration_sec: row.duration_sec,
+    session_status: row.session_status,
+    prompted_word: promptedWord,
+    phrase_id: phraseId,
+    normalized_label: normalizedLabel,
+    semantic_label: semanticLabel,
+    category,
+    language,
+    literal_transcript: recordingMetadata.literal_transcript ?? null,
+    label_source: recordingMetadata.label_source || 'prompt_assumed',
+    validation,
+    processed_audio: processedAudio,
+    processed_audio_status: getProcessedAudioStatus(processedAudio),
+    storage: {
+      storage_type: row.storage_type,
+      storage_key: row.storage_key,
+      object_key:
+        normalizeOptionalString(storageMetadata.object_key) ||
+        normalizeOptionalString(recordingMetadata.object_key) ||
+        null,
+      metadata_object_key:
+        normalizeOptionalString(storageMetadata.metadata_object_key) ||
+        normalizeOptionalString(recordingMetadata.metadata_object_key) ||
+        null,
+      bucket_name:
+        normalizeOptionalString(storageMetadata.bucket_name) ||
+        normalizeOptionalString(recordingMetadata.bucket_name) ||
+        null,
+    },
+  };
+
+  if (options.detail) {
+    sample.metadata = {
+      recording: recordingMetadata,
+      session: sessionMetadata,
+      task: taskMetadata,
+      topic: topicMetadata,
+    };
+    sample.read_only = {
+      device_id: sessionMetadata.device_id || null,
+      speaker_id: null,
+      demographics: normalizePlainObject(sessionMetadata.demographics),
+      environment: normalizePlainObject(sessionMetadata.environment),
+      technical: {
+        session: normalizePlainObject(sessionMetadata.technical),
+        recording: normalizePlainObject(recordingMetadata.technical),
+      },
+      storage_key: row.storage_key,
+      object_key: sample.storage.object_key,
+      bucket_name: sample.storage.bucket_name,
+      processed_audio: processedAudio,
+    };
+    sample.editable = {
+      literal_transcript: sample.literal_transcript,
+      label_source: sample.label_source,
+      validation,
+    };
+  }
+
+  return sample;
+}
+
+function buildSampleSelectSql({ forUpdate = false } = {}) {
+  return `
+    SELECT
+      r.id::text AS recording_id,
+      r.session_id::text AS session_id,
+      r.task_id,
+      r.storage_type,
+      r.storage_key,
+      r.duration_sec,
+      r.submitted_at,
+      COALESCE(r.metadata, '{}'::jsonb) AS recording_metadata,
+      ps.status AS session_status,
+      COALESCE(ps.metadata, '{}'::jsonb) AS session_metadata,
+      ps.created_at AS session_created_at,
+      tk.text AS transcript,
+      tk.text AS prompted_word,
+      COALESCE(tk.metadata, '{}'::jsonb) AS task_metadata,
+      tk.metadata->>'label' AS label,
+      tk.metadata->>'language' AS language,
+      tk.metadata->>'category' AS category,
+      tk.metadata->>'semantic_label' AS semantic_label,
+      t.id AS topic_id,
+      t.name AS topic_name,
+      COALESCE(t.metadata, '{}'::jsonb) AS topic_metadata
+    FROM recordings r
+    JOIN participant_sessions ps
+      ON ps.id = r.session_id
+    JOIN tasks tk
+      ON tk.id = r.task_id
+    JOIN topics t
+      ON t.id = tk.topic_id
+    WHERE r.id = $1
+    ${forUpdate ? 'FOR UPDATE OF r' : ''}
+  `;
+}
+
+function buildAllRowsSql() {
+  return `
+    SELECT
+      r.id::text AS recording_id,
+      r.session_id::text AS session_id,
+      r.task_id,
+      r.storage_type,
+      r.storage_key,
+      r.duration_sec,
+      r.submitted_at,
+      COALESCE(r.metadata, '{}'::jsonb) AS recording_metadata,
+      ps.status AS session_status,
+      COALESCE(ps.metadata, '{}'::jsonb) AS session_metadata,
+      ps.created_at AS session_created_at,
+      tk.text AS transcript,
+      tk.text AS prompted_word,
+      COALESCE(tk.metadata, '{}'::jsonb) AS task_metadata,
+      tk.metadata->>'label' AS label,
+      tk.metadata->>'language' AS language,
+      tk.metadata->>'category' AS category,
+      tk.metadata->>'semantic_label' AS semantic_label,
+      t.id AS topic_id,
+      t.name AS topic_name,
+      COALESCE(t.metadata, '{}'::jsonb) AS topic_metadata
+    FROM recordings r
+    JOIN participant_sessions ps
+      ON ps.id = r.session_id
+    JOIN tasks tk
+      ON tk.id = r.task_id
+    JOIN topics t
+      ON t.id = tk.topic_id
+  `;
+}
+
+function incrementCount(target, key) {
+  const normalizedKey = key || '(missing)';
+  target[normalizedKey] = (target[normalizedKey] || 0) + 1;
+}
+
+function buildStatusCounts(rows) {
+  const counts = {
+    pending: 0,
+    validated: 0,
+    needs_review: 0,
+    rejected: 0,
+  };
+
+  for (const row of rows) {
+    const status = getRecordingValidationStatus(row);
+    counts[status] = (counts[status] || 0) + 1;
+  }
+
+  return counts;
+}
+
+function buildReadiness(rows, activeStorageType, validationFilter) {
+  const status_counts = buildStatusCounts(rows);
+  let missing_metadata_count = 0;
+  let missing_processed_audio_count = 0;
+  let wrong_processed_audio_count = 0;
+  let missing_phrase_id_count = 0;
+  let missing_semantic_label_count = 0;
+  let missing_literal_transcript_key_count = 0;
+  let classifier_ready_validated_count = 0;
+  let exportable_count = 0;
+  let rejected_count = 0;
+
+  for (const row of rows) {
+    const metadata = normalizePlainObject(row.recording_metadata);
+    const taskMetadata = normalizePlainObject(row.task_metadata);
+    const status = getRecordingValidationStatus(row);
+    const processedStatus = getProcessedAudioStatus(metadata.processed_audio);
+
+    if (Object.keys(metadata).length === 0) {
+      missing_metadata_count += 1;
+    }
+
+    if (!Object.hasOwn(metadata, 'literal_transcript')) {
+      missing_literal_transcript_key_count += 1;
+    }
+
+    if (processedStatus === 'missing') {
+      missing_processed_audio_count += 1;
+    } else if (processedStatus === 'wrong_format') {
+      wrong_processed_audio_count += 1;
+    }
+
+    if (!getRowPhraseId(row, metadata, taskMetadata)) {
+      missing_phrase_id_count += 1;
+    }
+
+    if (!getRowSemanticLabel(row, metadata, taskMetadata)) {
+      missing_semantic_label_count += 1;
+    }
+
+    if (status === 'rejected') {
+      rejected_count += 1;
+    }
+
+    if (status === 'validated' && processedStatus === 'ready') {
+      classifier_ready_validated_count += 1;
+    }
+
+    if (
+      ['completed', 'abandoned'].includes(row.session_status) &&
+      row.storage_type === activeStorageType &&
+      isRowExportableByValidationFilter(row, validationFilter)
+    ) {
+      exportable_count += 1;
+    }
+  }
+
+  return {
+    total_recordings: rows.length,
+    status_counts,
+    pending_count: status_counts.pending || 0,
+    validated_count: status_counts.validated || 0,
+    needs_review_count: status_counts.needs_review || 0,
+    rejected_count,
+    classifier_ready_validated_count,
+    exportable_count,
+    validation_filter: validationFilter,
+    missing_metadata_count,
+    missing_processed_audio_count,
+    wrong_processed_audio_count,
+    missing_phrase_id_count,
+    missing_semantic_label_count,
+    missing_literal_transcript_key_count,
+  };
+}
+
+function buildValidationMetadata(existingMetadata, payload, now) {
+  const metadata = { ...normalizePlainObject(existingMetadata) };
+  const validationInput = normalizePlainObject(payload.validation);
+
+  if (Object.hasOwn(payload, 'literal_transcript')) {
+    const result = normalizeNullableString(payload.literal_transcript, 'literal_transcript');
+    if (!result.success) {
+      return result;
+    }
+    metadata.literal_transcript = result.value;
+  }
+
+  if (Object.hasOwn(payload, 'label_source')) {
+    const labelSource = normalizeOptionalString(payload.label_source);
+    if (!ADMIN_LABEL_SOURCES.has(labelSource)) {
+      return {
+        success: false,
+        code: 'invalid_validation_payload',
+        message: 'label_source is invalid.',
+      };
+    }
+    metadata.label_source = labelSource;
+  }
+
+  const existingValidation = normalizePlainObject(metadata.validation);
+  const requestedStatus =
+    normalizeOptionalString(validationInput.status) ||
+    normalizeOptionalString(payload.status) ||
+    getValidationStatusFromMetadata(metadata);
+
+  if (!ADMIN_VALIDATION_STATUSES.has(requestedStatus)) {
+    return {
+      success: false,
+      code: 'invalid_validation_payload',
+      message: 'validation.status is invalid.',
+    };
+  }
+
+  let notes = normalizeOptionalString(existingValidation.notes);
+  if (Object.hasOwn(validationInput, 'notes') || Object.hasOwn(payload, 'notes')) {
+    const result = normalizeNullableString(
+      Object.hasOwn(validationInput, 'notes') ? validationInput.notes : payload.notes,
+      'validation.notes'
+    );
+    if (!result.success) {
+      return result;
+    }
+    notes = result.value;
+  }
+
+  metadata.validation = {
+    status: requestedStatus,
+    validated_at:
+      requestedStatus === 'validated'
+        ? normalizeOptionalString(existingValidation.validated_at) || now
+        : null,
+    notes,
+  };
+
+  if (!Object.hasOwn(metadata, 'literal_transcript')) {
+    metadata.literal_transcript = null;
+  }
+
+  if (!metadata.label_source) {
+    metadata.label_source = 'prompt_assumed';
+  }
+
+  return {
+    success: true,
+    metadata,
+  };
+}
+
+function attachSidecarStorageMetadata(row, fileStorage, metadata) {
+  const sidecarInfo = fileStorage.getMetadataSidecarInfo({
+    ...row,
+    recording_metadata: metadata,
+  });
+  const storageMetadata = normalizePlainObject(metadata.storage);
+
+  return {
+    ...metadata,
+    storage: {
+      ...storageMetadata,
+      object_key:
+        normalizeOptionalString(storageMetadata.object_key) ||
+        normalizeOptionalString(metadata.object_key) ||
+        fileStorage.getRecordingObjectKey({
+          ...row,
+          recording_metadata: metadata,
+        }),
+      bucket_name:
+        normalizeOptionalString(storageMetadata.bucket_name) ||
+        normalizeOptionalString(metadata.bucket_name) ||
+        sidecarInfo.bucket_name ||
+        null,
+      metadata_object_key: sidecarInfo.metadata_object_key,
+    },
+  };
+}
+
+export class AdminService {
+  constructor({ provider, fileStorage, validationFilter = getDatasetValidationFilter() }) {
+    this.provider = provider;
+    this.fileStorage = fileStorage;
+    this.validationFilter = validationFilter;
+  }
+
+  async withClient(run) {
+    if (!this.provider || typeof this.provider.withClient !== 'function') {
+      throw new Error('Admin data access requires a provider with withClient().');
+    }
+
+    return this.provider.withClient(run);
+  }
+
+  async fetchSampleRow(client, id, options = {}) {
+    const result = await client.query(buildSampleSelectSql(options), [id]);
+    return result.rows[0] || null;
+  }
+
+  async fetchAllRows(client) {
+    const result = await client.query(`${buildAllRowsSql()} ORDER BY r.submitted_at DESC`);
+    return result.rows;
+  }
+
+  async listSamples(query = {}) {
+    const limit = normalizeLimit(query.limit);
+    const offset = normalizeOffset(query.offset);
+    const values = [];
+    const filters = [];
+
+    const status = normalizeOptionalString(query.status);
+    if (status && status !== 'all') {
+      if (!ADMIN_VALIDATION_STATUSES.has(status)) {
+        return {
+          success: false,
+          code: 'invalid_filter',
+          message: 'validation status filter is invalid.',
+        };
+      }
+
+      values.push(status);
+      filters.push(`COALESCE(r.metadata->'validation'->>'status', 'pending') = $${values.length}`);
+    }
+
+    const category = normalizeOptionalString(query.category);
+    if (category) {
+      values.push(category);
+      filters.push(
+        `COALESCE(r.metadata->>'category', tk.metadata->>'category') = $${values.length}`
+      );
+    }
+
+    const label = normalizeOptionalString(query.label);
+    if (label) {
+      values.push(label);
+      filters.push(`(
+        COALESCE(r.metadata->>'normalized_label', tk.metadata->>'label') = $${values.length}
+        OR COALESCE(r.metadata->>'semantic_label', tk.metadata->>'semantic_label') = $${values.length}
+      )`);
+    }
+
+    const whereSql = filters.length ? `WHERE ${filters.join(' AND ')}` : '';
+    values.push(limit, offset);
+    const limitIndex = values.length - 1;
+    const offsetIndex = values.length;
+
+    return this.withClient(async (client) => {
+      const rowsResult = await client.query(
+        `
+          ${buildAllRowsSql()}
+          ${whereSql}
+          ORDER BY
+            CASE COALESCE(r.metadata->'validation'->>'status', 'pending')
+              WHEN 'pending' THEN 0
+              WHEN 'needs_review' THEN 1
+              WHEN 'validated' THEN 2
+              WHEN 'rejected' THEN 3
+              ELSE 4
+            END,
+            r.submitted_at DESC
+          LIMIT $${limitIndex}
+          OFFSET $${offsetIndex}
+        `,
+        values
+      );
+      const countResult = await client.query(
+        `
+          SELECT COUNT(*)::integer AS total
+          FROM recordings r
+          JOIN participant_sessions ps
+            ON ps.id = r.session_id
+          JOIN tasks tk
+            ON tk.id = r.task_id
+          ${whereSql}
+        `,
+        values.slice(0, values.length - 2)
+      );
+
+      return {
+        success: true,
+        samples: rowsResult.rows.map((row) => mapAdminSample(row)),
+        pagination: {
+          limit,
+          offset,
+          total: countResult.rows[0]?.total || 0,
+          has_next: offset + rowsResult.rows.length < (countResult.rows[0]?.total || 0),
+          has_previous: offset > 0,
+        },
+      };
+    });
+  }
+
+  async getSample(id) {
+    return this.withClient(async (client) => {
+      const row = await this.fetchSampleRow(client, id);
+      if (!row) {
+        return {
+          success: false,
+          code: 'sample_not_found',
+          message: 'Sample was not found.',
+        };
+      }
+
+      return {
+        success: true,
+        sample: mapAdminSample(row, { detail: true }),
+      };
+    });
+  }
+
+  async getAudioStream(id, rangeHeader) {
+    return this.withClient(async (client) => {
+      const row = await this.fetchSampleRow(client, id);
+      if (!row) {
+        return {
+          success: false,
+          code: 'sample_not_found',
+          message: 'Sample was not found.',
+        };
+      }
+
+      return {
+        success: true,
+        audio: await this.fileStorage.getRecordingAudioStream(row, { rangeHeader }),
+      };
+    });
+  }
+
+  async saveValidation(id, payload = {}) {
+    return this.withClient(async (client) => {
+      await client.query('BEGIN');
+
+      try {
+        const row = await this.fetchSampleRow(client, id, { forUpdate: true });
+        if (!row) {
+          await client.query('ROLLBACK');
+          return {
+            success: false,
+            code: 'sample_not_found',
+            message: 'Sample was not found.',
+          };
+        }
+
+        const updateResult = buildValidationMetadata(
+          row.recording_metadata,
+          normalizePlainObject(payload),
+          new Date().toISOString()
+        );
+        if (!updateResult.success) {
+          await client.query('ROLLBACK');
+          return updateResult;
+        }
+
+        const nextMetadata = attachSidecarStorageMetadata(row, this.fileStorage, updateResult.metadata);
+        const updatedRow = {
+          ...row,
+          recording_metadata: nextMetadata,
+        };
+        const sidecar = buildDatabuilderSidecar(updatedRow);
+        const sidecarWrite = await this.fileStorage.writeJsonSidecar(updatedRow, sidecar);
+
+        await client.query(
+          `
+            UPDATE recordings
+            SET metadata = $2::jsonb
+            WHERE id = $1
+          `,
+          [id, nextMetadata]
+        );
+        await client.query('COMMIT');
+
+        return {
+          success: true,
+          sample: mapAdminSample(updatedRow, { detail: true }),
+          sidecar: {
+            storage_type: sidecarWrite.storage_type,
+            storage_key: sidecarWrite.storage_key,
+            object_key: sidecarWrite.object_key,
+            metadata_object_key: sidecarWrite.metadata_object_key,
+            bucket_name: sidecarWrite.bucket_name,
+          },
+        };
+      } catch (error) {
+        await client.query('ROLLBACK').catch(() => {});
+        throw error;
+      }
+    });
+  }
+
+  async getSummary() {
+    return this.withClient(async (client) => {
+      const rows = await this.fetchAllRows(client);
+      const readiness = buildReadiness(rows, this.fileStorage.storageType, this.validationFilter);
+
+      return {
+        success: true,
+        summary: {
+          total_recordings: rows.length,
+          pending: readiness.pending_count,
+          validated: readiness.validated_count,
+          needs_review: readiness.needs_review_count,
+          rejected: readiness.rejected_count,
+          classifier_ready_validated: readiness.classifier_ready_validated_count,
+          exportable: readiness.exportable_count,
+          missing_metadata: readiness.missing_metadata_count,
+          missing_processed_audio: readiness.missing_processed_audio_count,
+          wrong_processed_audio: readiness.wrong_processed_audio_count,
+        },
+      };
+    });
+  }
+
+  async getDistributions() {
+    return this.withClient(async (client) => {
+      const rows = await this.fetchAllRows(client);
+      const distributions = {
+        category: {},
+        normalized_label: {},
+        semantic_label: {},
+        validation_status: {},
+      };
+
+      for (const row of rows) {
+        const recordingMetadata = normalizePlainObject(row.recording_metadata);
+        const taskMetadata = normalizePlainObject(row.task_metadata);
+        incrementCount(distributions.category, getRowCategory(row, recordingMetadata, taskMetadata));
+        incrementCount(
+          distributions.normalized_label,
+          getRowNormalizedLabel(row, recordingMetadata, taskMetadata)
+        );
+        incrementCount(
+          distributions.semantic_label,
+          getRowSemanticLabel(row, recordingMetadata, taskMetadata)
+        );
+        incrementCount(distributions.validation_status, getRecordingValidationStatus(row));
+      }
+
+      return {
+        success: true,
+        distributions,
+      };
+    });
+  }
+
+  async getExportReadiness() {
+    return this.withClient(async (client) => {
+      const rows = await this.fetchAllRows(client);
+      return {
+        success: true,
+        readiness: buildReadiness(rows, this.fileStorage.storageType, this.validationFilter),
+      };
+    });
+  }
+
+  async getHealth() {
+    return this.withClient(async (client) => {
+      const rows = await this.fetchAllRows(client);
+      const readiness = buildReadiness(rows, this.fileStorage.storageType, this.validationFilter);
+      const categories = new Set();
+      const categoriesWithRecordings = new Set();
+      const warnings = [];
+
+      const v2TaskResult = await client.query(
+        `
+          SELECT
+            COUNT(*)::integer AS task_count,
+            COUNT(*) FILTER (
+              WHERE NOT (
+                COALESCE(metadata, '{}'::jsonb) ? 'phrase_id'
+                AND COALESCE(metadata, '{}'::jsonb) ? 'semantic_label'
+                AND COALESCE(metadata, '{}'::jsonb) ? 'category'
+              )
+            )::integer AS missing_v2_metadata_count
+          FROM tasks
+          WHERE COALESCE(metadata, '{}'::jsonb)->>'dataset_version' = 'v2'
+             OR id LIKE 'short_finnish_responses_v2_%'
+        `
+      );
+
+      const categoryResult = await client.query(`
+        SELECT DISTINCT metadata->>'category' AS category
+        FROM tasks
+        WHERE COALESCE(metadata, '{}'::jsonb) ? 'category'
+        ORDER BY metadata->>'category'
+      `);
+
+      for (const row of categoryResult.rows) {
+        if (row.category) {
+          categories.add(row.category);
+        }
+      }
+
+      for (const row of rows) {
+        const recordingMetadata = normalizePlainObject(row.recording_metadata);
+        const taskMetadata = normalizePlainObject(row.task_metadata);
+        const category = getRowCategory(row, recordingMetadata, taskMetadata);
+        if (category) {
+          categoriesWithRecordings.add(category);
+        }
+      }
+
+      const zeroRecordingCategories = [...categories].filter(
+        (category) => !categoriesWithRecordings.has(category)
+      );
+      const v2TaskCount = v2TaskResult.rows[0]?.task_count || 0;
+      const missingV2MetadataCount = v2TaskResult.rows[0]?.missing_v2_metadata_count || 0;
+      const unexpectedStorageCount = rows.filter(
+        (row) => row.storage_type !== this.fileStorage.storageType
+      ).length;
+
+      if (readiness.missing_metadata_count) {
+        warnings.push({
+          code: 'missing_metadata',
+          count: readiness.missing_metadata_count,
+          message: 'Recordings linked to empty recording metadata exist.',
+        });
+      }
+      if (readiness.missing_phrase_id_count) {
+        warnings.push({
+          code: 'missing_phrase_id',
+          count: readiness.missing_phrase_id_count,
+          message: 'Recordings missing phrase_id exist.',
+        });
+      }
+      if (readiness.missing_semantic_label_count) {
+        warnings.push({
+          code: 'missing_semantic_label',
+          count: readiness.missing_semantic_label_count,
+          message: 'Recordings missing semantic_label exist.',
+        });
+      }
+      if (readiness.missing_literal_transcript_key_count) {
+        warnings.push({
+          code: 'missing_literal_transcript_key',
+          count: readiness.missing_literal_transcript_key_count,
+          message: 'Recordings missing literal_transcript key exist.',
+        });
+      }
+      if (readiness.missing_processed_audio_count) {
+        warnings.push({
+          code: 'missing_processed_audio',
+          count: readiness.missing_processed_audio_count,
+          message: 'Recordings missing processed_audio exist.',
+        });
+      }
+      if (readiness.wrong_processed_audio_count) {
+        warnings.push({
+          code: 'wrong_processed_audio',
+          count: readiness.wrong_processed_audio_count,
+          message: 'Recordings with non-16kHz mono pcm_s16le processed_audio exist.',
+        });
+      }
+      if (v2TaskCount === 0) {
+        warnings.push({
+          code: 'no_v2_tasks',
+          count: 0,
+          message: 'DB has no v2 tasks seeded.',
+        });
+      }
+      if (missingV2MetadataCount) {
+        warnings.push({
+          code: 'tasks_missing_v2_phrase_metadata',
+          count: missingV2MetadataCount,
+          message: 'Tasks missing v2 phrase metadata exist.',
+        });
+      }
+      if (zeroRecordingCategories.length) {
+        warnings.push({
+          code: 'categories_with_zero_recordings',
+          count: zeroRecordingCategories.length,
+          categories: zeroRecordingCategories,
+          message: 'Some seeded categories have zero recordings.',
+        });
+      }
+      if (unexpectedStorageCount) {
+        warnings.push({
+          code: 'storage_type_unexpected',
+          count: unexpectedStorageCount,
+          message: 'Some recordings do not match the active storage mode.',
+        });
+      }
+
+      return {
+        success: true,
+        health: {
+          ready: true,
+          backend_time: new Date().toISOString(),
+          app_environment: process.env.NODE_ENV || 'development',
+          storage_mode: this.fileStorage.storageType,
+          validation_filter: this.validationFilter,
+          warnings,
+        },
+      };
+    });
+  }
+}
+
+export function createAdminRouter(options = {}) {
+  const adminService = options.adminService;
+  const loginAttempts = new Map();
+
+  function sendNotConfigured(res) {
+    return res.status(503).json({
+      success: false,
+      code: 'admin_not_configured',
+      message: 'Admin authentication is not configured.',
+    });
+  }
+
+  function requireConfigured(req, res) {
+    const config = getAdminConfig(options);
+    if (!config.configured) {
+      sendNotConfigured(res);
+      return null;
+    }
+
+    return config;
+  }
+
+  function isAuthenticated(req, config) {
+    const cookies = parseCookies(req.headers.cookie || '');
+    return verifyAdminSessionToken(cookies[ADMIN_COOKIE_NAME], config);
+  }
+
+  function requireAdmin(req, res) {
+    const config = requireConfigured(req, res);
+    if (!config) {
+      return false;
+    }
+
+    if (!isAuthenticated(req, config)) {
+      res.status(401).json({
+        success: false,
+        code: 'admin_auth_required',
+        message: 'Admin authentication is required.',
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  function recordLoginFailure(req) {
+    if (options.disableThrottle) {
+      return;
+    }
+
+    const key = getRequestIp(req);
+    const now = Date.now();
+    const entry = loginAttempts.get(key) || { count: 0, blockedUntil: 0 };
+    const count = entry.blockedUntil > now ? entry.count + 1 : entry.count + 1;
+    loginAttempts.set(key, {
+      count,
+      blockedUntil: count >= 5 ? now + Math.min(count * 500, 5000) : 0,
+    });
+  }
+
+  async function maybeThrottle(req) {
+    if (options.disableThrottle) {
+      return;
+    }
+
+    const entry = loginAttempts.get(getRequestIp(req));
+    const now = Date.now();
+    if (entry?.blockedUntil > now) {
+      await delay(entry.blockedUntil - now);
+    }
+  }
+
+  function clearLoginFailures(req) {
+    loginAttempts.delete(getRequestIp(req));
+  }
+
+  async function handleAdminService(req, res, run) {
+    if (!requireAdmin(req, res)) {
+      return;
+    }
+
+    try {
+      const result = await run(adminService);
+      if (!result.success) {
+        const status = result.code === 'sample_not_found' ? 404 : 400;
+        res.status(status).json(result);
+        return;
+      }
+
+      res.json(result);
+    } catch (error) {
+      console.error('Admin API error:', error);
+      res.status(500).json({
+        success: false,
+        code: 'admin_request_failed',
+        message: 'Admin request failed.',
+      });
+    }
+  }
+
+  return {
+    routes(app) {
+      app.post('/api/admin/login', async (req, res) => {
+        const config = requireConfigured(req, res);
+        if (!config) {
+          return;
+        }
+
+        await maybeThrottle(req);
+        const password = typeof req.body?.password === 'string' ? req.body.password : '';
+        const ok = await verifyAdminPassword(password, config.passwordHash);
+        if (!ok) {
+          recordLoginFailure(req);
+          res.status(401).json({
+            success: false,
+            code: 'invalid_admin_login',
+            message: 'Invalid admin credentials.',
+          });
+          return;
+        }
+
+        clearLoginFailures(req);
+        const token = createAdminSessionToken(config);
+        res.setHeader(
+          'Set-Cookie',
+          serializeAdminCookie(token, req, { maxAgeSeconds: config.ttlHours * 60 * 60 })
+        );
+        res.json({
+          success: true,
+          authenticated: true,
+          ttl_hours: config.ttlHours,
+        });
+      });
+
+      app.post('/api/admin/logout', (req, res) => {
+        res.setHeader('Set-Cookie', serializeAdminCookie('', req, { maxAgeSeconds: 0 }));
+        res.json({ success: true });
+      });
+
+      app.get('/api/admin/me', (req, res) => {
+        const config = requireConfigured(req, res);
+        if (!config) {
+          return;
+        }
+
+        if (!isAuthenticated(req, config)) {
+          res.status(401).json({
+            success: false,
+            authenticated: false,
+            code: 'admin_auth_required',
+            message: 'Admin authentication is required.',
+          });
+          return;
+        }
+
+        res.json({
+          success: true,
+          authenticated: true,
+          admin: {
+            role: 'project_member',
+          },
+        });
+      });
+
+      app.get('/api/admin/samples', (req, res) =>
+        handleAdminService(req, res, (service) => service.listSamples(req.query))
+      );
+
+      app.get('/api/admin/samples/:id', (req, res) =>
+        handleAdminService(req, res, (service) => service.getSample(req.params.id))
+      );
+
+      app.get('/api/admin/samples/:id/audio', async (req, res) => {
+        if (!requireAdmin(req, res)) {
+          return;
+        }
+
+        try {
+          const result = await adminService.getAudioStream(req.params.id, req.headers.range);
+          if (!result.success) {
+            res.status(result.code === 'sample_not_found' ? 404 : 400).json(result);
+            return;
+          }
+
+          const { audio } = result;
+          res.status(audio.statusCode || 200);
+          res.setHeader('Content-Type', audio.contentType || 'audio/wav');
+          if (audio.contentLength !== undefined) {
+            res.setHeader('Content-Length', String(audio.contentLength));
+          }
+          for (const [name, value] of Object.entries(audio.headers || {})) {
+            res.setHeader(name, value);
+          }
+          audio.stream.pipe(res);
+        } catch (error) {
+          console.error('Admin audio stream error:', error);
+          res.status(500).json({
+            success: false,
+            code: 'admin_audio_failed',
+            message: 'Could not stream admin audio.',
+          });
+        }
+      });
+
+      app.post('/api/admin/samples/:id/validation', (req, res) =>
+        handleAdminService(req, res, (service) => service.saveValidation(req.params.id, req.body))
+      );
+
+      app.get('/api/admin/summary', (req, res) =>
+        handleAdminService(req, res, (service) => service.getSummary())
+      );
+
+      app.get('/api/admin/distributions', (req, res) =>
+        handleAdminService(req, res, (service) => service.getDistributions())
+      );
+
+      app.get('/api/admin/export-readiness', (req, res) =>
+        handleAdminService(req, res, (service) => service.getExportReadiness())
+      );
+
+      app.get('/api/admin/health', (req, res) =>
+        handleAdminService(req, res, (service) => service.getHealth())
+      );
+    },
+  };
+}
+
+export function createDefaultAdminService(provider, fileStorage) {
+  return new AdminService({ provider, fileStorage });
+}

--- a/backend/src/admin.test.js
+++ b/backend/src/admin.test.js
@@ -1,0 +1,355 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { Readable } from 'node:stream';
+
+import { AdminService, createAdminPasswordHash, verifyAdminPassword } from './admin.js';
+import { createApp } from './index.js';
+
+function createProvider(overrides = {}) {
+  return {
+    async startSession() {
+      return { success: true, session: { sessionToken: 'session-token' } };
+    },
+    async getCategoryState() {
+      return { success: true, categories: [] };
+    },
+    ...overrides,
+  };
+}
+
+function createFileStorage(overrides = {}) {
+  return {
+    storageType: 'local',
+    async saveRecording() {
+      return {
+        storageType: 'local',
+        storageKey: 'session-123/task-123/recording-123.wav',
+        objectKey: 'session-123/task-123/recording-123.wav',
+        bucketName: null,
+        durationSec: 0.8,
+        processedAudio: {
+          sample_rate_hz: 16000,
+          channel_count: 1,
+          encoding: 'pcm_s16le',
+        },
+      };
+    },
+    ...overrides,
+  };
+}
+
+function createAdminService(overrides = {}) {
+  return {
+    async listSamples() {
+      return { success: true, samples: [], pagination: { total: 0, limit: 25, offset: 0 } };
+    },
+    async getAudioStream() {
+      return {
+        success: true,
+        audio: {
+          stream: Readable.from(Buffer.from('wav-data')),
+          statusCode: 200,
+          contentType: 'audio/wav',
+          contentLength: 8,
+          headers: { 'Accept-Ranges': 'bytes' },
+        },
+      };
+    },
+    async getSummary() {
+      return { success: true, summary: { total_recordings: 0 } };
+    },
+    async getDistributions() {
+      return { success: true, distributions: {} };
+    },
+    async getExportReadiness() {
+      return { success: true, readiness: {} };
+    },
+    async getHealth() {
+      return { success: true, health: { ready: true, warnings: [] } };
+    },
+    ...overrides,
+  };
+}
+
+async function withServer(app, run) {
+  const server = app.listen(0);
+  await once(server, 'listening');
+  const address = server.address();
+  const baseUrl = `http://127.0.0.1:${address.port}`;
+
+  try {
+    await run(baseUrl);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function getSetCookie(response) {
+  return response.headers.get('set-cookie') || '';
+}
+
+test('admin password hashes verify only the matching password', async () => {
+  const hash = await createAdminPasswordHash('correct horse battery staple');
+
+  assert.equal(hash.startsWith('scrypt$'), true);
+  assert.equal(await verifyAdminPassword('correct horse battery staple', hash), true);
+  assert.equal(await verifyAdminPassword('wrong password', hash), false);
+  assert.equal(hash.includes('correct horse battery staple'), false);
+});
+
+test('admin config missing blocks data endpoints', async () => {
+  const app = createApp({
+    provider: createProvider(),
+    fileStorage: createFileStorage(),
+    adminService: createAdminService(),
+    adminPasswordHash: '',
+    adminSessionSecret: '',
+    turnstileSecretKey: '',
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/admin/samples`);
+    const body = await response.json();
+
+    assert.equal(response.status, 503);
+    assert.equal(body.code, 'admin_not_configured');
+    assert.equal(JSON.stringify(body).includes('ADMIN_SESSION_SECRET'), false);
+  });
+});
+
+test('admin login rejects wrong password and accepts correct hash', async () => {
+  const hash = await createAdminPasswordHash('review-password');
+  const app = createApp({
+    provider: createProvider(),
+    fileStorage: createFileStorage(),
+    adminService: createAdminService(),
+    adminPasswordHash: hash,
+    adminSessionSecret: 'test-secret',
+    disableAdminThrottle: true,
+    turnstileSecretKey: '',
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const wrongResponse = await fetch(`${baseUrl}/api/admin/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'wrong' }),
+    });
+    const wrongBody = await wrongResponse.json();
+
+    assert.equal(wrongResponse.status, 401);
+    assert.equal(wrongBody.code, 'invalid_admin_login');
+
+    const loginResponse = await fetch(`${baseUrl}/api/admin/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'review-password' }),
+    });
+    const loginBody = await loginResponse.json();
+    const cookie = getSetCookie(loginResponse);
+
+    assert.equal(loginResponse.status, 200);
+    assert.equal(loginBody.success, true);
+    assert.match(cookie, /HttpOnly/);
+    assert.match(cookie, /SameSite=Lax/);
+    assert.doesNotMatch(cookie, /review-password/);
+
+    const meResponse = await fetch(`${baseUrl}/api/admin/me`, {
+      headers: { Cookie: cookie },
+    });
+    const meBody = await meResponse.json();
+
+    assert.equal(meResponse.status, 200);
+    assert.equal(meBody.authenticated, true);
+    assert.deepEqual(meBody.admin, { role: 'project_member' });
+
+    const logoutResponse = await fetch(`${baseUrl}/api/admin/logout`, {
+      method: 'POST',
+      headers: { Cookie: cookie },
+    });
+    assert.match(getSetCookie(logoutResponse), /Max-Age=0/);
+  });
+});
+
+test('admin data and audio endpoints reject unauthenticated requests', async () => {
+  const hash = await createAdminPasswordHash('review-password');
+  const adminService = createAdminService({
+    async listSamples() {
+      throw new Error('should not be called');
+    },
+  });
+  const app = createApp({
+    provider: createProvider(),
+    fileStorage: createFileStorage(),
+    adminService,
+    adminPasswordHash: hash,
+    adminSessionSecret: 'test-secret',
+    disableAdminThrottle: true,
+    turnstileSecretKey: '',
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const listResponse = await fetch(`${baseUrl}/api/admin/samples`);
+    const audioResponse = await fetch(`${baseUrl}/api/admin/samples/recording-123/audio`);
+
+    assert.equal(listResponse.status, 401);
+    assert.equal(audioResponse.status, 401);
+  });
+});
+
+test('authenticated admin audio endpoint streams through backend', async () => {
+  const hash = await createAdminPasswordHash('review-password');
+  const app = createApp({
+    provider: createProvider(),
+    fileStorage: createFileStorage(),
+    adminService: createAdminService(),
+    adminPasswordHash: hash,
+    adminSessionSecret: 'test-secret',
+    disableAdminThrottle: true,
+    turnstileSecretKey: '',
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const loginResponse = await fetch(`${baseUrl}/api/admin/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'review-password' }),
+    });
+    const cookie = getSetCookie(loginResponse);
+    const audioResponse = await fetch(`${baseUrl}/api/admin/samples/recording-123/audio`, {
+      headers: { Cookie: cookie, Range: 'bytes=0-3' },
+    });
+
+    assert.equal(audioResponse.status, 200);
+    assert.equal(audioResponse.headers.get('content-type'), 'audio/wav');
+    assert.equal(await audioResponse.text(), 'wav-data');
+  });
+});
+
+test('validation update accepts allowed fields and preserves trusted metadata', async () => {
+  const row = {
+    recording_id: '11111111-1111-4111-8111-111111111111',
+    session_id: 'session-123',
+    session_status: 'completed',
+    session_metadata: {
+      schema_version: 'v1',
+      device_id: 'device-123',
+      demographics: {},
+      environment: {},
+      technical: {},
+    },
+    topic_id: 'short_finnish_responses_v2_0001',
+    topic_metadata: {},
+    task_id: 'short_finnish_responses_v2_0001_yes_joo',
+    task_metadata: {
+      phrase_id: 'yes_joo',
+      label: 'joo',
+      semantic_label: 'yes',
+      category: 'yes',
+      language: 'fi',
+    },
+    transcript: 'Joo',
+    label: 'joo',
+    language: 'fi',
+    category: 'yes',
+    storage_type: 'local',
+    storage_key: 'session-123/task-123/recording-123.wav',
+    duration_sec: 0.72,
+    submitted_at: '2026-05-31T10:00:00.000Z',
+    recording_metadata: {
+      schema_version: 'v1',
+      timestamp: '2026-05-31T10:00:00.000Z',
+      prompted_word: 'Joo',
+      phrase_id: 'yes_joo',
+      normalized_label: 'joo',
+      semantic_label: 'yes',
+      literal_transcript: null,
+      label_source: 'prompt_assumed',
+      language: 'fi',
+      category: 'yes',
+      processed_audio: {
+        sample_rate_hz: 16000,
+        channel_count: 1,
+        encoding: 'pcm_s16le',
+      },
+      storage: {
+        object_key: 'session-123/task-123/recording-123.wav',
+        bucket_name: null,
+      },
+    },
+  };
+  let updatedMetadata = null;
+  let writtenSidecar = null;
+  const client = {
+    async query(sql, params = []) {
+      if (sql.includes('SELECT') && sql.includes('FROM recordings')) {
+        return { rows: [row], rowCount: 1 };
+      }
+
+      if (sql.includes('UPDATE recordings')) {
+        updatedMetadata = params[1];
+        return { rows: [], rowCount: 1 };
+      }
+
+      return { rows: [], rowCount: 0 };
+    },
+  };
+  const provider = {
+    async withClient(run) {
+      return run(client);
+    },
+  };
+  const fileStorage = {
+    storageType: 'local',
+    getRecordingObjectKey() {
+      return 'session-123/task-123/recording-123.wav';
+    },
+    getMetadataSidecarInfo() {
+      return {
+        storage_type: 'local',
+        storage_key: 'session-123/task-123/recording-123.json',
+        object_key: 'session-123/task-123/recording-123.json',
+        metadata_object_key: 'session-123/task-123/recording-123.json',
+        bucket_name: null,
+      };
+    },
+    async writeJsonSidecar(_row, sidecar) {
+      writtenSidecar = sidecar;
+      return this.getMetadataSidecarInfo();
+    },
+  };
+  const service = new AdminService({ provider, fileStorage, validationFilter: 'validated' });
+
+  const result = await service.saveValidation(row.recording_id, {
+    literal_transcript: 'Joo',
+    label_source: 'reviewed',
+    validation: {
+      status: 'validated',
+      notes: 'clear sample',
+    },
+    normalized_label: 'malicious',
+    semantic_label: 'malicious',
+    phrase_id: 'malicious',
+    storage_key: 'malicious.wav',
+  });
+
+  assert.equal(result.success, true);
+  assert.equal(updatedMetadata.literal_transcript, 'Joo');
+  assert.equal(updatedMetadata.label_source, 'reviewed');
+  assert.equal(updatedMetadata.validation.status, 'validated');
+  assert.equal(updatedMetadata.validation.notes, 'clear sample');
+  assert.equal(updatedMetadata.normalized_label, 'joo');
+  assert.equal(updatedMetadata.semantic_label, 'yes');
+  assert.equal(updatedMetadata.phrase_id, 'yes_joo');
+  assert.equal(updatedMetadata.storage.metadata_object_key, 'session-123/task-123/recording-123.json');
+  assert.equal(Object.hasOwn(updatedMetadata.validation, 'validated_by'), false);
+  assert.equal(writtenSidecar.normalized_label, 'joo');
+  assert.equal(writtenSidecar.semantic_label, 'yes');
+  assert.equal(writtenSidecar.validation.status, 'validated');
+  assert.equal(writtenSidecar.storage.metadata_object_key, 'session-123/task-123/recording-123.json');
+  assert.equal(Object.hasOwn(writtenSidecar.validation, 'validated_by'), false);
+  assert.equal(JSON.stringify(writtenSidecar).includes('ADMIN_SESSION_SECRET'), false);
+});

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -12,6 +12,9 @@ const DEFAULT_MAX_UPLOAD_BYTES = 2_000_000;
 const DEFAULT_MAX_RECORDING_DURATION_TOLERANCE_SECONDS = 1;
 const DEFAULT_DATASET_ID = 'short_finnish_responses';
 const DEFAULT_DATASET_VERSION = 'v2';
+const DEFAULT_ADMIN_SESSION_TTL_HOURS = 12;
+const DEFAULT_DATASET_VALIDATION_FILTER = 'validated';
+const DATASET_VALIDATION_FILTERS = new Set(['validated', 'not_rejected', 'all']);
 
 function normalizePosixPrefix(prefix) {
   return (prefix || '').replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
@@ -71,6 +74,23 @@ export function getMaxAllowedRecordingDurationSeconds() {
 
 export function getTurnstileSecretKey() {
   return (process.env.TURNSTILE_SECRET_KEY || '').trim();
+}
+
+export function getAdminPasswordHash() {
+  return (process.env.ADMIN_PASSWORD_HASH || '').trim();
+}
+
+export function getAdminSessionSecret() {
+  return (process.env.ADMIN_SESSION_SECRET || '').trim();
+}
+
+export function getAdminSessionTtlHours() {
+  return getPositiveIntegerEnv('ADMIN_SESSION_TTL_HOURS', DEFAULT_ADMIN_SESSION_TTL_HOURS);
+}
+
+export function getDatasetValidationFilter() {
+  const value = (process.env.DATASET_VALIDATION_FILTER || DEFAULT_DATASET_VALIDATION_FILTER).trim();
+  return DATASET_VALIDATION_FILTERS.has(value) ? value : DEFAULT_DATASET_VALIDATION_FILTER;
 }
 
 export function getDatasetId() {

--- a/backend/src/config.test.js
+++ b/backend/src/config.test.js
@@ -2,6 +2,8 @@ import test, { afterEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
+  getAdminSessionTtlHours,
+  getDatasetValidationFilter,
   getMaxRecordingDurationToleranceSeconds,
   getMaxRecordingSeconds,
   getMaxUploadBytes,
@@ -45,4 +47,23 @@ test('config falls back when safety limits are invalid', () => {
   assert.equal(getMaxRecordingSeconds(), 5);
   assert.equal(getMaxUploadBytes(), 2000000);
   assert.equal(getMaxRecordingDurationToleranceSeconds(), 1);
+});
+
+test('config reads admin session TTL with default fallback', () => {
+  delete process.env.ADMIN_SESSION_TTL_HOURS;
+  assert.equal(getAdminSessionTtlHours(), 12);
+
+  process.env.ADMIN_SESSION_TTL_HOURS = '4';
+  assert.equal(getAdminSessionTtlHours(), 4);
+});
+
+test('config defaults validation filter to validated', () => {
+  delete process.env.DATASET_VALIDATION_FILTER;
+  assert.equal(getDatasetValidationFilter(), 'validated');
+
+  process.env.DATASET_VALIDATION_FILTER = 'not_rejected';
+  assert.equal(getDatasetValidationFilter(), 'not_rejected');
+
+  process.env.DATASET_VALIDATION_FILTER = 'invalid';
+  assert.equal(getDatasetValidationFilter(), 'validated');
 });

--- a/backend/src/fileStorage.js
+++ b/backend/src/fileStorage.js
@@ -23,6 +23,65 @@ function toPosixPath(value) {
   return value.replace(/\\/g, '/');
 }
 
+function assertPathInside(rootPath, targetPath) {
+  const relativePath = path.relative(rootPath, targetPath);
+  if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+    throw new Error(`Refusing to access storage path outside recordings root: ${targetPath}`);
+  }
+}
+
+function normalizeOptionalString(value) {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function getRecordingMetadata(recording) {
+  const metadata = recording?.recording_metadata || recording?.metadata || {};
+  return metadata && typeof metadata === 'object' && !Array.isArray(metadata) ? metadata : {};
+}
+
+function getRecordingStorageMetadata(recording) {
+  const metadata = getRecordingMetadata(recording);
+  return metadata.storage && typeof metadata.storage === 'object' && !Array.isArray(metadata.storage)
+    ? metadata.storage
+    : {};
+}
+
+function getRecordingStorageType(recording, fallback) {
+  return normalizeOptionalString(recording?.storage_type) || normalizeOptionalString(recording?.storageType) || fallback;
+}
+
+function parseRangeHeader(rangeHeader, totalSize) {
+  if (!rangeHeader) {
+    return null;
+  }
+
+  const match = /^bytes=(\d*)-(\d*)$/.exec(rangeHeader);
+  if (!match) {
+    return null;
+  }
+
+  let start = match[1] ? Number.parseInt(match[1], 10) : null;
+  let end = match[2] ? Number.parseInt(match[2], 10) : null;
+
+  if (start === null && end === null) {
+    return null;
+  }
+
+  if (start === null) {
+    const suffixLength = Math.min(end, totalSize);
+    start = Math.max(totalSize - suffixLength, 0);
+    end = totalSize - 1;
+  } else if (end === null || end >= totalSize) {
+    end = totalSize - 1;
+  }
+
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start < 0 || end < start || start >= totalSize) {
+    return null;
+  }
+
+  return { start, end };
+}
+
 export const PROCESSED_AUDIO_FFMPEG_OPTIONS = [
   '-c:a pcm_s16le',
   '-ar 16000',
@@ -43,6 +102,15 @@ export function buildRecordingStorageKey(sessionId, taskId, recordingId) {
   }
 
   return normalizeStorageKey(sessionId, taskId, `${recordingId}.wav`);
+}
+
+export function buildMetadataSidecarStorageKey(audioStorageKey) {
+  const storageKey = normalizeStorageKey(audioStorageKey);
+  if (!storageKey) {
+    throw new Error('audioStorageKey is required to build a metadata sidecar storage key.');
+  }
+
+  return /\.wav$/i.test(storageKey) ? storageKey.replace(/\.wav$/i, '.json') : `${storageKey}.json`;
 }
 
 export class RecordingTooLongError extends Error {
@@ -108,13 +176,65 @@ export class FileStorage {
     return normalizeStorageKey(this.collectionAudioPrefix, storageKey);
   }
 
+  getRecordingObjectKey(recording) {
+    const storageMetadata = getRecordingStorageMetadata(recording);
+    const metadata = getRecordingMetadata(recording);
+    const explicitObjectKey =
+      normalizeOptionalString(recording?.objectKey) ||
+      normalizeOptionalString(recording?.object_key) ||
+      normalizeOptionalString(storageMetadata.object_key) ||
+      normalizeOptionalString(metadata.object_key);
+
+    if (explicitObjectKey) {
+      return normalizeStorageKey(explicitObjectKey);
+    }
+
+    const storageKey = normalizeStorageKey(recording?.storage_key || recording?.storageKey);
+    const storageType = getRecordingStorageType(recording, this.storageType);
+    return storageType === 'local' ? storageKey : this.getObjectKey(storageKey);
+  }
+
+  getRecordingBucketName(recording) {
+    const storageMetadata = getRecordingStorageMetadata(recording);
+    const metadata = getRecordingMetadata(recording);
+    return (
+      normalizeOptionalString(recording?.bucketName) ||
+      normalizeOptionalString(recording?.bucket_name) ||
+      normalizeOptionalString(storageMetadata.bucket_name) ||
+      normalizeOptionalString(metadata.bucket_name) ||
+      this.bucketName ||
+      null
+    );
+  }
+
+  getMetadataSidecarInfo(recording) {
+    const storageType = getRecordingStorageType(recording, this.storageType);
+    const audioStorageKey = normalizeStorageKey(recording?.storage_key || recording?.storageKey);
+    const audioObjectKey = this.getRecordingObjectKey(recording);
+    const metadataStorageKey = buildMetadataSidecarStorageKey(audioStorageKey);
+    const metadataObjectKey =
+      storageType === 'local'
+        ? metadataStorageKey
+        : buildMetadataSidecarStorageKey(audioObjectKey || this.getObjectKey(audioStorageKey));
+
+    return {
+      storage_type: storageType,
+      storage_key: metadataStorageKey,
+      object_key: metadataObjectKey,
+      metadata_object_key: metadataObjectKey,
+      bucket_name: this.getRecordingBucketName(recording),
+    };
+  }
+
   getTempFilePath(sessionId, taskId) {
     const timestamp = Date.now();
     return path.join(this.tempRoot, `${sessionId}-${taskId}-${timestamp}.wav`);
   }
 
   getFinalLocalPath(storageKey) {
-    return path.join(this.recordingsRoot, ...storageKey.split('/'));
+    const finalPath = path.join(this.recordingsRoot, ...storageKey.split('/'));
+    assertPathInside(this.recordingsRoot, finalPath);
+    return finalPath;
   }
 
   async reencodeFile(inputPath) {
@@ -204,6 +324,114 @@ export class FileStorage {
 
     await pipeline(response.Body, fs.createWriteStream(destinationPath));
     return destinationPath;
+  }
+
+  async getRecordingAudioStream(recording, options = {}) {
+    const storageType = getRecordingStorageType(recording, this.storageType);
+    const rangeHeader = normalizeOptionalString(options.rangeHeader);
+
+    if (storageType === 'local') {
+      const storageKey = normalizeStorageKey(recording?.storage_key || recording?.storageKey);
+      const filePath = this.getFinalLocalPath(storageKey);
+      const stats = fs.statSync(filePath);
+      const range = parseRangeHeader(rangeHeader, stats.size);
+      const contentLength = range ? range.end - range.start + 1 : stats.size;
+      const stream = range
+        ? fs.createReadStream(filePath, { start: range.start, end: range.end })
+        : fs.createReadStream(filePath);
+
+      return {
+        stream,
+        statusCode: range ? 206 : 200,
+        contentType: 'audio/wav',
+        contentLength,
+        headers: {
+          'Accept-Ranges': 'bytes',
+          ...(range
+            ? { 'Content-Range': `bytes ${range.start}-${range.end}/${stats.size}` }
+            : {}),
+        },
+      };
+    }
+
+    if (storageType === 'aws-s3' || storageType === 'r2') {
+      if (!this.s3Client) {
+        throw new Error(`Storage client is not configured for ${storageType}.`);
+      }
+
+      const objectKey = this.getRecordingObjectKey(recording);
+      const bucketName = this.getRecordingBucketName(recording);
+      if (!objectKey || !bucketName) {
+        throw new Error('Object key and bucket name are required to stream remote audio.');
+      }
+
+      const response = await this.s3Client.send(
+        new GetObjectCommand({
+          Bucket: bucketName,
+          Key: objectKey,
+          ...(rangeHeader ? { Range: rangeHeader } : {}),
+        })
+      );
+
+      if (!response.Body) {
+        throw new Error(`Storage object ${objectKey} did not include a response body.`);
+      }
+
+      return {
+        stream: response.Body,
+        statusCode: rangeHeader ? 206 : 200,
+        contentType: response.ContentType || 'audio/wav',
+        contentLength: response.ContentLength,
+        headers: {
+          'Accept-Ranges': 'bytes',
+          ...(response.ContentRange ? { 'Content-Range': response.ContentRange } : {}),
+        },
+      };
+    }
+
+    throw new Error(`Unsupported storage type for audio stream: ${storageType}`);
+  }
+
+  async writeJsonSidecar(recording, data) {
+    const storageType = getRecordingStorageType(recording, this.storageType);
+    const sidecarInfo = this.getMetadataSidecarInfo(recording);
+    const body =
+      typeof data === 'string'
+        ? Buffer.from(data, 'utf-8')
+        : Buffer.from(`${JSON.stringify(data, null, 2)}\n`, 'utf-8');
+
+    if (storageType === 'local') {
+      const filePath = this.getFinalLocalPath(sidecarInfo.storage_key);
+      ensureDirectory(path.dirname(filePath));
+      fs.writeFileSync(filePath, body);
+      return {
+        ...sidecarInfo,
+        file_path: filePath,
+      };
+    }
+
+    if (storageType === 'aws-s3' || storageType === 'r2') {
+      if (!this.s3Client) {
+        throw new Error(`Storage client is not configured for ${storageType}.`);
+      }
+
+      if (!sidecarInfo.bucket_name) {
+        throw new Error('Bucket name is required to write a metadata sidecar.');
+      }
+
+      await this.s3Client.send(
+        new PutObjectCommand({
+          Bucket: sidecarInfo.bucket_name,
+          Key: sidecarInfo.metadata_object_key,
+          Body: body,
+          ContentType: 'application/json',
+        })
+      );
+
+      return sidecarInfo;
+    }
+
+    throw new Error(`Unsupported storage type for metadata sidecar: ${storageType}`);
   }
 
   async saveRecording(file, { sessionId, taskId, recordingId }) {

--- a/backend/src/fileStorage.test.js
+++ b/backend/src/fileStorage.test.js
@@ -1,7 +1,11 @@
 import fs from 'fs';
 import path from 'path';
+import { execFile } from 'node:child_process';
 import test, { afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { promisify } from 'node:util';
+import ffmpegPath from 'ffmpeg-static';
+import ffprobe from 'ffprobe-static';
 
 import { inferAudioRoot } from '../../scripts/aina/exportDataset.js';
 import { getSpeechCollectorRoot, getSoundRecordingsRoot } from './config.js';
@@ -15,6 +19,7 @@ import {
 
 const originalEnv = { ...process.env };
 const cleanupPaths = [];
+const execFileAsync = promisify(execFile);
 
 afterEach(() => {
   for (const key of Object.keys(process.env)) {
@@ -41,6 +46,52 @@ test('buildRecordingStorageKey uses a unique session/task/recording layout', () 
   );
 });
 
+async function generateTinyAudioFixture(outputPath, outputOptions) {
+  try {
+    await execFileAsync(ffmpegPath, [
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-f',
+      'lavfi',
+      '-i',
+      'sine=frequency=440:duration=0.25',
+      ...outputOptions,
+      '-y',
+      outputPath,
+    ]);
+  } catch (error) {
+    const stderr = typeof error?.stderr === 'string' ? error.stderr.trim() : '';
+    throw new Error(stderr || error.message);
+  }
+}
+
+async function probeAudioFile(inputPath) {
+  const { stdout } = await execFileAsync(ffprobe.path, [
+    '-v',
+    'error',
+    '-select_streams',
+    'a:0',
+    '-show_entries',
+    'stream=codec_name,sample_rate,channels',
+    '-of',
+    'json',
+    inputPath,
+  ]);
+
+  return JSON.parse(stdout).streams?.[0] || {};
+}
+
+async function assertReencodedFixture(inputPath) {
+  const storage = new FileStorage('local');
+  await storage.reencodeFile(inputPath);
+
+  const metadata = await probeAudioFile(inputPath);
+  assert.equal(metadata.codec_name, 'pcm_s16le');
+  assert.equal(metadata.sample_rate, '16000');
+  assert.equal(metadata.channels, 1);
+}
+
 test('buildMetadataSidecarStorageKey replaces wav extension with json', () => {
   assert.equal(
     buildMetadataSidecarStorageKey('session-123/task-456/recording-789.wav'),
@@ -59,6 +110,38 @@ test('processed audio ffmpeg options enforce 16 kHz mono PCM WAV', () => {
     channel_count: 1,
     encoding: 'pcm_s16le',
   });
+});
+
+test('reencodeFile normalizes WebM Opus input to 16 kHz mono PCM audio', async () => {
+  const appRoot = getSpeechCollectorRoot();
+  const testParent = path.join(appRoot, 'tmp');
+  fs.mkdirSync(testParent, { recursive: true });
+
+  const tempRoot = fs.mkdtempSync(path.join(testParent, 'webm-reencode-root-'));
+  cleanupPaths.push(tempRoot);
+
+  const inputPath = path.join(tempRoot, 'browser-webm-bytes-in-wav-temp-file.wav');
+  process.env.STORAGE = 'local';
+  process.env.SOUND_RECORDINGS_PATH = path.relative(appRoot, path.join(tempRoot, 'recordings'));
+
+  await generateTinyAudioFixture(inputPath, ['-c:a', 'libopus', '-f', 'webm']);
+  await assertReencodedFixture(inputPath);
+});
+
+test('reencodeFile normalizes MP4 AAC input to 16 kHz mono PCM audio', async () => {
+  const appRoot = getSpeechCollectorRoot();
+  const testParent = path.join(appRoot, 'tmp');
+  fs.mkdirSync(testParent, { recursive: true });
+
+  const tempRoot = fs.mkdtempSync(path.join(testParent, 'mp4-reencode-root-'));
+  cleanupPaths.push(tempRoot);
+
+  const inputPath = path.join(tempRoot, 'browser-mp4-bytes-in-wav-temp-file.wav');
+  process.env.STORAGE = 'local';
+  process.env.SOUND_RECORDINGS_PATH = path.relative(appRoot, path.join(tempRoot, 'recordings'));
+
+  await generateTinyAudioFixture(inputPath, ['-c:a', 'aac', '-f', 'mp4']);
+  await assertReencodedFixture(inputPath);
 });
 
 test('relative SOUND_RECORDINGS_PATH resolves from the speech-collector root in backend and exporter', () => {

--- a/backend/src/fileStorage.test.js
+++ b/backend/src/fileStorage.test.js
@@ -6,6 +6,7 @@ import assert from 'node:assert/strict';
 import { inferAudioRoot } from '../../scripts/aina/exportDataset.js';
 import { getSpeechCollectorRoot, getSoundRecordingsRoot } from './config.js';
 import {
+  buildMetadataSidecarStorageKey,
   buildRecordingStorageKey,
   FileStorage,
   getProcessedAudioMetadata,
@@ -37,6 +38,13 @@ test('buildRecordingStorageKey uses a unique session/task/recording layout', () 
       'recording-789'
     ),
     'session-123/short_finnish_responses_v2_0001_yes_kylla/recording-789.wav'
+  );
+});
+
+test('buildMetadataSidecarStorageKey replaces wav extension with json', () => {
+  assert.equal(
+    buildMetadataSidecarStorageKey('session-123/task-456/recording-789.wav'),
+    'session-123/task-456/recording-789.json'
   );
 });
 
@@ -95,6 +103,72 @@ test('local persistence writes files under the same root the exporter publishes'
 
   assert.equal(finalPath, expectedPath);
   assert.equal(fs.readFileSync(finalPath, 'utf-8'), 'wav-data');
+});
+
+test('local JSON sidecar is written beside the wav file', async () => {
+  const appRoot = getSpeechCollectorRoot();
+  const testParent = path.join(appRoot, 'tmp');
+  fs.mkdirSync(testParent, { recursive: true });
+
+  const tempRoot = fs.mkdtempSync(path.join(testParent, 'sidecar-root-'));
+  cleanupPaths.push(tempRoot);
+
+  const recordingsRoot = path.join(tempRoot, 'recordings');
+  process.env.STORAGE = 'local';
+  process.env.SOUND_RECORDINGS_PATH = path.relative(appRoot, recordingsRoot);
+
+  const storage = new FileStorage('local');
+  const result = await storage.writeJsonSidecar(
+    {
+      storage_type: 'local',
+      storage_key: 'session-123/task-456/recording-789.wav',
+      recording_metadata: {
+        storage: {
+          object_key: 'session-123/task-456/recording-789.wav',
+        },
+      },
+    },
+    { sample_id: 'recording-789' }
+  );
+
+  const expectedPath = path.join(recordingsRoot, 'session-123', 'task-456', 'recording-789.json');
+  assert.equal(result.metadata_object_key, 'session-123/task-456/recording-789.json');
+  assert.equal(fs.existsSync(expectedPath), true);
+  assert.equal(JSON.parse(fs.readFileSync(expectedPath, 'utf-8')).sample_id, 'recording-789');
+});
+
+test('local audio stream supports byte ranges', async () => {
+  const appRoot = getSpeechCollectorRoot();
+  const testParent = path.join(appRoot, 'tmp');
+  fs.mkdirSync(testParent, { recursive: true });
+
+  const tempRoot = fs.mkdtempSync(path.join(testParent, 'audio-stream-root-'));
+  cleanupPaths.push(tempRoot);
+
+  const recordingsRoot = path.join(tempRoot, 'recordings');
+  const audioPath = path.join(recordingsRoot, 'session-123', 'task-456', 'recording-789.wav');
+  process.env.STORAGE = 'local';
+  process.env.SOUND_RECORDINGS_PATH = path.relative(appRoot, recordingsRoot);
+  fs.mkdirSync(path.dirname(audioPath), { recursive: true });
+  fs.writeFileSync(audioPath, Buffer.from('0123456789'));
+
+  const storage = new FileStorage('local');
+  const result = await storage.getRecordingAudioStream(
+    {
+      storage_type: 'local',
+      storage_key: 'session-123/task-456/recording-789.wav',
+    },
+    { rangeHeader: 'bytes=2-5' }
+  );
+  const chunks = [];
+  for await (const chunk of result.stream) {
+    chunks.push(chunk);
+  }
+
+  assert.equal(result.statusCode, 206);
+  assert.equal(result.contentLength, 4);
+  assert.equal(Buffer.concat(chunks).toString('utf-8'), '2345');
+  assert.equal(result.headers['Content-Range'], 'bytes 2-5/10');
 });
 
 test('saveRecording returns processed audio metadata with persisted local recordings', async () => {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -5,7 +5,7 @@ import { randomUUID } from 'crypto';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
-import { TaskProvider } from './taskProvider.js';
+import { hasRequiredConsentMetadata, TaskProvider } from './taskProvider.js';
 import { FileStorage, RecordingTooLongError } from './fileStorage.js';
 import { createAdminRouter, createDefaultAdminService } from './admin.js';
 import {
@@ -246,7 +246,16 @@ export function createApp(options = {}) {
       }
 
       const sessionToken = normalizeSessionToken(req.body?.sessionToken);
-      const result = await provider.startSession(sessionToken);
+      const metadata = req.body?.metadata;
+      if (!hasRequiredConsentMetadata(metadata)) {
+        return res.status(400).json({
+          success: false,
+          code: 'consent_required',
+          message: 'Valid consent and 18+ confirmation are required before starting a session.',
+        });
+      }
+
+      const result = await provider.startSession(sessionToken, metadata);
       res.status(200).json(result);
     } catch (error) {
       console.error('Error in /api/start-session:', error);

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'url';
 
 import { TaskProvider } from './taskProvider.js';
 import { FileStorage, RecordingTooLongError } from './fileStorage.js';
+import { createAdminRouter, createDefaultAdminService } from './admin.js';
 import {
   getDbConnectionString,
   getMaxUploadBytes,
@@ -209,15 +210,24 @@ export function createApp(options = {}) {
   const provider = options.provider || createDefaultProvider();
   const fileStorage = options.fileStorage || createDefaultFileStorage();
   const upload = options.upload || createDefaultUpload();
+  const adminService = options.adminService || createDefaultAdminService(provider, fileStorage);
   const turnstileSecretKey =
     options.turnstileSecretKey === undefined ? getTurnstileSecretKey() : options.turnstileSecretKey;
   const fetchImpl = options.fetchImpl || fetch;
 
   const app = express();
 
-  app.use(cors({ origin: process.env.APP_URL }));
+  app.use(cors({ origin: process.env.APP_URL, credentials: true }));
   app.use(express.json());
   app.use(express.urlencoded({ extended: true }));
+
+  createAdminRouter({
+    adminService,
+    passwordHash: options.adminPasswordHash,
+    sessionSecret: options.adminSessionSecret,
+    sessionTtlHours: options.adminSessionTtlHours,
+    disableThrottle: options.disableAdminThrottle,
+  }).routes(app);
 
   app.post('/api/start-session', async (req, res) => {
     try {

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -11,14 +11,26 @@ import {
 } from './index.js';
 import { RecordingTooLongError } from './fileStorage.js';
 
+const validConsentMetadata = {
+  schema_version: 'v1',
+  device_id: 'browser-device-id',
+  consent_response: 'yes',
+  consent_version: '1.0',
+  privacy_notice_version: '1.0',
+  consent_accepted_at: '2026-06-03T12:00:00.000Z',
+  age_confirmed_18_or_over: true,
+  technical: {},
+};
+
 function createProvider(overrides = {}) {
   return {
     startSessionCalls: 0,
     getCategoryStateCalls: 0,
     getUploadTargetCalls: 0,
     submitRecordingCalls: 0,
-    async startSession() {
+    async startSession(_sessionToken, metadata) {
       this.startSessionCalls += 1;
+      this.lastStartSessionMetadata = metadata;
       return { success: true, session: { sessionToken: 'session-token' } };
     },
     async getUploadTarget() {
@@ -246,6 +258,51 @@ test('Turnstile failure rejects session start before creating a session', async 
     assert.equal(response.status, 400);
     assert.equal(body.code, 'turnstile_failed');
     assert.equal(provider.startSessionCalls, 0);
+  });
+});
+
+test('start-session rejects missing consent metadata before provider start', async () => {
+  const provider = createProvider();
+  const app = createApp({
+    provider,
+    fileStorage: createFileStorage(),
+    turnstileSecretKey: '',
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/start-session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 400);
+    assert.equal(body.code, 'consent_required');
+    assert.equal(provider.startSessionCalls, 0);
+  });
+});
+
+test('start-session passes valid consent metadata to provider', async () => {
+  const provider = createProvider();
+  const app = createApp({
+    provider,
+    fileStorage: createFileStorage(),
+    turnstileSecretKey: '',
+  });
+
+  await withServer(app, async (baseUrl) => {
+    const response = await fetch(`${baseUrl}/api/start-session`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ metadata: validConsentMetadata }),
+    });
+    const body = await response.json();
+
+    assert.equal(response.status, 200);
+    assert.equal(body.success, true);
+    assert.equal(provider.startSessionCalls, 1);
+    assert.deepEqual(provider.lastStartSessionMetadata, validConsentMetadata);
   });
 });
 

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -60,8 +60,10 @@ function createProvider(overrides = {}) {
         categories: [],
       };
     },
-    async submitRecording(_sessionToken, _taskId, recordingDetails) {
+    async submitRecording(sessionToken, taskId, recordingDetails) {
       this.submitRecordingCalls += 1;
+      this.lastSubmitSessionToken = sessionToken;
+      this.lastSubmitTaskId = taskId;
       this.lastRecordingDetails = recordingDetails;
       return { success: true, sessionStatus: 'active' };
     },
@@ -72,8 +74,9 @@ function createProvider(overrides = {}) {
 function createFileStorage(overrides = {}) {
   return {
     saveRecordingCalls: 0,
-    async saveRecording(_file, options) {
+    async saveRecording(file, options) {
       this.saveRecordingCalls += 1;
+      this.lastFile = file;
       this.lastSaveOptions = options;
       const storageKey = `${options.sessionId}/${options.taskId}/${options.recordingId}.wav`;
       return {
@@ -108,7 +111,12 @@ async function withServer(app, run) {
   }
 }
 
-function createUploadForm({ metadata = undefined, fileBytes = 'wav-data' } = {}) {
+function createUploadForm({
+  metadata = undefined,
+  fileBytes = 'wav-data',
+  fileType = 'audio/wav',
+  filename = 'task-123.wav',
+} = {}) {
   const form = new FormData();
   form.set('sessionToken', 'session-token');
   form.set('taskId', 'task-123');
@@ -116,7 +124,7 @@ function createUploadForm({ metadata = undefined, fileBytes = 'wav-data' } = {})
     form.set('metadata', metadata);
   }
 
-  form.set('file', new Blob([fileBytes], { type: 'audio/wav' }), 'task-123.wav');
+  form.set('file', new Blob([fileBytes], { type: fileType }), filename);
   return form;
 }
 
@@ -351,9 +359,18 @@ test('session metadata guard rejection prevents storage and DB submit', async ()
     const response = await fetch(`${baseUrl}/api/upload-sound`, {
       method: 'POST',
       body: createUploadForm({
+        fileType: 'audio/webm;codecs=opus',
+        filename: 'task-123.webm',
         metadata: JSON.stringify({
-          literal_transcript: null,
-          label_source: 'prompt_assumed',
+          literal_transcript: 'kyl',
+          label_source: 'user_confirmed',
+          technical: {
+            sample_rate_hz: 48000,
+            channel_count: 1,
+            media_stream_settings: {
+              echoCancellation: true,
+            },
+          },
         }),
       }),
     });
@@ -381,9 +398,18 @@ test('upload continues past upload target when session metadata is valid', async
     const response = await fetch(`${baseUrl}/api/upload-sound`, {
       method: 'POST',
       body: createUploadForm({
+        fileType: 'audio/webm;codecs=opus',
+        filename: 'task-123.webm',
         metadata: JSON.stringify({
-          literal_transcript: null,
-          label_source: 'prompt_assumed',
+          literal_transcript: 'kyl',
+          label_source: 'user_confirmed',
+          technical: {
+            sample_rate_hz: 48000,
+            channel_count: 1,
+            media_stream_settings: {
+              echoCancellation: true,
+            },
+          },
         }),
       }),
     });
@@ -394,6 +420,12 @@ test('upload continues past upload target when session metadata is valid', async
     assert.equal(provider.getUploadTargetCalls, 1);
     assert.equal(fileStorage.saveRecordingCalls, 1);
     assert.equal(provider.submitRecordingCalls, 1);
+    assert.equal(provider.lastSubmitSessionToken, 'session-token');
+    assert.equal(provider.lastSubmitTaskId, 'task-123');
+    assert.equal(fileStorage.lastSaveOptions.sessionId, 'session-123');
+    assert.equal(fileStorage.lastSaveOptions.taskId, 'task-123');
+    assert.equal(fileStorage.lastFile.originalname, 'task-123.webm');
+    assert.equal(fileStorage.lastFile.mimetype, 'audio/webm');
     assert.match(fileStorage.lastSaveOptions.recordingId, /^[0-9a-f-]{36}$/);
     assert.equal(provider.lastRecordingDetails.recordingId, fileStorage.lastSaveOptions.recordingId);
     assert.equal(
@@ -402,6 +434,15 @@ test('upload continues past upload target when session metadata is valid', async
     );
     assert.equal(provider.lastRecordingDetails.metadata.phrase_id, 'yes_kylla');
     assert.equal(provider.lastRecordingDetails.metadata.semantic_label, 'yes');
+    assert.equal(provider.lastRecordingDetails.metadata.literal_transcript, 'kyl');
+    assert.equal(provider.lastRecordingDetails.metadata.label_source, 'user_confirmed');
+    assert.deepEqual(provider.lastRecordingDetails.metadata.technical, {
+      sample_rate_hz: 48000,
+      channel_count: 1,
+      media_stream_settings: {
+        echoCancellation: true,
+      },
+    });
     assert.deepEqual(provider.lastRecordingDetails.metadata.processed_audio, {
       sample_rate_hz: 16000,
       channel_count: 1,

--- a/backend/src/taskProvider.js
+++ b/backend/src/taskProvider.js
@@ -9,6 +9,9 @@ export const SESSION_STATUS = {
   ABANDONED: 'abandoned',
 };
 
+export const CONSENT_VERSION = '1.0';
+export const PRIVACY_NOTICE_VERSION = '1.0';
+
 export function calculateProgress(totalTasks, completedTasks) {
   const total = Number.parseInt(totalTasks, 10) || 0;
   const completed = Number.parseInt(completedTasks, 10) || 0;
@@ -35,12 +38,31 @@ function hasNonEmptyString(value) {
   return typeof value === 'string' && value.trim().length > 0;
 }
 
+function isValidIsoTimestamp(value) {
+  if (!hasNonEmptyString(value)) {
+    return false;
+  }
+
+  return Number.isFinite(Date.parse(value));
+}
+
+export function hasRequiredConsentMetadata(metadata) {
+  return (
+    isPlainObject(metadata) &&
+    metadata.consent_response === 'yes' &&
+    metadata.consent_version === CONSENT_VERSION &&
+    metadata.privacy_notice_version === PRIVACY_NOTICE_VERSION &&
+    isValidIsoTimestamp(metadata.consent_accepted_at) &&
+    metadata.age_confirmed_18_or_over === true
+  );
+}
+
 export function hasRequiredSessionMetadata(metadata) {
   return (
     isPlainObject(metadata) &&
     metadata.schema_version === 'v1' &&
     hasNonEmptyString(metadata.device_id) &&
-    metadata.consent_response === 'yes' &&
+    hasRequiredConsentMetadata(metadata) &&
     isPlainObject(metadata.demographics) &&
     isPlainObject(metadata.environment) &&
     isPlainObject(metadata.technical)
@@ -501,13 +523,30 @@ export class TaskProvider {
     );
   }
 
-  async startSession(existingToken = null) {
+  async startSession(existingToken = null, metadata = {}) {
     return this.withClient(async (client) => {
       await this.expireStaleSessions(client);
+      const consentMetadata = normalizeMetadata(metadata);
 
       if (existingToken) {
         const existingSession = await this.getSessionSummaryByToken(client, existingToken);
         if (existingSession?.status === SESSION_STATUS.ACTIVE) {
+          if (!hasRequiredConsentMetadata(existingSession.metadata)) {
+            if (!hasRequiredConsentMetadata(consentMetadata)) {
+              return {
+                success: false,
+                code: 'consent_required',
+                message:
+                  'Valid consent and 18+ confirmation are required before starting a session.',
+              };
+            }
+
+            await this.updateSessionMetadataDocument(client, existingSession.id, {
+              ...existingSession.metadata,
+              ...consentMetadata,
+            });
+          }
+
           await this.touchSession(client, existingSession.id);
           return {
             success: true,
@@ -515,6 +554,14 @@ export class TaskProvider {
             session: await this.getSessionSummaryByToken(client, existingToken),
           };
         }
+      }
+
+      if (!hasRequiredConsentMetadata(consentMetadata)) {
+        return {
+          success: false,
+          code: 'consent_required',
+          message: 'Valid consent and 18+ confirmation are required before starting a session.',
+        };
       }
 
       const sessionToken = randomUUID();
@@ -561,10 +608,10 @@ export class TaskProvider {
         const topicId = topicResult.rows[0].id;
         await client.query(
           `
-            INSERT INTO participant_sessions (session_token, topic_id, status)
-            VALUES ($1, $2, $3)
+            INSERT INTO participant_sessions (session_token, topic_id, status, metadata)
+            VALUES ($1, $2, $3, $4::jsonb)
           `,
-          [sessionToken, topicId, SESSION_STATUS.ACTIVE]
+          [sessionToken, topicId, SESSION_STATUS.ACTIVE, consentMetadata]
         );
 
         await client.query('COMMIT');
@@ -848,6 +895,20 @@ export class TaskProvider {
           success: false,
           code: 'session_not_active',
           message: 'Only active sessions can be updated.',
+          session,
+        };
+      }
+
+      const nextMetadata = {
+        ...normalizeMetadata(session.metadata),
+        ...normalizeMetadata(metadata),
+      };
+
+      if (!hasRequiredConsentMetadata(nextMetadata)) {
+        return {
+          success: false,
+          code: 'consent_required',
+          message: 'Valid consent and 18+ confirmation are required before updating session details.',
           session,
         };
       }

--- a/backend/src/taskProvider.test.js
+++ b/backend/src/taskProvider.test.js
@@ -13,6 +13,10 @@ const validV1SessionMetadata = {
   schema_version: 'v1',
   device_id: 'browser-device-id',
   consent_response: 'yes',
+  consent_version: '1.0',
+  privacy_notice_version: '1.0',
+  consent_accepted_at: '2026-06-03T12:00:00.000Z',
+  age_confirmed_18_or_over: true,
   demographics: {},
   environment: {},
   technical: {},
@@ -92,6 +96,20 @@ test('hasRequiredSessionMetadata rejects missing or incomplete metadata', () => 
   assert.equal(
     hasRequiredSessionMetadata({
       ...validV1SessionMetadata,
+      age_confirmed_18_or_over: false,
+    }),
+    false
+  );
+  assert.equal(
+    hasRequiredSessionMetadata({
+      ...validV1SessionMetadata,
+      consent_accepted_at: '',
+    }),
+    false
+  );
+  assert.equal(
+    hasRequiredSessionMetadata({
+      ...validV1SessionMetadata,
       technical: null,
     }),
     false
@@ -100,6 +118,26 @@ test('hasRequiredSessionMetadata rejects missing or incomplete metadata', () => 
 
 test('hasRequiredSessionMetadata accepts valid v1 metadata shape', () => {
   assert.equal(hasRequiredSessionMetadata(validV1SessionMetadata), true);
+});
+
+test('startSession rejects missing consent metadata before topic allocation', async () => {
+  const provider = new TaskProvider('postgresql://example');
+  let queryCount = 0;
+
+  provider.withClient = async (run) =>
+    run({
+      query: async () => {
+        queryCount += 1;
+        return { rowCount: 0, rows: [] };
+      },
+    });
+  provider.expireStaleSessions = async () => {};
+
+  const result = await provider.startSession(null, {});
+
+  assert.equal(result.success, false);
+  assert.equal(result.code, 'consent_required');
+  assert.equal(queryCount, 0);
 });
 
 test('getUploadTarget rejects sessions without completed v1 metadata before task lookup', async () => {

--- a/docs/admin-validation-ui.md
+++ b/docs/admin-validation-ui.md
@@ -1,0 +1,126 @@
+# Admin Validation UI
+
+## Purpose
+
+The internal admin validation UI lets project members review collected Speech Collector samples, listen to recordings, edit safe review metadata, and mark each sample as `pending`, `validated`, `needs_review`, or `rejected`.
+
+The route is internal:
+
+```text
+/#/admin
+```
+
+There is no visible admin link in the volunteer recording UI. Volunteers should use the normal collection route.
+
+## Deployment Compatibility
+
+The admin UI fits the current production path:
+
+```text
+Cloudflare -> Nginx -> static React frontend + /api backend -> local PostgreSQL + Cloudflare R2
+```
+
+The frontend uses `/#/admin`, so no Nginx static fallback route is required. All admin API calls live under `/api/admin/*`, so the existing `/api` proxy handles them. The frontend never receives PostgreSQL, R2, Turnstile, or admin session credentials.
+
+The existing remote build path remains compatible:
+
+```text
+/var/www/speech-collector/scripts/build-remote.sh
+```
+
+## Authentication
+
+Admin login is shared-password only. There is no username and the system does not store `validated_by`.
+
+Required server `.env` additions:
+
+```env
+ADMIN_PASSWORD_HASH=
+ADMIN_SESSION_SECRET=
+ADMIN_SESSION_TTL_HOURS=12
+DATASET_VALIDATION_FILTER=validated
+```
+
+Generate the password hash:
+
+```bash
+pnpm run admin:hash-password
+```
+
+For non-interactive secret setup:
+
+```bash
+printf '%s' '<password>' | pnpm run admin:hash-password -- --stdin
+```
+
+The command prints only the hash. Do not put the plaintext password in code, `.env`, docs, shell history, or PR text.
+
+Admin sessions use an HTTP-only cookie with `SameSite=Lax`; the cookie is marked `Secure` in production or when the backend sees HTTPS through the proxy. `ADMIN_SESSION_TTL_HOURS` defaults to 12.
+
+If admin env vars are missing, `/api/admin/*` returns `admin_not_configured` and does not expose sample data.
+
+## Editable Fields
+
+v1 allows editing only:
+
+- `literal_transcript`
+- `label_source`
+- `validation.status`
+- `validation.notes`
+
+Allowed `label_source` values:
+
+- `prompt_assumed`
+- `user_confirmed`
+- `reviewed`
+
+Allowed statuses:
+
+- `pending`
+- `validated`
+- `needs_review`
+- `rejected`
+
+Trusted fields are read-only in v1, including `normalized_label`, `semantic_label`, `phrase_id`, `category`, `language`, processed-audio metadata, and storage keys. Future label correction should use separate reviewed fields rather than overwriting trusted task metadata.
+
+## Sidecar Writes
+
+When validation is saved, the backend:
+
+1. Checks the admin cookie.
+2. Loads the recording, session, task, and topic context from PostgreSQL.
+3. Applies only allowed metadata changes.
+4. Updates `recordings.metadata`.
+5. Writes a complete JSON sidecar beside the WAV in local storage or R2/S3-compatible storage.
+
+Example:
+
+```text
+short-finnish-responses/v2/audio/session_id/task_id/recording_id.wav
+short-finnish-responses/v2/audio/session_id/task_id/recording_id.json
+```
+
+The sidecar includes dataset-ready metadata such as sample ID, prompt labels, validation status, processed-audio metadata, pseudonymous device/speaker IDs, collection fields, and storage object keys. It does not include secrets, usernames, plaintext passwords, or `validated_by`.
+
+## Export Behavior
+
+Validation affects exports immediately through `DATASET_VALIDATION_FILTER`.
+
+Supported values:
+
+- `validated`: export only recordings whose validation status is `validated`.
+- `not_rejected`: export pending, needs_review, and validated recordings; exclude rejected.
+- `all`: export all otherwise eligible recordings.
+
+Missing or invalid values default to `validated`.
+
+Both normal export and databuilder export respect the filter. In `validated` mode, pending, needs_review, rejected, and missing-status legacy rows are not exported. In `not_rejected` mode, rejected rows are excluded. In `all` mode, validation status does not affect eligibility.
+
+## v1 Limitations
+
+- No delete action.
+- No download button.
+- No direct label editing.
+- No usernames.
+- No `validated_by`.
+- No frontend access to PostgreSQL or R2 credentials.

--- a/docs/aina-data-contract.md
+++ b/docs/aina-data-contract.md
@@ -27,6 +27,10 @@ Required v1 shape:
   "schema_version": "v1",
   "device_id": "anonymous-browser-uuid",
   "consent_response": "yes",
+  "consent_version": "1.0",
+  "privacy_notice_version": "1.0",
+  "consent_accepted_at": "2026-06-03T12:00:00.000Z",
+  "age_confirmed_18_or_over": true,
   "demographics": {
     "age_group": "26-35",
     "gender": "prefer_not_to_say",
@@ -49,6 +53,8 @@ Required v1 shape:
 ```
 
 The volunteer does not type `device_id`, ISO language codes, browser user agent, OS, browser, or device type. `device_id` is an anonymous browser UUID stored in `localStorage` under `aina.speechCollector.deviceId` after consent is accepted; it is not a real hardware ID or serial number. It is used to resume an active session and show which phrases this browser has already recorded.
+
+`consent_response`, `consent_version`, `privacy_notice_version`, `consent_accepted_at`, and `age_confirmed_18_or_over` are required before the backend creates or resumes a volunteer collection session. The current consent and privacy notice versions are both `1.0`. Under-18 participation is blocked in the app by requiring `age_confirmed_18_or_over: true` before session creation.
 
 `native_language_other` is only shown and stored when `native_language` is `other`; otherwise it is `null`. `dialect_region_other` behaves the same way for `dialect_region = "other"`.
 
@@ -245,13 +251,21 @@ Example exported row:
       "storage_type": "local",
       "category": "yes",
       "phrase_id": "yes_kylla",
-      "semantic_label": "yes"
+      "semantic_label": "yes",
+      "consent": {
+        "consent_response": "yes",
+        "consent_version": "1.0",
+        "privacy_notice_version": "1.0",
+        "consent_accepted_at": "2026-06-03T12:00:00.000Z",
+        "age_confirmed_18_or_over": true
+      }
     }
   }
 }
 ```
 
 `label` remains an alias of `normalized_label` for the current audio-classifier loader. `speaker_id` is stable for the same browser `device_id` and is hashed with `DATASET_SPEAKER_HASH_SALT` during export.
+Consent fields are exported under `metadata.collection.consent` as governance metadata. They are not classifier labels and do not change `normalized_label`, `semantic_label`, `phrase_id`, or validation filtering.
 
 ## Databuilder Compatibility Export
 
@@ -324,7 +338,15 @@ Each `<sample_id>.json` sidecar is root-level for fields used by classifier filt
     "channel_count": 1,
     "encoding": "pcm_s16le"
   },
-  "collection": {},
+  "collection": {
+    "consent": {
+      "consent_response": "yes",
+      "consent_version": "1.0",
+      "privacy_notice_version": "1.0",
+      "consent_accepted_at": "2026-06-03T12:00:00.000Z",
+      "age_confirmed_18_or_over": true
+    }
+  },
   "storage": {}
 }
 ```

--- a/docs/aina-data-contract.md
+++ b/docs/aina-data-contract.md
@@ -13,6 +13,7 @@ The frontend must not append directly to a shared `samples.jsonl` file. Public v
 - `recordings.metadata` stores recording-level v1 metadata without a DB schema change.
 - `participant_sessions.metadata` stores session-level v1 metadata without a DB schema change.
 - Each upload inserts a new `recordings` row. Repeat recordings for the same `(session_id, task_id)` are separate samples.
+- Admin validation stores review state in `recordings.metadata.validation` and writes a JSON sidecar beside the WAV file in storage.
 - Backend safety limits are authoritative. The frontend timer improves UX, but the backend rejects files that are too large or too long.
 
 ## Session Metadata
@@ -67,6 +68,11 @@ Required v1 shape:
   "normalized_label": "kylla",
   "literal_transcript": null,
   "label_source": "prompt_assumed",
+  "validation": {
+    "status": "pending",
+    "validated_at": null,
+    "notes": null
+  },
   "language": "fi",
   "category": "yes",
   "technical": {
@@ -101,6 +107,21 @@ Allowed `label_source` values:
 - `reviewed`: reserved for a later manual review workflow.
 
 The classifier should train on `normalized_label`, not `literal_transcript`.
+
+## Admin Validation Metadata
+
+The internal admin UI at `/#/admin` can edit only safe review fields:
+
+- `literal_transcript`
+- `label_source`
+- `validation.status`
+- `validation.notes`
+
+Allowed statuses are `pending`, `validated`, `needs_review`, and `rejected`. Missing legacy validation metadata is treated as `pending`.
+
+Trusted task-derived fields remain read-only in v1, including `phrase_id`, `semantic_label`, `normalized_label`, `category`, `language`, processed-audio metadata, and storage keys.
+
+Validation sidecars are written beside the WAV file by replacing `.wav` with `.json`. They contain complete dataset-ready metadata and do not include `validated_by`, usernames, secrets, or raw `.env` values.
 
 ## Category Progress Metadata
 
@@ -155,6 +176,8 @@ Each sample row combines:
 - task metadata
 - storage information
 
+Exports first apply `DATASET_VALIDATION_FILTER`, defaulting to `validated`. `not_rejected` excludes rejected samples only, and `all` keeps all otherwise eligible recordings.
+
 Example exported row:
 
 ```json
@@ -169,6 +192,12 @@ Example exported row:
   "transcript": "Kyllä",
   "literal_transcript": null,
   "label_source": "prompt_assumed",
+  "validation": {
+    "status": "validated",
+    "validated_at": "2026-05-31T10:00:00.000Z",
+    "notes": null
+  },
+  "original": true,
   "language": "fi",
   "duration_sec": 0.82,
   "split": null,
@@ -201,6 +230,11 @@ Example exported row:
       "sample_rate_hz": 16000,
       "channel_count": 1,
       "encoding": "pcm_s16le"
+    },
+    "validation": {
+      "status": "validated",
+      "validated_at": "2026-05-31T10:00:00.000Z",
+      "notes": null
     },
     "collection": {
       "topic_id": "short_finnish_responses_v2_0001",
@@ -317,6 +351,6 @@ Old recordings collected before the processed-audio fix may not contain `process
 - Use `prompted_word`/`transcript` for display and review.
 - Treat `literal_transcript` as optional metadata, not the default target label.
 - `sample_id` is the UUID from `recordings.id`.
-- Export filters recordings by the active `STORAGE` setting so one manifest does not mix local and S3 audio roots.
+- Export filters recordings by validation status and by the active `STORAGE` setting so one manifest does not mix local and S3 audio roots.
 - Use `scripts/aina/exportDataset.js` for the collector-native `dataset.json + samples.jsonl` export.
 - Use `scripts/aina/exportDatabuilderDataset.js` when the current audio-classifier databuilder needs `manifest.json + <sample_id>.wav + <sample_id>.json`.

--- a/docs/database-structure.md
+++ b/docs/database-structure.md
@@ -56,6 +56,8 @@ Status values:
 
 `metadata.ui.category_phrase_v1` stores the shuffled phrase order for the category UI. The order is created once per session and reused on refresh. If newly seeded phrases appear later, missing phrase IDs are appended in stable `task_idx` order.
 
+Consent governance fields are also stored in `metadata`: `consent_response`, `consent_version`, `privacy_notice_version`, `consent_accepted_at`, and `age_confirmed_18_or_over`. These fields are required before a volunteer session is created or updated for recording, but they do not require a database schema migration because `metadata` is JSONB.
+
 ### `recordings`
 
 One saved recording row per upload. Repeat recordings for the same `(session_id, task_id)` are separate valid samples.

--- a/docs/databuilder-export.md
+++ b/docs/databuilder-export.md
@@ -105,7 +105,15 @@ Each `<sample_id>.json` sidecar is root-level:
     "channel_count": 1,
     "encoding": "pcm_s16le"
   },
-  "collection": {},
+  "collection": {
+    "consent": {
+      "consent_response": "yes",
+      "consent_version": "1.0",
+      "privacy_notice_version": "1.0",
+      "consent_accepted_at": "2026-06-03T12:00:00.000Z",
+      "age_confirmed_18_or_over": true
+    }
+  },
   "storage": {}
 }
 ```
@@ -116,7 +124,7 @@ It is flat because audio-classifier filters use dotted paths like `demographics.
 
 Older recordings collected before the processed-audio fix may not contain `processed_audio`; those sidecars keep the root-level key with `null`. Legacy recordings without `phrase_id` or `semantic_label` keep those keys as `null`; missing semantic metadata does not make an otherwise classifier-ready recording invalid.
 
-The same `phrase_id` and `semantic_label` values are also included under `collection.phrase_id` and `collection.semantic_label`. `normalized_label` remains the phrase-level classifier target.
+The same `phrase_id` and `semantic_label` values are also included under `collection.phrase_id` and `collection.semantic_label`. `collection.consent` carries consent governance metadata only. `normalized_label` remains the phrase-level classifier target.
 
 ## Manifest
 

--- a/docs/databuilder-export.md
+++ b/docs/databuilder-export.md
@@ -33,6 +33,7 @@ Optional settings:
 ```env
 DATABUILDER_OUTPUT_DIR=./exports/short-finnish-responses/v2/databuilder
 DATABUILDER_MANIFEST_VERSION=20260501001
+DATASET_VALIDATION_FILTER=validated
 ```
 
 Generated databuilder outputs contain audio and should not be committed.
@@ -40,6 +41,12 @@ Generated databuilder outputs contain audio and should not be committed.
 ## Storage Behavior
 
 The bridge filters rows by the active `STORAGE` value, matching `scripts/aina/exportDataset.js`.
+
+It also filters rows by validation status before writing audio or JSON:
+
+- `validated`: export only validated recordings. This is the default.
+- `not_rejected`: export pending, needs_review, and validated recordings; exclude rejected.
+- `all`: ignore validation status for export eligibility.
 
 It also filters out recordings that are not classifier-ready. A row is exported only when `recording.metadata.processed_audio` is exactly:
 
@@ -77,6 +84,12 @@ Each `<sample_id>.json` sidecar is root-level:
   "normalized_label": "kylla",
   "literal_transcript": null,
   "label_source": "prompt_assumed",
+  "validation": {
+    "status": "validated",
+    "validated_at": "2026-05-31T10:00:00.000Z",
+    "notes": null
+  },
+  "original": true,
   "language": "fi",
   "category": "yes",
   "augmentation_strategy": null,

--- a/docs/privacy-consent-flow.md
+++ b/docs/privacy-consent-flow.md
@@ -1,0 +1,132 @@
+# Privacy Consent Flow
+
+Date: 03.06.2026
+
+## Goal
+
+The volunteer-facing Speech Collector app shows a simple, friendly welcome and consent screen before any collection session is created unless the same browser already has valid stored consent for the current policy versions. The main screen explains the project, what the volunteer will do, a short privacy/consent summary, and one small read-more link to the full details page at `/#/privacy`.
+
+## Source Content
+
+Source document: `Linnea_tietosuoja_ja_suostumus (1).docx`.
+
+The full `/#/privacy` page consolidates the document sections:
+
+- `Tietosuojaseloste`
+- `Tietoon perustuva suostumus`
+- `Ikärajahuomio - alle 18-vuotiaat`
+- `Tutkimustiedote`
+
+The Finnish text is the official volunteer-facing content. English text in the app is helper translation for review and non-Finnish team members.
+
+## Filled Values
+
+- Company: Linnea Technologies Oy
+- Y-tunnus: 3571288-4
+- Address: Kulmalantie 11 as. 2, 28130 Pori, Finland
+- Contact: Ollipekka Kivin
+- Contact email: ollipekka@hellolinnea.com
+- Policy date: 03.06.2026
+- Consent version: 1.0
+- Privacy notice version: 1.0
+- Minimum age: 18+
+- English purpose wording: AI-based phone service
+- Finnish purpose wording: tekoälypohjainen puhelinpalvelu
+
+The contact title and phone placeholders from the source document are not published in the UI.
+
+## Volunteer Flow
+
+1. Main route opens at `/#/`.
+2. If valid same-browser consent is stored and the consent/privacy versions match, the app skips the welcome and consent screen.
+3. If no valid stored consent exists, the simple welcome and consent screen appears first.
+4. The main screen shows the welcome title, short project purpose, what-volunteers-will-do steps, and a short privacy/consent summary.
+5. One small read-more link points to `/#/privacy`: `Lue tietosuoja- ja suostumustiedot kokonaan / Read full privacy and consent details`.
+6. Continue stays disabled until both required checkboxes are checked.
+7. Decline shows the bilingual blocked message, clears any stored accepted consent, and does not start a backend session.
+8. Accepted consent is stored in browser localStorage and proceeds to Turnstile if configured.
+9. `/api/start-session` receives consent metadata, including reused stored consent when available, and creates or resumes the session.
+10. Metadata form appears without exposing the internal participant/device code.
+11. Category phrase recording starts only after metadata is complete.
+
+The normal volunteer flow does not show participant code, deletion-request instructions, technical identifier explanation, persistent footer policy links, or multiple legal-looking cards.
+
+## Routes
+
+- `/#/privacy`: full privacy, consent, age restriction, and study information page.
+- `/#/participant-info`: compatibility route that renders the same full details page as `/#/privacy`.
+- `/#/admin`: unchanged internal admin validation route.
+
+The normal UI links only to `/#/privacy` through the single small read-more link on the main consent screen. `/#/participant-info` is kept for compatibility but is not shown as a normal volunteer-flow link.
+
+## Session Metadata
+
+The consent gate sends these fields when a session is created. Returning same-browser volunteers reuse the original `consent_accepted_at` timestamp from browser storage when the stored versions still match.
+
+```json
+{
+  "consent_response": "yes",
+  "consent_version": "1.0",
+  "privacy_notice_version": "1.0",
+  "consent_accepted_at": "ISO timestamp",
+  "age_confirmed_18_or_over": true
+}
+```
+
+The same metadata also includes `schema_version`, browser technical metadata, and the anonymous internal `device_id`. The metadata form preserves these consent fields when it saves demographics and recording-environment metadata, but the normal volunteer flow does not display the identifier.
+
+## Browser Consent Storage
+
+Accepted consent is stored locally in `localStorage` under `speechCollectorConsent`:
+
+```json
+{
+  "consent_response": "yes",
+  "consent_version": "1.0",
+  "privacy_notice_version": "1.0",
+  "consent_accepted_at": "ISO timestamp",
+  "age_confirmed_18_or_over": true
+}
+```
+
+Stored consent is valid only when:
+
+- `consent_response` is `yes`
+- `age_confirmed_18_or_over` is `true`
+- `consent_version` matches `CONSENT_VERSION`
+- `privacy_notice_version` matches `PRIVACY_NOTICE_VERSION`
+- `consent_accepted_at` is a valid timestamp
+
+If `CONSENT_VERSION` or `PRIVACY_NOTICE_VERSION` changes in code, the stored consent no longer matches and the volunteer is asked to consent again. Malformed or stale stored consent is removed locally and the welcome/consent screen is shown again.
+
+Only the consent decision is stored in this key. When starting a backend session, the frontend rebuilds the full session metadata with the stored consent timestamp, the current anonymous browser `device_id`, and current browser technical metadata.
+
+## Backend Enforcement
+
+`POST /api/start-session` rejects missing or invalid consent metadata with `consent_required` before calling the provider. `TaskProvider.startSession()` also validates consent before allocating a topic copy or inserting `participant_sessions`.
+
+`TaskProvider.updateSessionMetadata()` rejects updates that would remove or invalidate required consent fields. Upload and category-state guards still require complete v1 session metadata before recording.
+
+Backend consent enforcement remains active even when consent is reused from browser storage. If the backend rejects reused consent, the frontend clears the stored browser consent and shows the consent screen again.
+
+## Export Compatibility
+
+Normal export and databuilder export include consent only as governance metadata under `collection.consent`.
+
+Consent metadata does not change:
+
+- `normalized_label`
+- `semantic_label`
+- `phrase_id`
+- `category`
+- admin validation status
+- validation filtering
+- classifier label behavior
+
+The audio-classifier package is not changed.
+
+## Remaining TODOs
+
+- Manual browser smoke test should be run before push or PR.
+- Confirm final legal wording with Linnea before production deployment.
+- No production deployment has been performed for this implementation.

--- a/docs/session-logs/2026-05-31-admin-validation-ui.md
+++ b/docs/session-logs/2026-05-31-admin-validation-ui.md
@@ -1,0 +1,124 @@
+# 2026-05-31 Admin Validation UI
+
+## Goal
+
+Build Admin Validation UI v1 for internal Speech Collector sample review.
+
+## Final Agreed Design
+
+- Internal route is `/#/admin`.
+- No visible admin link is shown in the volunteer UI.
+- Admin login is shared password only.
+- No username is required.
+- No `validated_by` field is stored.
+- Audio playback goes through a backend-protected admin endpoint.
+- Admins can edit only safe review metadata:
+  - `literal_transcript`
+  - `label_source`
+  - `validation.status`
+  - `validation.notes`
+- Trusted task labels are read-only:
+  - `phrase_id`
+  - `normalized_label`
+  - `semantic_label`
+  - `category`
+  - `language`
+- Validation statuses are:
+  - `pending`
+  - `validated`
+  - `needs_review`
+  - `rejected`
+- Saving validation updates PostgreSQL and writes a JSON sidecar beside the WAV.
+- Validation affects exports immediately through `DATASET_VALIDATION_FILTER`.
+
+## Production Context
+
+The production architecture is:
+
+```text
+Cloudflare -> Nginx -> static React frontend + /api backend -> local PostgreSQL + Cloudflare R2
+```
+
+Admin APIs live under `/api/admin`, so the existing Nginx `/api` proxy model applies. The frontend never receives PostgreSQL, R2, Turnstile, or admin session credentials.
+
+Deployment remains compatible with:
+
+```text
+/var/www/speech-collector/scripts/build-remote.sh
+```
+
+Production admin URL after deployment:
+
+```text
+https://participate.hellolinnea.com/#/admin
+```
+
+## Local Auth Debugging
+
+During local setup, the admin UI alternated between `admin_not_configured` and invalid-password responses.
+
+Root cause:
+
+- `dotenv-cli` expands `$` inside quoted values.
+- The generated scrypt password hash contains `$`.
+- The local `.env` hash was being loaded incorrectly by the dev backend.
+
+Local fix:
+
+- Regenerated a local-only test hash for the temporary admin test password.
+- Stored it in `.env` with dotenv-safe escaped `$` characters.
+- Verified the value loads through the same `dotenv-cli` path used by `pnpm dev`.
+- `.env` and `.env.admin-debug-backup.local` were not committed.
+
+Production must generate a fresh admin password hash and fresh admin session secret. Do not use the local test password or hash in production.
+
+Because scrypt hashes contain `$`, production storage must use a dotenv-safe format. Escape `$` characters in `ADMIN_PASSWORD_HASH`, or use an equivalent storage method that preserves the literal hash value when dotenv tooling loads it.
+
+## Validation Completed
+
+- `corepack pnpm install`: passed.
+- `corepack pnpm run test:backend`: passed, 73/73.
+- `corepack pnpm build`: passed.
+- `corepack pnpm --filter sound-collector-frontend lint`: passed.
+- Admin API auth smoke: passed.
+- Sample list loaded: 19 samples.
+- Summary/readiness endpoints loaded.
+- Audio endpoint returned content for a real sample.
+- Validation save passed on one real sample.
+- PostgreSQL metadata was updated with `validation.status = "validated"` and `validated_at`.
+- JSON sidecar was written beside the WAV path and read back from S3-compatible storage.
+- Sidecar did not include secrets or `validated_by`.
+- `python .\scripts\aina\verify_v2_exports.py --run-exports`: passed after one sample was marked validated.
+- Export verifier confirmed `DATASET_VALIDATION_FILTER=validated` skipped 18 pending samples and exported 1 validated classifier-ready sample.
+- Manual browser test by Avishek showed login, sample list, dashboard, sample detail, audio playback, and validation controls working.
+- Screenshot captured for PR visual evidence only; it must not be committed.
+
+## Production Env Additions
+
+```env
+ADMIN_PASSWORD_HASH=
+ADMIN_SESSION_SECRET=
+ADMIN_SESSION_TTL_HOURS=12
+DATASET_VALIDATION_FILTER=validated
+```
+
+## Screenshot Handling
+
+The local Admin Validation UI screenshot is PR evidence only.
+
+- Do not commit the screenshot.
+- Do not add it to `docs/assets`.
+- Do not stage screenshots or browser artifacts.
+- If automatic GitHub image upload is unavailable, leave a UI Preview placeholder in the draft PR and add the screenshot manually through the GitHub UI.
+
+## Remaining TODOs
+
+- Senior must add production admin env values.
+- Senior/team should choose and privately share the production admin password.
+- Production deployment should happen after merge.
+- Run one live production smoke test after deployment.
+- Optional future improvements:
+  - individual reviewer accounts
+  - validation history
+  - label correction workflow
+  - audio download if needed

--- a/docs/session-logs/2026-06-03-privacy-consent-flow.md
+++ b/docs/session-logs/2026-06-03-privacy-consent-flow.md
@@ -1,0 +1,86 @@
+# 2026-06-03 Privacy Consent Flow
+
+## Goal
+
+Implement the volunteer-facing privacy, participant information, and consent flow for the Speech Collector app without production deployment, commit, push, or audio-classifier changes.
+
+## Source Document
+
+Used `d:\downloads from chrome\Linnea_tietosuoja_ja_suostumus (1).docx` as the policy source. It contains the privacy notice, informed consent, age restriction notice, and research information.
+
+## Filled Placeholder Values
+
+- Company: Linnea Technologies Oy
+- Y-tunnus: 3571288-4
+- Corrected address: Kulmalantie 11 as. 2, 28130 Pori, Finland
+- Contact person: Ollipekka Kivin
+- Contact email: ollipekka@hellolinnea.com
+- Policy date: 03.06.2026
+- Consent version: 1.0
+- Privacy notice version: 1.0
+- Purpose wording: AI-based phone service / tekoälypohjainen puhelinpalvelu
+- Minimum age: 18+
+
+The contact title and phone placeholders were removed from published UI/content.
+
+## Audit Findings
+
+- Frontend routing is lightweight hash routing in `frontend/src/App.tsx`; `/#/admin` already routes to `AdminValidationApp`.
+- The volunteer flow previously bootstrapped `/api/start-session` immediately, then showed intro, metadata, and category recording.
+- The metadata form previously included an older consent yes/no field from `infoFormConfig.json`.
+- Session metadata is built in `frontend/utils/sessionMetadata.ts` and persisted in `participant_sessions.metadata`.
+- Device ID already exists in `frontend/utils/deviceId.ts` as a localStorage UUID.
+- Backend upload/category guards already required v1 metadata before recording, but session creation did not require the new consent fields.
+- Normal export and databuilder export already preserve session metadata-derived governance-like data without changing classifier label fields.
+- Admin validation displays session metadata but does not depend on consent fields.
+
+## Implementation Notes
+
+- Added a main-route consent gate before Turnstile, metadata, or recording.
+- Polished the gate into a friendly welcome and consent screen with a short purpose summary, what-to-expect steps, and a short privacy/consent summary.
+- Removed the large privacy, participant information, and age detail cards from the main volunteer screen.
+- Added one small read-more link from the main consent screen to `/#/privacy`.
+- Consolidated the full privacy notice, informed consent, age restriction, and study information under `/#/privacy`.
+- Kept `/#/participant-info` as a compatibility route that renders the same full details page as `/#/privacy`, but removed it from the normal volunteer UI.
+- Kept `/#/admin` behavior unchanged and outside the volunteer flow.
+- Removed the old metadata-form consent field and the under-18 age option.
+- Removed the participant code display from the normal metadata step after manual review; the internal `device_id` remains in session metadata.
+- Removed persistent volunteer footer policy links after manual review.
+- Added version-aware local consent persistence under browser localStorage key `speechCollectorConsent`.
+- Returning same-browser volunteers with valid stored consent now skip the welcome/consent screen and continue to the metadata or recording flow.
+- Reused stored consent is still sent to `/api/start-session`; backend consent enforcement remains active.
+- Malformed, stale, declined, or backend-rejected stored consent is cleared so the volunteer must consent again.
+- Added consent metadata fields to session creation.
+- Backend rejects direct session starts without valid consent and 18+ confirmation.
+- Backend rejects metadata updates that would invalidate consent.
+- Normal export and databuilder export include consent under `collection.consent` only.
+
+## Compatibility Notes
+
+- Turnstile remains after consent and before backend session creation when configured.
+- Metadata form still stores demographics, environment, and browser technical metadata.
+- Metadata form no longer displays the internal participant/device code.
+- The current consent and privacy versions remain `1.0`; changing either frontend constant forces returning users to consent again.
+- Accepted consent stores only the consent decision and original `consent_accepted_at`; full session metadata is rebuilt with the anonymous `device_id` and current technical metadata when a session starts.
+- Normal volunteer screens do not show the internal participant code, save-code instructions, deletion-request instructions, technical identifier explanation, persistent policy footer links, separate privacy/participant route buttons, or multiple legal-looking cards.
+- Category phrase UI, phrase IDs, semantic labels, normalized labels, and validation filtering were not changed.
+- Admin validation route and behavior were not intentionally changed.
+- No database migration was required because consent fields are stored in JSONB metadata.
+- Databuilder export does not require consent fields for classifier loading.
+- Audio-classifier was not touched.
+
+## Safety
+
+- No production server changes.
+- No production deployment.
+- No commit.
+- No push.
+- No generated exports, audio, temp files, screenshots, traces, or browser artifacts intentionally committed.
+- `.env` was not modified by this implementation.
+
+## Remaining TODOs
+
+- Run the full command checklist.
+- Run browser smoke if browser automation is available; otherwise provide manual steps.
+- Avishek manual review before commit/push.
+- Legal/content review before production deployment.

--- a/frontend/components/AdminValidation.tsx
+++ b/frontend/components/AdminValidation.tsx
@@ -1,0 +1,857 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from "react";
+
+type ValidationStatus = "pending" | "validated" | "needs_review" | "rejected";
+type LabelSource = "prompt_assumed" | "user_confirmed" | "reviewed";
+
+type AdminValidation = {
+  status: ValidationStatus;
+  validated_at: string | null;
+  notes: string | null;
+};
+
+type AdminSample = {
+  id: string;
+  sample_id: string;
+  recording_id: string;
+  session_id: string;
+  task_id: string;
+  topic_id: string;
+  submitted_at: string;
+  duration_sec: number;
+  session_status: string;
+  prompted_word: string | null;
+  phrase_id: string | null;
+  normalized_label: string | null;
+  semantic_label: string | null;
+  category: string | null;
+  language: string | null;
+  literal_transcript: string | null;
+  label_source: LabelSource;
+  validation: AdminValidation;
+  processed_audio_status: string;
+  storage: {
+    storage_type: string;
+    storage_key: string;
+    object_key: string | null;
+    metadata_object_key: string | null;
+    bucket_name: string | null;
+  };
+  metadata?: {
+    recording: Record<string, unknown>;
+    session: Record<string, unknown>;
+    task: Record<string, unknown>;
+    topic: Record<string, unknown>;
+  };
+};
+
+type Summary = {
+  total_recordings: number;
+  pending: number;
+  validated: number;
+  needs_review: number;
+  rejected: number;
+  classifier_ready_validated: number;
+  exportable: number;
+  missing_metadata: number;
+  missing_processed_audio: number;
+  wrong_processed_audio: number;
+};
+
+type Readiness = {
+  validation_filter: string;
+  exportable_count: number;
+  missing_phrase_id_count: number;
+  missing_semantic_label_count: number;
+  missing_literal_transcript_key_count: number;
+  missing_processed_audio_count: number;
+  wrong_processed_audio_count: number;
+};
+
+type Health = {
+  ready: boolean;
+  backend_time: string;
+  app_environment: string;
+  storage_mode: string;
+  validation_filter: string;
+  warnings: Array<{
+    code: string;
+    count: number;
+    message: string;
+    categories?: string[];
+  }>;
+};
+
+type ListResponse = {
+  success: boolean;
+  samples: AdminSample[];
+  pagination: {
+    limit: number;
+    offset: number;
+    total: number;
+    has_next: boolean;
+    has_previous: boolean;
+  };
+  message?: string;
+};
+
+type AdminFormState = {
+  literal_transcript: string;
+  label_source: LabelSource;
+  status: ValidationStatus;
+  notes: string;
+};
+
+const STATUS_OPTIONS: Array<{ value: ValidationStatus; label: string }> = [
+  { value: "pending", label: "Pending" },
+  { value: "validated", label: "Validated" },
+  { value: "needs_review", label: "Needs review" },
+  { value: "rejected", label: "Rejected" },
+];
+
+const LABEL_SOURCE_OPTIONS: Array<{ value: LabelSource; label: string }> = [
+  { value: "prompt_assumed", label: "Prompt assumed" },
+  { value: "user_confirmed", label: "User confirmed" },
+  { value: "reviewed", label: "Reviewed" },
+];
+
+function asDisplay(value: string | number | null | undefined) {
+  if (value === null || value === undefined || value === "") {
+    return "Missing";
+  }
+
+  return String(value);
+}
+
+function formatDate(value: string | null | undefined) {
+  if (!value) {
+    return "Missing";
+  }
+
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? value : date.toLocaleString();
+}
+
+function buildInitialForm(sample: AdminSample): AdminFormState {
+  return {
+    literal_transcript: sample.literal_transcript || "",
+    label_source: sample.label_source || "prompt_assumed",
+    status: sample.validation.status,
+    notes: sample.validation.notes || "",
+  };
+}
+
+function getStatusClass(status: ValidationStatus) {
+  return `admin-status admin-status--${status.replace("_", "-")}`;
+}
+
+function MetadataBlock({ title, value }: { title: string; value: Record<string, unknown> }) {
+  return (
+    <details className="admin-metadata-block">
+      <summary>{title}</summary>
+      <pre>{JSON.stringify(value, null, 2)}</pre>
+    </details>
+  );
+}
+
+function StatGrid({ summary }: { summary: Summary | null }) {
+  const items = [
+    ["Total", summary?.total_recordings],
+    ["Pending", summary?.pending],
+    ["Validated", summary?.validated],
+    ["Needs review", summary?.needs_review],
+    ["Rejected", summary?.rejected],
+    ["Ready validated", summary?.classifier_ready_validated],
+    ["Exportable", summary?.exportable],
+    ["Missing audio meta", summary?.missing_processed_audio],
+  ];
+
+  return (
+    <div className="admin-stats" aria-label="Validation summary">
+      {items.map(([label, value]) => (
+        <div className="admin-stat" key={label}>
+          <span>{label}</span>
+          <strong>{value ?? "-"}</strong>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DistributionList({
+  title,
+  values,
+}: {
+  title: string;
+  values: Record<string, number> | undefined;
+}) {
+  const entries = Object.entries(values || {})
+    .sort((left, right) => right[1] - left[1])
+    .slice(0, 8);
+
+  return (
+    <div className="admin-distribution">
+      <h3>{title}</h3>
+      {entries.length ? (
+        <ul>
+          {entries.map(([label, count]) => (
+            <li key={label}>
+              <span>{label}</span>
+              <strong>{count}</strong>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No data</p>
+      )}
+    </div>
+  );
+}
+
+function AdminValidationApp() {
+  const apiUrl = import.meta.env.VITE_API_URL;
+  const [checkingAuth, setCheckingAuth] = useState(true);
+  const [authenticated, setAuthenticated] = useState(false);
+  const [password, setPassword] = useState("");
+  const [loginError, setLoginError] = useState("");
+  const [message, setMessage] = useState("");
+  const [samples, setSamples] = useState<AdminSample[]>([]);
+  const [selectedSample, setSelectedSample] = useState<AdminSample | null>(null);
+  const [summary, setSummary] = useState<Summary | null>(null);
+  const [readiness, setReadiness] = useState<Readiness | null>(null);
+  const [health, setHealth] = useState<Health | null>(null);
+  const [distributions, setDistributions] = useState<Record<string, Record<string, number>>>({});
+  const [statusFilter, setStatusFilter] = useState<ValidationStatus | "all">("pending");
+  const [categoryFilter, setCategoryFilter] = useState("");
+  const [labelFilter, setLabelFilter] = useState("");
+  const [offset, setOffset] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [loadingList, setLoadingList] = useState(false);
+  const [loadingDetail, setLoadingDetail] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [formState, setFormState] = useState<AdminFormState | null>(null);
+
+  const pageSize = 25;
+
+  const audioUrl = useMemo(() => {
+    if (!selectedSample) {
+      return "";
+    }
+
+    return `${apiUrl}/api/admin/samples/${selectedSample.id}/audio`;
+  }, [apiUrl, selectedSample]);
+
+  const requestJson = useCallback(
+    async <T,>(path: string, init: RequestInit = {}): Promise<T> => {
+      const response = await fetch(`${apiUrl}${path}`, {
+        ...init,
+        credentials: "include",
+        headers: {
+          ...(init.body ? { "Content-Type": "application/json" } : {}),
+          ...(init.headers || {}),
+        },
+      });
+      const data = (await response.json()) as T & { message?: string };
+
+      if (!response.ok) {
+        throw new Error(data.message || "Admin request failed.");
+      }
+
+      return data;
+    },
+    [apiUrl]
+  );
+
+  const loadDashboard = useCallback(async () => {
+    const [summaryResponse, readinessResponse, distributionsResponse, healthResponse] =
+      await Promise.all([
+        requestJson<{ summary: Summary }>("/api/admin/summary"),
+        requestJson<{ readiness: Readiness }>("/api/admin/export-readiness"),
+        requestJson<{ distributions: Record<string, Record<string, number>> }>(
+          "/api/admin/distributions"
+        ),
+        requestJson<{ health: Health }>("/api/admin/health"),
+      ]);
+
+    setSummary(summaryResponse.summary);
+    setReadiness(readinessResponse.readiness);
+    setDistributions(distributionsResponse.distributions);
+    setHealth(healthResponse.health);
+  }, [requestJson]);
+
+  const loadSampleDetail = useCallback(
+    async (sampleId: string) => {
+      setLoadingDetail(true);
+      setMessage("");
+
+      try {
+        const data = await requestJson<{ sample: AdminSample }>(`/api/admin/samples/${sampleId}`);
+        setSelectedSample(data.sample);
+        setFormState(buildInitialForm(data.sample));
+      } catch (error) {
+        setMessage(error instanceof Error ? error.message : "Could not load sample.");
+      } finally {
+        setLoadingDetail(false);
+      }
+    },
+    [requestJson]
+  );
+
+  const loadSamples = useCallback(async () => {
+    setLoadingList(true);
+    setMessage("");
+    const params = new URLSearchParams({
+      limit: String(pageSize),
+      offset: String(offset),
+      status: statusFilter,
+    });
+
+    if (categoryFilter.trim()) {
+      params.set("category", categoryFilter.trim());
+    }
+
+    if (labelFilter.trim()) {
+      params.set("label", labelFilter.trim());
+    }
+
+    try {
+      const data = await requestJson<ListResponse>(`/api/admin/samples?${params.toString()}`);
+      setSamples(data.samples);
+      setTotal(data.pagination.total);
+      if (!selectedSample && data.samples[0]) {
+        await loadSampleDetail(data.samples[0].id);
+      }
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not load samples.");
+    } finally {
+      setLoadingList(false);
+    }
+  }, [
+    categoryFilter,
+    labelFilter,
+    loadSampleDetail,
+    offset,
+    requestJson,
+    selectedSample,
+    statusFilter,
+  ]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function checkMe() {
+      try {
+        await requestJson("/api/admin/me");
+        if (!cancelled) {
+          setAuthenticated(true);
+          await loadDashboard();
+        }
+      } catch (_error) {
+        if (!cancelled) {
+          setAuthenticated(false);
+        }
+      } finally {
+        if (!cancelled) {
+          setCheckingAuth(false);
+        }
+      }
+    }
+
+    void checkMe();
+    return () => {
+      cancelled = true;
+    };
+  }, [loadDashboard, requestJson]);
+
+  useEffect(() => {
+    if (authenticated) {
+      void loadSamples();
+    }
+  }, [authenticated, loadSamples]);
+
+  async function handleLogin(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoginError("");
+
+    try {
+      await requestJson("/api/admin/login", {
+        method: "POST",
+        body: JSON.stringify({ password }),
+      });
+      setPassword("");
+      setAuthenticated(true);
+      await loadDashboard();
+      await loadSamples();
+    } catch (error) {
+      setLoginError(error instanceof Error ? error.message : "Login failed.");
+    }
+  }
+
+  async function handleLogout() {
+    await requestJson("/api/admin/logout", { method: "POST" });
+    setAuthenticated(false);
+    setSelectedSample(null);
+    setSamples([]);
+  }
+
+  async function handleSave() {
+    if (!selectedSample || !formState) {
+      return;
+    }
+
+    setSaving(true);
+    setMessage("");
+
+    try {
+      const data = await requestJson<{ sample: AdminSample }>(
+        `/api/admin/samples/${selectedSample.id}/validation`,
+        {
+          method: "POST",
+          body: JSON.stringify({
+            literal_transcript: formState.literal_transcript.trim() || null,
+            label_source: formState.label_source,
+            validation: {
+              status: formState.status,
+              notes: formState.notes.trim() || null,
+            },
+          }),
+        }
+      );
+      setSelectedSample(data.sample);
+      setFormState(buildInitialForm(data.sample));
+      setMessage("Validation saved.");
+      await Promise.all([loadDashboard(), loadSamples()]);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Could not save validation.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function resetFilters() {
+    setStatusFilter("pending");
+    setCategoryFilter("");
+    setLabelFilter("");
+    setOffset(0);
+  }
+
+  function openNextPending() {
+    const next = samples.find(
+      (sample) => sample.validation.status === "pending" && sample.id !== selectedSample?.id
+    );
+
+    if (next) {
+      void loadSampleDetail(next.id);
+      return;
+    }
+
+    setStatusFilter("pending");
+    setOffset(0);
+  }
+
+  if (checkingAuth) {
+    return (
+      <main className="admin-shell">
+        <section className="admin-panel admin-panel--login">
+          <span className="app-eyebrow">Speech Collector</span>
+          <h1>Admin validation</h1>
+          <p>Checking admin session.</p>
+        </section>
+      </main>
+    );
+  }
+
+  if (!authenticated) {
+    return (
+      <main className="admin-shell">
+        <section className="admin-panel admin-panel--login">
+          <span className="app-eyebrow">Speech Collector</span>
+          <h1>Admin validation</h1>
+          <p>
+            This area is only for project members reviewing collected speech data. Volunteers do
+            not need to use this section. If you are here to record samples, please return to the
+            main collection page.
+          </p>
+          <form className="admin-login-form" onSubmit={handleLogin}>
+            <label>
+              Shared admin password
+              <input
+                type="password"
+                value={password}
+                autoComplete="current-password"
+                onChange={(event) => setPassword(event.target.value)}
+                required
+              />
+            </label>
+            <button className="app-primary-button" type="submit">
+              Log in
+            </button>
+          </form>
+          {loginError && <p className="app-inline-message app-inline-message--error">{loginError}</p>}
+        </section>
+      </main>
+    );
+  }
+
+  return (
+    <main className="admin-shell">
+      <section className="admin-panel">
+        <header className="admin-header">
+          <div>
+            <span className="app-eyebrow">Internal review</span>
+            <h1>Sample validation</h1>
+          </div>
+          <button className="app-secondary-button" type="button" onClick={() => void handleLogout()}>
+            Logout
+          </button>
+        </header>
+
+        <StatGrid summary={summary} />
+
+        <div className="admin-dashboard">
+          <section className="admin-dashboard-section">
+            <h2>Export readiness</h2>
+            <dl>
+              <div>
+                <dt>Filter</dt>
+                <dd>{readiness?.validation_filter || "-"}</dd>
+              </div>
+              <div>
+                <dt>Exportable</dt>
+                <dd>{readiness?.exportable_count ?? "-"}</dd>
+              </div>
+              <div>
+                <dt>Missing phrase ID</dt>
+                <dd>{readiness?.missing_phrase_id_count ?? "-"}</dd>
+              </div>
+              <div>
+                <dt>Missing semantic label</dt>
+                <dd>{readiness?.missing_semantic_label_count ?? "-"}</dd>
+              </div>
+              <div>
+                <dt>Wrong processed audio</dt>
+                <dd>{readiness?.wrong_processed_audio_count ?? "-"}</dd>
+              </div>
+            </dl>
+          </section>
+
+          <section className="admin-dashboard-section">
+            <h2>Backend</h2>
+            <dl>
+              <div>
+                <dt>Storage</dt>
+                <dd>{health?.storage_mode || "-"}</dd>
+              </div>
+              <div>
+                <dt>Environment</dt>
+                <dd>{health?.app_environment || "-"}</dd>
+              </div>
+              <div>
+                <dt>Backend time</dt>
+                <dd>{health ? formatDate(health.backend_time) : "-"}</dd>
+              </div>
+              <div>
+                <dt>Warnings</dt>
+                <dd>{health?.warnings.length ?? "-"}</dd>
+              </div>
+            </dl>
+          </section>
+        </div>
+
+        {health?.warnings.length ? (
+          <div className="admin-warning-list">
+            {health.warnings.map((warning) => (
+              <p key={warning.code}>
+                <strong>{warning.code}</strong>: {warning.message} ({warning.count})
+              </p>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="admin-distributions">
+          <DistributionList title="Categories" values={distributions.category} />
+          <DistributionList title="Labels" values={distributions.normalized_label} />
+          <DistributionList title="Semantic" values={distributions.semantic_label} />
+        </div>
+
+        <div className="admin-workspace">
+          <section className="admin-list-pane" aria-label="Sample queue">
+            <div className="admin-filters">
+              <label>
+                Status
+                <select
+                  value={statusFilter}
+                  onChange={(event) => {
+                    setStatusFilter(event.target.value as ValidationStatus | "all");
+                    setOffset(0);
+                    setSelectedSample(null);
+                  }}
+                >
+                  <option value="all">All</option>
+                  {STATUS_OPTIONS.map((option) => (
+                    <option value={option.value} key={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Category
+                <input
+                  value={categoryFilter}
+                  onChange={(event) => {
+                    setCategoryFilter(event.target.value);
+                    setOffset(0);
+                  }}
+                  placeholder="yes"
+                />
+              </label>
+              <label>
+                Label
+                <input
+                  value={labelFilter}
+                  onChange={(event) => {
+                    setLabelFilter(event.target.value);
+                    setOffset(0);
+                  }}
+                  placeholder="joo or yes"
+                />
+              </label>
+              <button className="app-secondary-button" type="button" onClick={resetFilters}>
+                Reset
+              </button>
+            </div>
+
+            <div className="admin-table-wrap">
+              <table className="admin-table">
+                <thead>
+                  <tr>
+                    <th>Submitted</th>
+                    <th>Sample</th>
+                    <th>Prompt</th>
+                    <th>Phrase</th>
+                    <th>Label</th>
+                    <th>Semantic</th>
+                    <th>Category</th>
+                    <th>Duration</th>
+                    <th>Status</th>
+                    <th>Audio</th>
+                    <th>Storage</th>
+                    <th>Open</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {samples.map((sample) => (
+                    <tr
+                      key={sample.id}
+                      className={selectedSample?.id === sample.id ? "admin-table-row--selected" : ""}
+                    >
+                      <td>{formatDate(sample.submitted_at)}</td>
+                      <td>{sample.sample_id.slice(0, 8)}</td>
+                      <td>{asDisplay(sample.prompted_word)}</td>
+                      <td>{asDisplay(sample.phrase_id)}</td>
+                      <td>{asDisplay(sample.normalized_label)}</td>
+                      <td>{asDisplay(sample.semantic_label)}</td>
+                      <td>{asDisplay(sample.category)}</td>
+                      <td>{Number(sample.duration_sec || 0).toFixed(2)}s</td>
+                      <td>
+                        <span className={getStatusClass(sample.validation.status)}>
+                          {sample.validation.status}
+                        </span>
+                      </td>
+                      <td>{sample.processed_audio_status}</td>
+                      <td>{sample.storage.storage_type}</td>
+                      <td>
+                        <button
+                          className="admin-link-button"
+                          type="button"
+                          onClick={() => void loadSampleDetail(sample.id)}
+                        >
+                          Review
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                  {!samples.length && (
+                    <tr>
+                      <td colSpan={12}>{loadingList ? "Loading samples." : "No samples found."}</td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+
+            <div className="admin-pagination">
+              <button
+                className="app-secondary-button"
+                type="button"
+                disabled={offset === 0}
+                onClick={() => setOffset(Math.max(0, offset - pageSize))}
+              >
+                Previous
+              </button>
+              <span>
+                {total ? offset + 1 : 0}-{Math.min(offset + pageSize, total)} of {total}
+              </span>
+              <button
+                className="app-secondary-button"
+                type="button"
+                disabled={offset + pageSize >= total}
+                onClick={() => setOffset(offset + pageSize)}
+              >
+                Next
+              </button>
+            </div>
+          </section>
+
+          <section className="admin-detail-pane" aria-label="Sample detail">
+            {selectedSample && formState ? (
+              <>
+                <div className="admin-detail-header">
+                  <div>
+                    <span className="app-eyebrow">Selected sample</span>
+                    <h2>{selectedSample.sample_id}</h2>
+                  </div>
+                  <button className="app-secondary-button" type="button" onClick={openNextPending}>
+                    Next pending
+                  </button>
+                </div>
+
+                <audio
+                  className="admin-audio"
+                  controls
+                  src={audioUrl}
+                  crossOrigin="use-credentials"
+                />
+
+                <div className="admin-editor">
+                  <label>
+                    Literal transcript
+                    <input
+                      value={formState.literal_transcript}
+                      onChange={(event) =>
+                        setFormState({ ...formState, literal_transcript: event.target.value })
+                      }
+                      placeholder="Optional reviewed transcript"
+                    />
+                  </label>
+                  <label>
+                    Label source
+                    <select
+                      value={formState.label_source}
+                      onChange={(event) =>
+                        setFormState({
+                          ...formState,
+                          label_source: event.target.value as LabelSource,
+                        })
+                      }
+                    >
+                      {LABEL_SOURCE_OPTIONS.map((option) => (
+                        <option value={option.value} key={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label>
+                    Validation status
+                    <select
+                      value={formState.status}
+                      onChange={(event) =>
+                        setFormState({ ...formState, status: event.target.value as ValidationStatus })
+                      }
+                    >
+                      {STATUS_OPTIONS.map((option) => (
+                        <option value={option.value} key={option.value}>
+                          {option.label}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="admin-editor__notes">
+                    Notes
+                    <textarea
+                      value={formState.notes}
+                      rows={4}
+                      onChange={(event) =>
+                        setFormState({ ...formState, notes: event.target.value })
+                      }
+                      placeholder="Optional internal note"
+                    />
+                  </label>
+                </div>
+
+                <div className="admin-actions">
+                  <button
+                    className="app-primary-button"
+                    type="button"
+                    disabled={saving}
+                    onClick={() => void handleSave()}
+                  >
+                    {saving ? "Saving..." : "Save validation"}
+                  </button>
+                </div>
+
+                <dl className="admin-readonly-grid">
+                  <div>
+                    <dt>Prompted word</dt>
+                    <dd>{asDisplay(selectedSample.prompted_word)}</dd>
+                  </div>
+                  <div>
+                    <dt>Phrase ID</dt>
+                    <dd>{asDisplay(selectedSample.phrase_id)}</dd>
+                  </div>
+                  <div>
+                    <dt>Normalized label</dt>
+                    <dd>{asDisplay(selectedSample.normalized_label)}</dd>
+                  </div>
+                  <div>
+                    <dt>Semantic label</dt>
+                    <dd>{asDisplay(selectedSample.semantic_label)}</dd>
+                  </div>
+                  <div>
+                    <dt>Category</dt>
+                    <dd>{asDisplay(selectedSample.category)}</dd>
+                  </div>
+                  <div>
+                    <dt>Language</dt>
+                    <dd>{asDisplay(selectedSample.language)}</dd>
+                  </div>
+                  <div>
+                    <dt>Task</dt>
+                    <dd>{selectedSample.task_id}</dd>
+                  </div>
+                  <div>
+                    <dt>Session</dt>
+                    <dd>{selectedSample.session_id}</dd>
+                  </div>
+                  <div>
+                    <dt>Storage key</dt>
+                    <dd>{selectedSample.storage.storage_key}</dd>
+                  </div>
+                  <div>
+                    <dt>Metadata sidecar</dt>
+                    <dd>{asDisplay(selectedSample.storage.metadata_object_key)}</dd>
+                  </div>
+                </dl>
+
+                {selectedSample.metadata && (
+                  <div className="admin-metadata-grid">
+                    <MetadataBlock title="Recording metadata" value={selectedSample.metadata.recording} />
+                    <MetadataBlock title="Session metadata" value={selectedSample.metadata.session} />
+                    <MetadataBlock title="Task metadata" value={selectedSample.metadata.task} />
+                  </div>
+                )}
+              </>
+            ) : (
+              <p>{loadingDetail ? "Loading sample." : "Select a sample to review."}</p>
+            )}
+          </section>
+        </div>
+
+        {message && <p className="app-inline-message">{message}</p>}
+      </section>
+    </main>
+  );
+}
+
+export default AdminValidationApp;

--- a/frontend/components/ConsentGate.tsx
+++ b/frontend/components/ConsentGate.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import { WelcomeInformationSummary } from "./ConsentInformation";
+
+interface ConsentGateProps {
+  message?: string;
+  onAccepted: () => Promise<void> | void;
+  onDeclined: () => void;
+}
+
+const ConsentGate = ({ message, onAccepted, onDeclined }: ConsentGateProps) => {
+  const [ageConfirmed, setAgeConfirmed] = useState(false);
+  const [consentConfirmed, setConsentConfirmed] = useState(false);
+  const canContinue = ageConfirmed && consentConfirmed;
+
+  return (
+    <section className="app-panel app-panel--narrow consent-panel">
+      <span className="app-eyebrow">Linnea Technologies Oy</span>
+      <h1 className="app-title">
+        Tervetuloa osallistumaan suomenkieliseen puheaineiston keruuseen
+      </h1>
+      <p className="consent-title-translation">Welcome to the Finnish speech collection</p>
+
+      <WelcomeInformationSummary />
+
+      {message && <p className="app-inline-message app-inline-message--error">{message}</p>}
+
+      <div className="consent-checks">
+        <label className="consent-check">
+          <input
+            type="checkbox"
+            checked={ageConfirmed}
+            onChange={(event) => setAgeConfirmed(event.target.checked)}
+          />
+          <span>
+            <strong>Vahvistan, että olen täysi-ikäinen (18 vuotta tai vanhempi).</strong>
+            <span>I confirm that I am 18 years or older.</span>
+          </span>
+        </label>
+
+        <label className="consent-check">
+          <input
+            type="checkbox"
+            checked={consentConfirmed}
+            onChange={(event) => setConsentConfirmed(event.target.checked)}
+          />
+          <span>
+            <strong>
+              Olen lukenut osallistumista ja tietosuojaa koskevat tiedot, ja annan
+              suostumukseni osallistua.
+            </strong>
+            <span>
+              I have read the participation and privacy information, and I consent to
+              participate.
+            </span>
+          </span>
+        </label>
+      </div>
+
+      <div className="consent-actions">
+        <button
+          type="button"
+          className="app-primary-button"
+          disabled={!canContinue}
+          onClick={() => void onAccepted()}
+        >
+          Jatka / Continue
+        </button>
+        <button type="button" className="app-secondary-button" onClick={onDeclined}>
+          En osallistu / Decline
+        </button>
+      </div>
+    </section>
+  );
+};
+
+export default ConsentGate;

--- a/frontend/components/ConsentInformation.tsx
+++ b/frontend/components/ConsentInformation.tsx
@@ -1,0 +1,58 @@
+export function WelcomeInformationSummary() {
+  return (
+    <>
+      <div className="consent-purpose">
+        <p>
+          Keräämme lyhyitä suomenkielisiä ääninäytteitä kehittääksemme lyhytvastausten
+          puheentunnistusta Linnean tekoälypohjaista puhelinpalvelua varten.
+        </p>
+        <p>
+          We collect short Finnish voice samples to improve short-response speech
+          recognition for Linnea's AI-based phone service.
+        </p>
+      </div>
+
+      <section className="consent-steps" aria-labelledby="consent-steps-title-fi">
+        <div>
+          <h2 id="consent-steps-title-fi">Mitä osallistuminen tarkoittaa?</h2>
+          <ol>
+            <li>Vastaat muutamaan lyhyeen taustakysymykseen tallennusolosuhteista.</li>
+            <li>Nauhoitat lyhyitä suomenkielisiä sanoja tai vastauksia.</li>
+            <li>
+              Osallistuminen vie yleensä vain muutaman minuutin, ja voit lopettaa
+              milloin tahansa.
+            </li>
+          </ol>
+        </div>
+
+        <div>
+          <h2>What will you do?</h2>
+          <ol>
+            <li>Answer a few short background questions about the recording conditions.</li>
+            <li>Record short Finnish words or responses.</li>
+            <li>Participation usually takes only a few minutes, and you can stop at any time.</li>
+          </ol>
+        </div>
+      </section>
+
+      <section className="consent-summary-note" aria-labelledby="consent-summary-title">
+        <h2 id="consent-summary-title">Tietosuoja ja suostumus / Privacy and consent</h2>
+        <p>
+          Osallistuminen on vapaaehtoista. Emme pyydä nimeäsi, sähköpostiosoitettasi
+          tai puhelinnumeroasi osallistumisen aikana. Jatkamalla vahvistat, että olet
+          vähintään 18-vuotias ja annat suostumuksesi ääninäytteiden käyttämiseen yllä
+          kuvattuun tarkoitukseen.
+        </p>
+        <p>
+          Participation is voluntary. We do not ask for your name, email address, or
+          phone number during participation. By continuing, you confirm that you are at
+          least 18 years old and consent to the use of your voice samples for the
+          purpose described above.
+        </p>
+        <a className="consent-read-more-link" href="/#/privacy">
+          Lue tietosuoja- ja suostumustiedot kokonaan / Read full privacy and consent details
+        </a>
+      </section>
+    </>
+  );
+}

--- a/frontend/components/InfoForm.tsx
+++ b/frontend/components/InfoForm.tsx
@@ -137,7 +137,7 @@ const InfoForm = ({ message, canCancel = false, onCancel, onSaved }: InfoFormPro
 
     try {
       setFormMessage("");
-      const metadata = buildV1SessionMetadata(data);
+      const metadata = buildV1SessionMetadata(data, participantMetadata);
       const response = await fetch(`${apiUrl}/api/update-session-metadata`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/frontend/components/PolicyPages.tsx
+++ b/frontend/components/PolicyPages.tsx
@@ -1,0 +1,374 @@
+const CONTACT_EMAIL = "ollipekka@hellolinnea.com";
+
+function PolicyHeader({ compatibilityNote }: { compatibilityNote?: string }) {
+  return (
+    <header className="policy-header">
+      <span className="app-eyebrow">Linnea Technologies Oy</span>
+      <h1 className="app-title">Tietosuoja- ja suostumustiedot</h1>
+      <p className="consent-title-translation">Privacy and consent details</p>
+      <p className="app-copy">
+        Päivitetty 03.06.2026. Suomenkielinen teksti on virallinen osallistujille
+        näytettävä sisältö; englanninkielinen teksti on apukäännös.
+      </p>
+      {compatibilityNote && <p className="policy-route-note">{compatibilityNote}</p>}
+      <a className="policy-back-link" href="#/">
+        Back to participation
+      </a>
+    </header>
+  );
+}
+
+function FullPrivacyDetailsPage({ compatibilityNote }: { compatibilityNote?: string }) {
+  return (
+    <section className="app-panel app-panel--wide policy-page">
+      <PolicyHeader compatibilityNote={compatibilityNote} />
+
+      <div className="policy-language-block">
+        <h2>Suomi</h2>
+
+        <section>
+          <h3>Tietosuojaseloste</h3>
+          <p>Linnea Technologies Oy - Puheentunnistuksen kehittämistutkimus</p>
+          <p>Päivitetty: 03.06.2026</p>
+        </section>
+
+        <section>
+          <h3>1. Rekisterinpitäjä</h3>
+          <p>
+            Linnea Technologies Oy
+            <br />
+            Y-tunnus: 3571288-4
+            <br />
+            Kulmalantie 11 as. 2
+            <br />
+            28130 Pori
+            <br />
+            Finland
+            <br />
+            Sähköposti: <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+          </p>
+        </section>
+
+        <section>
+          <h3>2. Yhteyshenkilö rekisteriasioissa</h3>
+          <p>
+            Ollipekka Kivin
+            <br />
+            Sähköposti: <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+          </p>
+        </section>
+
+        <section>
+          <h3>3. Rekisterin nimi</h3>
+          <p>Puheentunnistuksen kehittämistutkimuksen ääniaineisto.</p>
+        </section>
+
+        <section>
+          <h3>4. Henkilötietojen käsittelyn tarkoitus ja oikeusperuste</h3>
+          <p>
+            Keräämme ääninäytteitä suomenkielisten lyhytvastauksien puheentunnistuksen
+            kehittämistä varten. Aineistoa käytetään Linnea Technologies Oy:n
+            kehittämän tekoälypohjaisen puhelinpalvelun kehittämiseen.
+          </p>
+          <p>
+            GDPR:n mukainen käsittelyperuste on rekisteröidyn antama suostumus (GDPR
+            6 artikla 1 kohta a).
+          </p>
+        </section>
+
+        <section>
+          <h3>5. Kerättävät tiedot</h3>
+          <p>Kerätään seuraavat tiedot:</p>
+          <ul>
+            <li>Ääninäytteet, kuten lyhyet sanavastauksien toistot.</li>
+            <li>
+              Tekninen tunnistekoodi, joka yhdistää saman käyttäjän eri nauhoitukset
+              toisiinsa pseudonyymisti.
+            </li>
+            <li>Vapaaehtoisesti annetut taustatiedot ja tallennusolosuhteiden tiedot.</li>
+            <li>
+              Perustason selain-, laite- ja mikrofonitiedot tallennuksen laadun
+              arvioimiseksi.
+            </li>
+          </ul>
+          <p>
+            Ääninäytteisiin ei yhdistetä nimeä, sähköpostiosoitetta tai muita suoria
+            tunnistetietoja. Tekninen tunnistekoodi ei itsessään paljasta
+            henkilöllisyyttä.
+          </p>
+        </section>
+
+        <section>
+          <h3>6. Tietojen säilytysaika</h3>
+          <p>
+            Ääninäytteitä ja niihin liittyviä tietoja säilytetään toistaiseksi
+            tutkimus- ja kehityskäyttöä varten. Aineisto poistetaan, jos organisaatio
+            lakkaa toimintansa tai rekisteröity peruuttaa suostumuksensa.
+          </p>
+          <p>
+            Pseudonyymiä tunnistekoodia käyttäen rekisteröity voi pyytää omien
+            tietojensa poistamista.
+          </p>
+        </section>
+
+        <section>
+          <h3>7. Tietojen vastaanottajat ja siirrot</h3>
+          <p>
+            Tietoja ei luovuteta kolmansille osapuolille kaupallisiin tarkoituksiin.
+            Aineistoa saatetaan käsitellä alihankkijana toimivien teknisten
+            palveluntarjoajien järjestelmissä, kuten pilvipalvelussa,
+            tietosuojasopimuksen nojalla.
+          </p>
+          <p>
+            Tietoja käsitellään ainoastaan EU- tai ETA-alueella. Tietoja ei siirretä
+            EU:n tai ETA:n ulkopuolelle.
+          </p>
+        </section>
+
+        <section>
+          <h3>8. Tekniset ja organisatoriset suojatoimet</h3>
+          <ul>
+            <li>Tiedot siirretään ja tallennetaan salattuna HTTPS/TLS-yhteydellä.</li>
+            <li>Pääsy aineistoon on rajattu Linnea Technologies Oy:n kehitystiimille.</li>
+            <li>
+              Teknistä tunnistekoodia ja mahdollisia taustatietoja käsitellään
+              pseudonyymisti.
+            </li>
+          </ul>
+        </section>
+
+        <section>
+          <h3>9. Rekisteröidyn oikeudet</h3>
+          <p>Rekisteröidyllä on GDPR:n nojalla seuraavat oikeudet:</p>
+          <ul>
+            <li>Oikeus saada vahvistus siitä, käsitelläänkö häntä koskevia tietoja.</li>
+            <li>Oikeus saada pääsy omiin tietoihinsa.</li>
+            <li>Oikeus pyytää tietojen oikaisemista tai poistamista.</li>
+            <li>
+              Oikeus peruuttaa suostumus milloin tahansa. Tämä ei vaikuta ennen
+              peruuttamista suoritetun käsittelyn lainmukaisuuteen.
+            </li>
+            <li>Oikeus tehdä valitus valvontaviranomaiselle.</li>
+          </ul>
+          <p>
+            Koska tietoja käsitellään pseudonyymisti teknisen tunnistekoodin avulla,
+            rekisteröidyltä voidaan pyytää riittävät tiedot oman aineistonsa
+            löytämiseksi. Oikeuksien käyttämistä koskevat pyynnöt lähetetään
+            osoitteeseen <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+          </p>
+        </section>
+
+        <section>
+          <h3>10. Valvontaviranomainen</h3>
+          <p>
+            Rekisteröidyllä on oikeus tehdä valitus tietosuojavaltuutetulle, jos hän
+            katsoo, että häntä koskevien henkilötietojen käsittelyssä on rikottu
+            tietosuoja-asetusta.
+          </p>
+          <p>
+            Tietosuojavaltuutetun toimisto
+            <br />
+            PL 800, 00521 Helsinki
+            <br />
+            tietosuoja@om.fi
+            <br />
+            <a href="https://tietosuoja.fi">https://tietosuoja.fi</a>
+          </p>
+        </section>
+
+        <section>
+          <h3>Tietoon perustuva suostumus</h3>
+          <p>
+            Osallistut tutkimukseen, jossa kerätään ääninäytteitä suomenkielisten
+            lyhytvastausten tunnistamisen kehittämistä varten. Nauhoituksia käytetään
+            Linnea Technologies Oy:n tekoälypohjaisen puhelinpalvelun kehittämiseen.
+          </p>
+        </section>
+
+        <section>
+          <h3>Mitä osallistuminen tarkoittaa?</h3>
+          <p>
+            Sinulle näytetään näytöllä lyhyitä sanoja, kuten "joo", "ei" tai
+            "kyllä". Sinua pyydetään toistamaan ja nauhoittamaan nämä sanat
+            mikrofonin kautta. Nauhoittaminen vie yleensä vain muutaman minuutin.
+          </p>
+        </section>
+
+        <section>
+          <h3>Mitä tietoja kerätään?</h3>
+          <ul>
+            <li>Ääninäytteet.</li>
+            <li>Tekninen tunnistekoodi, joka käsitellään pseudonyymisti.</li>
+            <li>Vapaaehtoisesti annetut taustatiedot ja tallennusolosuhteiden tiedot.</li>
+          </ul>
+          <p>
+            Nauhoituksia ei yhdistetä nimeesi tai sähköpostiisi. Tietoja käsitellään
+            EU/ETA-alueella.
+          </p>
+        </section>
+
+        <section>
+          <h3>Osallistuminen on vapaaehtoista</h3>
+          <p>
+            Voit keskeyttää osallistumisen milloin tahansa sulkemalla selaimen. Voit
+            myös myöhemmin pyytää tietojesi poistamista tai peruuttaa suostumuksesi
+            ottamalla yhteyttä osoitteeseen{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+          </p>
+        </section>
+
+        <section>
+          <h3>Vahvistus</h3>
+          <p>Jatkamalla osallistumista vahvistat, että:</p>
+          <ul>
+            <li>Olet lukenut kuvauksen tutkimuksesta.</li>
+            <li>Ymmärrät, mitä tietoja kerätään ja mihin niitä käytetään.</li>
+            <li>Osallistut vapaaehtoisesti.</li>
+            <li>Olet täysi-ikäinen eli 18 vuotta tai vanhempi.</li>
+            <li>Olet lukenut tietosuojaselosteen ja hyväksyt tietojen keräämisen kuvatulla tavalla.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h3>Ikärajahuomio - alle 18-vuotiaat</h3>
+          <p>
+            Tämä tutkimus on tarkoitettu vain täysi-ikäisille eli 18 vuotta
+            täyttäneille. Jos et ole vielä 18-vuotias, et voi osallistua tutkimukseen.
+          </p>
+          <p>
+            Tämä ikärajaehto on pakollinen, koska emme kerää alaikäisten ääninäytteitä
+            ilman vanhemman tai huoltajan nimenomaista kirjallista suostumusta.
+          </p>
+        </section>
+
+        <section>
+          <h3>Tutkimustiedote</h3>
+          <p>
+            Linnea Technologies Oy kehittää tekoälypohjaista puhelinpalvelua, joka
+            auttaa organisaatioita vastaamaan asiakaspuheluihin. Järjestelmä tunnistaa
+            asiakkaan vastauksia, kuten "kyllä" tai "ei", ja tarvitsee harjoitusdataa
+            toimiakseen luotettavasti.
+          </p>
+          <p>
+            Tutkimuksen tavoitteena on kerätä laaja ja monimuotoinen kokoelma
+            suomenkielisiä lyhyitä äänivastauksia, joita käytetään puheentunnistuksen
+            kehittämiseen.
+          </p>
+        </section>
+
+        <section>
+          <h3>Kuka voi osallistua?</h3>
+          <ul>
+            <li>Täysi-ikäiset henkilöt eli 18-vuotiaat tai vanhemmat.</li>
+            <li>Suomen kielen puhujat.</li>
+            <li>Henkilöt, joilla on pääsy mikrofonilla varustettuun laitteeseen.</li>
+          </ul>
+        </section>
+
+        <section>
+          <h3>Miten osallistuminen tapahtuu?</h3>
+          <p>
+            Osallistuminen tapahtuu selaimen kautta tutkimussivustolla. Sinulle
+            näytetään lyhyitä suomenkielisiä sanoja, jotka toistat ääneen.
+            Nauhoittaminen vie yleensä vain muutaman minuutin.
+          </p>
+        </section>
+
+        <section>
+          <h3>Onko osallistuminen anonyymia?</h3>
+          <p>
+            Osallistuminen on pseudonyymistä. Sisäinen tekninen tunniste yhdistää omat
+            nauhoituksesi toisiinsa, mutta ei paljasta henkilöllisyyttäsi meille. Emme
+            kerää nimeäsi tai sähköpostiosoitettasi. Voit antaa vapaaehtoisesti
+            taustatietoja tutkimusdatan laadun parantamiseksi.
+          </p>
+        </section>
+
+        <section>
+          <h3>Yhteystiedot</h3>
+          <p>
+            Lisätietoja tutkimuksesta antaa Ollipekka Kivin, Linnea Technologies Oy,{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>. Tietosuojaseloste
+            on saatavilla tutkimussivustolla.
+          </p>
+        </section>
+      </div>
+
+      <div className="policy-language-block policy-language-block--helper">
+        <h2>English Helper Translation</h2>
+
+        <section>
+          <h3>Privacy Notice</h3>
+          <p>
+            Linnea Technologies Oy is the data controller for the speech-recognition
+            development study. The company collects short Finnish voice samples to
+            improve short-response speech recognition for Linnea's AI-based phone
+            service.
+          </p>
+          <p>
+            The legal basis is consent under GDPR Article 6(1)(a). The collection does
+            not ask for a participant's name, email address, or phone number during the
+            volunteer flow.
+          </p>
+        </section>
+
+        <section>
+          <h3>Controller And Contact</h3>
+          <p>
+            Linnea Technologies Oy, business ID 3571288-4, Kulmalantie 11 as. 2, 28130
+            Pori, Finland. Contact person: Ollipekka Kivin,{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>.
+          </p>
+        </section>
+
+        <section>
+          <h3>Data Collected</h3>
+          <ul>
+            <li>Short voice samples.</li>
+            <li>A pseudonymous technical identifier for grouping recordings.</li>
+            <li>Voluntary background and recording-environment information.</li>
+            <li>Basic browser, device, and microphone information for quality review.</li>
+          </ul>
+          <p>
+            Recordings are not connected to a name or email address. Data is processed
+            in the EU/EEA and is not disclosed to third parties for commercial purposes.
+          </p>
+        </section>
+
+        <section>
+          <h3>Participation And Consent</h3>
+          <p>
+            Participation is voluntary. Participants record short Finnish words or
+            responses in the browser and may stop at any time. Only people who are 18
+            years or older may participate in this app version.
+          </p>
+          <p>
+            Participants may request access, correction, deletion, or withdrawal of
+            consent by contacting{" "}
+            <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>. Withdrawal does not
+            affect processing that happened lawfully before withdrawal.
+          </p>
+        </section>
+
+        <section>
+          <h3>Research Information</h3>
+          <p>
+            Linnea Technologies Oy develops an AI-based phone service that helps
+            organizations handle customer calls. The study collects a broad and varied
+            set of short Finnish spoken responses to improve speech recognition.
+          </p>
+        </section>
+      </div>
+    </section>
+  );
+}
+
+export function PrivacyPolicyPage() {
+  return <FullPrivacyDetailsPage />;
+}
+
+export function ParticipantInfoPage() {
+  return (
+    <FullPrivacyDetailsPage compatibilityNote="This compatibility route shows the same full privacy and consent details as /#/privacy." />
+  );
+}

--- a/frontend/components/SoundRecorder.tsx
+++ b/frontend/components/SoundRecorder.tsx
@@ -1,14 +1,29 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useReactMediaRecorder } from "react-media-recorder";
 
+import {
+  buildRecordingUploadFile,
+  getActualRecordingMimeType,
+  getAudioFileExtension,
+  selectRecordingMimeType,
+} from "../utils/recordingMime";
+import type { SessionState, SessionStatus } from "../types/session";
 import { getAudioTrackTechnicalMetadata } from "../utils/technicalMetadata";
 import "./SoundRecorder.css";
+
+interface UploadSoundResult {
+  success?: boolean;
+  message?: string;
+  session?: SessionState;
+  sessionStatus?: SessionStatus;
+  [key: string]: unknown;
+}
 
 interface SoundRecorderProps {
   sessionToken: string | null;
   taskId: string;
   promptedWord: string;
-  onUploadComplete: (result: any) => Promise<void> | void;
+  onUploadComplete: (result: UploadSoundResult) => Promise<void> | void;
   onNextTask?: () => Promise<void> | void;
   nextActionLabel?: string;
 }
@@ -28,6 +43,33 @@ const SoundRecorder = ({
   onNextTask,
   nextActionLabel = "Next prompt",
 }: SoundRecorderProps) => {
+  const selectedRecordingMimeType = useMemo(() => selectRecordingMimeType(), []);
+  const mediaDebugEnabled = useMemo(() => {
+    if (!import.meta.env.DEV || typeof window === "undefined") {
+      return false;
+    }
+
+    return new URLSearchParams(window.location.search).get("mediaDebug") === "1";
+  }, []);
+  const mediaRecorderOptions = useMemo<MediaRecorderOptions | undefined>(
+    () =>
+      selectedRecordingMimeType
+        ? {
+            mimeType: selectedRecordingMimeType,
+          }
+        : undefined,
+    [selectedRecordingMimeType]
+  );
+  const blobPropertyBag = useMemo<BlobPropertyBag>(() => ({}), []);
+  const [recordingBlob, setRecordingBlob] = useState<Blob | null>(null);
+  const [playbackMessage, setPlaybackMessage] = useState<string>("");
+  const logMediaDebug = (event: string, payload: Record<string, unknown>) => {
+    if (!mediaDebugEnabled) {
+      return;
+    }
+
+    console.info("[mediaDebug]", event, payload);
+  };
   const {
     error: recorderError,
     status,
@@ -39,6 +81,21 @@ const SoundRecorder = ({
   } = useReactMediaRecorder({
     audio: true,
     video: false,
+    mediaRecorderOptions,
+    blobPropertyBag,
+    onStop: (_blobUrl, blob) => {
+      const actualMimeType = getActualRecordingMimeType(blob.type, [], selectedRecordingMimeType);
+      const typedBlob =
+        actualMimeType && blob.type !== actualMimeType ? new Blob([blob], { type: actualMimeType }) : blob;
+
+      logMediaDebug("recording-stopped", {
+        selectedMimeType: selectedRecordingMimeType || null,
+        actualBlobMimeType: typedBlob.type || null,
+        blobSize: typedBlob.size,
+        extension: getAudioFileExtension(typedBlob.type),
+      });
+      setRecordingBlob(typedBlob);
+    },
   });
   const [taskDone, setTaskDone] = useState<boolean>(false);
   const [soundUploading, setSoundUploading] = useState<boolean>(false);
@@ -57,6 +114,8 @@ const SoundRecorder = ({
     stopRecordingRef.current = stopRecording;
   }, [clearBlobUrl, stopRecording]);
 
+  useEffect(() => () => clearBlobUrlRef.current(), []);
+
   useEffect(() => {
     setTaskDone(false);
     setSoundUploading(false);
@@ -65,6 +124,8 @@ const SoundRecorder = ({
     setElapsedSeconds(0);
     setTranscriptMode("same");
     setLiteralTranscript("");
+    setRecordingBlob(null);
+    setPlaybackMessage("");
     clearBlobUrlRef.current();
   }, [taskId]);
 
@@ -101,6 +162,8 @@ const SoundRecorder = ({
 
   const handleStartRecording = () => {
     clearBlobUrl();
+    setRecordingBlob(null);
+    setPlaybackMessage("");
     setTaskDone(false);
     setUploadFailed(false);
     setUploadMessage("");
@@ -123,12 +186,12 @@ const SoundRecorder = ({
     };
   };
 
-  const uploadSound = async () => {
+  const uploadSound = async (): Promise<UploadSoundResult> => {
     if (!sessionToken) {
       throw new Error("A session token is required before uploading.");
     }
 
-    if (!mediaBlobUrl) {
+    if (!recordingBlob || recordingBlob.size === 0) {
       throw new Error("Record audio before uploading.");
     }
 
@@ -137,8 +200,7 @@ const SoundRecorder = ({
     formData.append("taskId", taskId);
     formData.append("metadata", JSON.stringify(buildUploadMetadata()));
 
-    const blob = await fetch(mediaBlobUrl).then((response) => response.blob());
-    const file = new File([blob], `${taskId}.wav`, { type: "audio/wav" });
+    const file = buildRecordingUploadFile(recordingBlob, taskId);
     formData.append("file", file);
 
     const response = await fetch(`${apiUrl}/api/upload-sound`, {
@@ -146,7 +208,7 @@ const SoundRecorder = ({
       body: formData,
     });
 
-    const data = await response.json();
+    const data = (await response.json()) as UploadSoundResult;
     if (!data.success) {
       throw new Error(data.message || "Could not upload the recording.");
     }
@@ -159,7 +221,50 @@ const SoundRecorder = ({
       <div className="recorder-preview">
         {mediaBlobUrl ? (
           <>
-            <audio src={mediaBlobUrl} controls />
+            <audio
+              key={mediaBlobUrl}
+              controls
+              preload="metadata"
+              onCanPlay={() => setPlaybackMessage("")}
+              onLoadedMetadata={(event) => {
+                setPlaybackMessage("");
+                logMediaDebug("audio-loadedmetadata", {
+                  blobMimeType: recordingBlob?.type || null,
+                  canPlayType: recordingBlob?.type
+                    ? event.currentTarget.canPlayType(recordingBlob.type)
+                    : "",
+                  duration: event.currentTarget.duration,
+                });
+              }}
+              onStalled={() => {
+                logMediaDebug("audio-stalled", {
+                  blobMimeType: recordingBlob?.type || null,
+                  blobSize: recordingBlob?.size ?? null,
+                });
+                setPlaybackMessage("Playback is still loading. If it does not start, try re-recording.");
+              }}
+              onError={(event) => {
+                const audioError = event.currentTarget.error;
+                logMediaDebug("audio-error", {
+                  blobMimeType: recordingBlob?.type || null,
+                  canPlayType: recordingBlob?.type
+                    ? event.currentTarget.canPlayType(recordingBlob.type)
+                    : "",
+                  errorCode: audioError?.code ?? null,
+                  errorMessage: audioError?.message || null,
+                });
+                setPlaybackMessage(
+                  audioError
+                    ? `Playback could not load on this device. Error code: ${audioError.code}.`
+                    : "Playback could not load on this device. Try re-recording before upload."
+                );
+              }}
+            >
+              <source src={mediaBlobUrl} type={recordingBlob?.type || undefined} />
+            </audio>
+            {playbackMessage && (
+              <p className="app-inline-message app-inline-message--error">{playbackMessage}</p>
+            )}
             <div className="recorder-transcript">
               <span>What did you actually say?</span>
               <div className="recorder-transcript__options">
@@ -243,6 +348,8 @@ const SoundRecorder = ({
               setUploadMessage("");
               const result = await uploadSound();
               setTaskDone(Boolean(onNextTask) && result.sessionStatus !== "completed");
+              setRecordingBlob(null);
+              setPlaybackMessage("");
               clearBlobUrlRef.current();
               setUploadMessage("Recording saved.");
               await onUploadComplete(result);
@@ -255,7 +362,7 @@ const SoundRecorder = ({
               setSoundUploading(false);
             }
           }}
-          disabled={status !== "stopped" || !mediaBlobUrl || soundUploading}
+          disabled={status !== "stopped" || !recordingBlob || recordingBlob.size === 0 || soundUploading}
         >
           {soundUploading ? "Uploading..." : "Upload"}
         </button>

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -535,3 +535,364 @@
     grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
   }
 }
+
+.admin-shell {
+  min-height: 100vh;
+  width: 100%;
+  padding: 16px;
+  background: #f2f6f8;
+}
+
+.admin-panel {
+  width: min(1560px, calc(100vw - 32px));
+  margin: 0 auto;
+  background: #ffffff;
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  padding: 18px;
+  box-shadow: 0 10px 28px rgba(18, 50, 74, 0.08);
+}
+
+.admin-panel--login {
+  width: min(680px, calc(100vw - 32px));
+  margin-top: 10vh;
+}
+
+.admin-panel h1,
+.admin-panel h2,
+.admin-panel h3 {
+  margin: 0;
+  color: #12324a;
+}
+
+.admin-panel h1 {
+  font-size: 28px;
+  line-height: 1.15;
+}
+
+.admin-panel h2 {
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.admin-panel h3 {
+  font-size: 15px;
+}
+
+.admin-header,
+.admin-detail-header,
+.admin-pagination,
+.admin-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.admin-header {
+  margin-bottom: 18px;
+}
+
+.admin-login-form,
+.admin-editor,
+.admin-filters {
+  display: grid;
+  gap: 12px;
+}
+
+.admin-login-form {
+  margin-top: 18px;
+}
+
+.admin-login-form label,
+.admin-editor label,
+.admin-filters label {
+  display: grid;
+  gap: 6px;
+  color: #36556f;
+  font-weight: 700;
+  font-size: 13px;
+}
+
+.admin-login-form input,
+.admin-editor input,
+.admin-editor select,
+.admin-editor textarea,
+.admin-filters input,
+.admin-filters select {
+  min-height: 42px;
+  border: 1px solid #c6d4de;
+  border-radius: 8px;
+  padding: 9px 10px;
+  color: #12324a;
+  background: #ffffff;
+  min-width: 0;
+}
+
+.admin-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(132px, 1fr));
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.admin-stat {
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #f8fbfc;
+  min-width: 0;
+}
+
+.admin-stat span {
+  display: block;
+  color: #5d7181;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.admin-stat strong {
+  display: block;
+  color: #12324a;
+  font-size: 22px;
+}
+
+.admin-dashboard,
+.admin-distributions,
+.admin-workspace {
+  display: grid;
+  gap: 14px;
+  margin-top: 14px;
+}
+
+.admin-dashboard-section,
+.admin-distribution {
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  padding: 12px;
+  min-width: 0;
+}
+
+.admin-dashboard-section dl,
+.admin-readonly-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px 14px;
+  margin: 10px 0 0;
+}
+
+.admin-dashboard-section dt,
+.admin-readonly-grid dt {
+  color: #5d7181;
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.admin-dashboard-section dd,
+.admin-readonly-grid dd {
+  margin: 0;
+  color: #12324a;
+  overflow-wrap: anywhere;
+}
+
+.admin-warning-list {
+  display: grid;
+  gap: 6px;
+  border: 1px solid #e5c07b;
+  border-radius: 8px;
+  background: #fff9ea;
+  color: #71510c;
+  padding: 10px 12px;
+  margin-top: 14px;
+}
+
+.admin-warning-list p {
+  margin: 0;
+}
+
+.admin-distribution ul {
+  list-style: none;
+  padding: 0;
+  margin: 10px 0 0;
+  display: grid;
+  gap: 6px;
+}
+
+.admin-distribution li {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  color: #36556f;
+}
+
+.admin-distribution p {
+  margin: 10px 0 0;
+  color: #5d7181;
+}
+
+.admin-list-pane,
+.admin-detail-pane {
+  min-width: 0;
+}
+
+.admin-table-wrap {
+  width: 100%;
+  overflow-x: auto;
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  margin-top: 12px;
+}
+
+.admin-table {
+  width: 100%;
+  min-width: 1120px;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+
+.admin-table th,
+.admin-table td {
+  padding: 9px 10px;
+  border-bottom: 1px solid #e5edf2;
+  text-align: left;
+  vertical-align: top;
+  overflow-wrap: anywhere;
+}
+
+.admin-table th {
+  background: #f3f7f9;
+  color: #36556f;
+  font-size: 12px;
+}
+
+.admin-table-row--selected td {
+  background: #edf7f5;
+}
+
+.admin-status {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  border-radius: 999px;
+  padding: 2px 8px;
+  font-size: 12px;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.admin-status--pending {
+  color: #5d4b00;
+  background: #fff4bf;
+}
+
+.admin-status--validated {
+  color: #0b5f58;
+  background: #dff4ef;
+}
+
+.admin-status--needs-review {
+  color: #234f87;
+  background: #e4eefb;
+}
+
+.admin-status--rejected {
+  color: #8f1d2c;
+  background: #fde5e8;
+}
+
+.admin-link-button {
+  border: 0;
+  background: transparent;
+  color: #0f766e;
+  font-weight: 700;
+  padding: 0;
+  cursor: pointer;
+}
+
+.admin-pagination {
+  margin-top: 12px;
+}
+
+.admin-detail-pane {
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  padding: 14px;
+}
+
+.admin-audio {
+  width: 100%;
+  margin: 14px 0;
+}
+
+.admin-editor {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.admin-editor__notes {
+  grid-column: 1 / -1;
+}
+
+.admin-actions {
+  justify-content: flex-start;
+  margin: 12px 0;
+}
+
+.admin-readonly-grid {
+  border-top: 1px solid #e5edf2;
+  padding-top: 12px;
+}
+
+.admin-metadata-grid {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.admin-metadata-block {
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  padding: 10px;
+}
+
+.admin-metadata-block summary {
+  cursor: pointer;
+  color: #12324a;
+  font-weight: 700;
+}
+
+.admin-metadata-block pre {
+  max-height: 280px;
+  overflow: auto;
+  margin: 10px 0 0;
+  color: #263f53;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
+@media (min-width: 720px) {
+  .admin-shell {
+    padding: 24px;
+  }
+
+  .admin-panel {
+    padding: 22px;
+  }
+
+  .admin-dashboard,
+  .admin-distributions {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .admin-filters {
+    grid-template-columns: 160px minmax(120px, 1fr) minmax(120px, 1fr) auto;
+    align-items: end;
+  }
+}
+
+@media (min-width: 1180px) {
+  .admin-workspace {
+    grid-template-columns: minmax(0, 1.35fr) minmax(420px, 0.65fr);
+    align-items: start;
+  }
+}

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -173,6 +173,212 @@
   margin-top: 20px;
 }
 
+.policy-back-link,
+.policy-page a {
+  color: #0f766e;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.policy-back-link:hover,
+.policy-page a:hover {
+  text-decoration: underline;
+}
+
+.consent-panel {
+  display: grid;
+  gap: 18px;
+}
+
+.consent-title-translation {
+  margin: -4px 0 0;
+  color: #4d677a;
+  font-size: 18px;
+  line-height: 1.35;
+}
+
+.consent-purpose {
+  display: grid;
+  gap: 10px;
+  color: #36556f;
+  line-height: 1.55;
+}
+
+.consent-purpose p {
+  margin: 0;
+}
+
+.consent-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.consent-actions > button {
+  flex: 1 1 220px;
+}
+
+.consent-steps {
+  display: grid;
+  gap: 16px;
+  border-top: 1px solid #d7e2ea;
+  border-bottom: 1px solid #d7e2ea;
+  padding: 16px 0;
+  min-width: 0;
+}
+
+.consent-steps h2 {
+  margin: 0 0 8px;
+  color: #12324a;
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.consent-steps ol {
+  margin: 0;
+  padding-left: 20px;
+  color: #36556f;
+  line-height: 1.5;
+}
+
+.consent-steps li + li {
+  margin-top: 6px;
+}
+
+.consent-summary-note {
+  display: grid;
+  gap: 10px;
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  padding: 14px;
+  background: #f7fafc;
+  color: #36556f;
+  line-height: 1.55;
+  min-width: 0;
+}
+
+.consent-summary-note h2 {
+  margin: 0;
+  color: #12324a;
+  font-size: 18px;
+  line-height: 1.25;
+}
+
+.consent-summary-note p {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.consent-read-more-link {
+  justify-self: start;
+  max-width: 100%;
+  color: #0f766e;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  text-decoration: none;
+}
+
+.consent-read-more-link:hover {
+  text-decoration: underline;
+}
+
+.consent-checks {
+  display: grid;
+  gap: 12px;
+}
+
+.consent-check {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 12px;
+  align-items: start;
+  border: 1px solid #c6d4de;
+  border-radius: 8px;
+  padding: 12px;
+  color: #12324a;
+  background: #f7fafc;
+  cursor: pointer;
+}
+
+.consent-check input {
+  width: 18px;
+  height: 18px;
+  margin-top: 2px;
+  accent-color: #0f766e;
+}
+
+.consent-check span {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.policy-page {
+  display: grid;
+  gap: 24px;
+}
+
+.policy-header {
+  display: grid;
+  gap: 8px;
+}
+
+.policy-back-link {
+  justify-self: start;
+}
+
+.policy-route-note {
+  margin: 0;
+  border: 1px solid #d7e2ea;
+  border-radius: 8px;
+  padding: 10px 12px;
+  background: #f7fafc;
+  color: #36556f;
+}
+
+.policy-language-block {
+  display: grid;
+  gap: 18px;
+  color: #36556f;
+  line-height: 1.58;
+}
+
+.policy-language-block--helper {
+  border-top: 1px solid #d7e2ea;
+  padding-top: 20px;
+}
+
+.policy-language-block h2,
+.policy-language-block h3 {
+  margin: 0;
+  color: #12324a;
+}
+
+.policy-language-block h2 {
+  font-size: 22px;
+}
+
+.policy-language-block h3 {
+  font-size: 17px;
+}
+
+.policy-language-block section {
+  display: grid;
+  gap: 8px;
+}
+
+.policy-language-block p,
+.policy-language-block ul {
+  margin: 0;
+}
+
+.policy-language-block ul {
+  padding-left: 20px;
+}
+
 .category-intro-copy {
   display: grid;
   gap: 12px;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,23 @@
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useContext, useEffect, useMemo, useState } from "react";
+import type { ReactNode } from "react";
 
 import SessionContext from "../contexts/SessionProvider";
+import ConsentGate from "../components/ConsentGate";
 import InfoForm from "../components/InfoForm";
+import { ParticipantInfoPage, PrivacyPolicyPage } from "../components/PolicyPages";
 import SessionIntro from "../components/SessionIntro";
 import SessionEndScreen from "../components/SessionEndScreen";
 import SoundRecorder from "../components/SoundRecorder";
 import TurnstileGate from "../components/TurnstileGate";
 import AdminValidationApp from "../components/AdminValidation";
 import {
+  buildConsentSessionMetadata,
+  clearStoredConsentSessionMetadata,
   getConsentDeclineMessage,
+  getStoredConsentSessionMetadata,
   hasDeclinedConsent,
   isMetadataComplete,
+  storeConsentSessionMetadata,
 } from "../utils/sessionMetadata";
 import type {
   CategoryPhraseState,
@@ -23,6 +30,7 @@ import "bootstrap/dist/css/bootstrap.min.css";
 import "./App.css";
 
 type Phase =
+  | "consent"
   | "bootstrapping"
   | "verification"
   | "intro"
@@ -49,6 +57,10 @@ const CATEGORY_HELPER_TEXT: Record<string, string> = {
   correct: "Record short confirmation phrases.",
   number: "Record number words in a clear, natural voice.",
 };
+
+function VolunteerShell({ children }: { children: ReactNode }) {
+  return <main className="app-shell">{children}</main>;
+}
 
 function getVolunteerAppTitle(value: unknown) {
   const title = typeof value === "string" ? value.replace(/\bAINA\s*/gi, "").trim() : "";
@@ -201,7 +213,7 @@ function App() {
     setProgress,
   } = useContext(SessionContext);
 
-  const [phase, setPhase] = useState<Phase>("bootstrapping");
+  const [phase, setPhase] = useState<Phase>("consent");
   const [metadataMode, setMetadataMode] = useState<MetadataMode>("required");
   const [message, setMessage] = useState<string>("");
   const [categoryState, setCategoryState] = useState<CategoryStateResponse | null>(null);
@@ -209,7 +221,9 @@ function App() {
   const [selectedPhraseId, setSelectedPhraseId] = useState<string | null>(null);
   const [categoryLoading, setCategoryLoading] = useState<boolean>(false);
   const [turnstileToken, setTurnstileToken] = useState<string | null>(null);
-  const hasBootstrapped = useRef(false);
+  const [pendingConsentMetadata, setPendingConsentMetadata] = useState<Record<string, unknown> | null>(
+    null
+  );
 
   const apiUrl = import.meta.env.VITE_API_URL;
   const appName = getVolunteerAppTitle(import.meta.env.VITE_APP_TITLE);
@@ -401,7 +415,11 @@ function App() {
   );
 
   const startOrResumeSession = useCallback(
-    async (tokenOverride?: string | null, turnstileTokenOverride?: string | null) => {
+    async (
+      tokenOverride?: string | null,
+      turnstileTokenOverride?: string | null,
+      consentMetadataOverride?: Record<string, unknown> | null
+    ) => {
       setPhase("bootstrapping");
       setMessage("");
       setCurrentTask(null);
@@ -411,6 +429,7 @@ function App() {
 
       try {
         const activeTurnstileToken = turnstileTokenOverride ?? turnstileToken;
+        const activeConsentMetadata = consentMetadataOverride ?? pendingConsentMetadata;
         const response = await fetch(`${apiUrl}/api/start-session`, {
           method: "POST",
           headers: {
@@ -419,6 +438,7 @@ function App() {
           body: JSON.stringify({
             sessionToken: tokenOverride === undefined ? sessionToken : tokenOverride,
             turnstileToken: activeTurnstileToken || undefined,
+            metadata: activeConsentMetadata || undefined,
           }),
         });
 
@@ -433,6 +453,14 @@ function App() {
 
           if (data.sessionStatus === "unavailable" || data.code === "no_topics") {
             moveToTerminalPhase("unavailable", data.message || "No prompt sets are available right now.");
+            return;
+          }
+
+          if (data.code === "consent_required") {
+            clearStoredConsentSessionMetadata();
+            setPendingConsentMetadata(null);
+            setPhase("consent");
+            setMessage(data.message || "Consent is required before a session can be started.");
             return;
           }
 
@@ -451,7 +479,7 @@ function App() {
 
         if (!isMetadataComplete(data.session?.metadata)) {
           setMetadataMode("required");
-          setPhase("intro");
+          setPhase("metadata");
           return;
         }
 
@@ -468,6 +496,7 @@ function App() {
       apiUrl,
       closeSession,
       moveToTerminalPhase,
+      pendingConsentMetadata,
       sessionToken,
       setCurrentTask,
       syncSession,
@@ -476,30 +505,65 @@ function App() {
   );
 
   useEffect(() => {
-    if (hashRoute.startsWith("#/admin")) {
+    if (
+      hashRoute.startsWith("#/admin") ||
+      hashRoute.startsWith("#/privacy") ||
+      hashRoute.startsWith("#/participant-info") ||
+      phase !== "consent"
+    ) {
       return;
     }
 
-    if (hasBootstrapped.current) {
+    const storedConsentMetadata = getStoredConsentSessionMetadata();
+    if (!storedConsentMetadata) {
       return;
     }
 
-    hasBootstrapped.current = true;
+    setPendingConsentMetadata(storedConsentMetadata);
+    setMessage("");
+
     if (turnstileSiteKey && !turnstileToken) {
       setPhase("verification");
       return;
     }
 
-    void startOrResumeSession(sessionToken, turnstileToken);
-  }, [hashRoute, sessionToken, startOrResumeSession, turnstileSiteKey, turnstileToken]);
+    void startOrResumeSession(sessionToken, turnstileToken, storedConsentMetadata);
+  }, [hashRoute, phase, sessionToken, startOrResumeSession, turnstileSiteKey, turnstileToken]);
 
   const handleTurnstileVerified = useCallback(
     async (token: string) => {
       setTurnstileToken(token);
-      await startOrResumeSession(sessionToken, token);
+      const consentMetadata =
+        pendingConsentMetadata || getStoredConsentSessionMetadata() || buildConsentSessionMetadata();
+      setPendingConsentMetadata(consentMetadata);
+      await startOrResumeSession(sessionToken, token, consentMetadata);
     },
-    [sessionToken, startOrResumeSession]
+    [pendingConsentMetadata, sessionToken, startOrResumeSession]
   );
+
+  const handleConsentAccepted = useCallback(async () => {
+    const consentMetadata = buildConsentSessionMetadata();
+    storeConsentSessionMetadata(consentMetadata);
+    setPendingConsentMetadata(consentMetadata);
+    setMessage("");
+
+    if (turnstileSiteKey && !turnstileToken) {
+      setPhase("verification");
+      return;
+    }
+
+    await startOrResumeSession(sessionToken, turnstileToken, consentMetadata);
+  }, [sessionToken, startOrResumeSession, turnstileSiteKey, turnstileToken]);
+
+  const handleConsentDeclined = useCallback(() => {
+    clearStoredConsentSessionMetadata();
+    setPendingConsentMetadata(null);
+    clearSession();
+    setMessage(
+      "Et voi jatkaa osallistumista ilman suostumusta. Voit sulkea tämän sivun. You cannot continue without consent. You may close this page."
+    );
+    setPhase("declined");
+  }, [clearSession]);
 
   const handleMetadataSaved = useCallback(
     async (session: SessionState) => {
@@ -540,15 +604,11 @@ function App() {
     setSelectedCategoryId(null);
     setSelectedPhraseId(null);
     setMetadataMode("required");
+    setPendingConsentMetadata(null);
+    setTurnstileToken(null);
     setMessage("");
-    if (turnstileSiteKey) {
-      setTurnstileToken(null);
-      setPhase("verification");
-      return;
-    }
-
-    await startOrResumeSession(null);
-  }, [clearSession, startOrResumeSession, turnstileSiteKey]);
+    setPhase("consent");
+  }, [clearSession]);
 
   const handleSelectCategory = useCallback((category: CategoryStateCategory) => {
     if (!category.unlocked) {
@@ -639,22 +699,50 @@ function App() {
     return <AdminValidationApp />;
   }
 
+  if (hashRoute.startsWith("#/privacy")) {
+    return (
+      <VolunteerShell>
+        <PrivacyPolicyPage />
+      </VolunteerShell>
+    );
+  }
+
+  if (hashRoute.startsWith("#/participant-info")) {
+    return (
+      <VolunteerShell>
+        <ParticipantInfoPage />
+      </VolunteerShell>
+    );
+  }
+
+  if (phase === "consent") {
+    return (
+      <VolunteerShell>
+        <ConsentGate
+          message={message}
+          onAccepted={handleConsentAccepted}
+          onDeclined={handleConsentDeclined}
+        />
+      </VolunteerShell>
+    );
+  }
+
   if (phase === "bootstrapping") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <section className="app-panel app-panel--narrow">
           <span className="app-eyebrow">Speech Collector</span>
           <h1 className="app-title">Preparing your session</h1>
           <p className="app-copy">Connecting to the next available prompt set.</p>
         </section>
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "verification") {
     if (!turnstileSiteKey) {
       return (
-        <main className="app-shell">
+        <VolunteerShell>
           <section className="app-panel app-panel--narrow">
             <span className="app-eyebrow">Speech Collector</span>
             <h1 className="app-title">Verification unavailable</h1>
@@ -662,24 +750,24 @@ function App() {
               Human verification is required, but the Turnstile site key is not configured.
             </p>
           </section>
-        </main>
+        </VolunteerShell>
       );
     }
 
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <TurnstileGate
           siteKey={turnstileSiteKey}
           message={message}
           onVerified={handleTurnstileVerified}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "intro") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionIntro
           title="Short Finnish response collection"
           summary="This session records short spoken answers for phone-quality speech classification."
@@ -691,31 +779,31 @@ function App() {
           actionLabel="Continue"
           onContinue={() => setPhase("metadata")}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "metadata") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <InfoForm
           message={
             message ||
             (metadataMode === "required"
-              ? "Tell us a little about the recording conditions and confirm consent before you begin."
+              ? "Tell us a little about the recording conditions before you begin."
               : "Update the session details if something changed.")
           }
           canCancel={metadataMode === "edit" && metadataComplete}
           onCancel={() => setPhase(categoryState ? "categoryRecording" : "categoryIntro")}
           onSaved={handleMetadataSaved}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "categoryIntro") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <section className="app-panel app-panel--narrow">
           <span className="app-eyebrow">{appName}</span>
           <h1 className="app-title">Record Finnish short responses</h1>
@@ -748,77 +836,77 @@ function App() {
           </div>
           {message && <p className="app-inline-message app-inline-message--error">{message}</p>}
         </section>
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "completed") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="Session complete"
           message={message || "Thank you. Your recordings were saved."}
           actionLabel="Start a new session"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "abandoned") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="Session closed"
           message={message || "Your submitted recordings were saved."}
           actionLabel="Start a new session"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "declined") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="Thanks for your response"
           message={message || "This session has been closed and no prompts were shown."}
           actionLabel="Start over"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "unavailable") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="No prompts available"
           message={message || "There are no prompt sets available right now."}
           actionLabel="Try again"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   if (phase === "error") {
     return (
-      <main className="app-shell">
+      <VolunteerShell>
         <SessionEndScreen
           title="Something went wrong"
           message={message || "The session could not continue."}
           actionLabel="Start over"
           onRestart={handleRestart}
         />
-      </main>
+      </VolunteerShell>
     );
   }
 
   return (
-    <main className="app-shell">
+    <VolunteerShell>
       <section className="app-panel app-panel--wide">
         <header className="app-header">
           <div className="app-header__content">
@@ -1004,7 +1092,7 @@ function App() {
           <p className="app-inline-message">{message}</p>
         )}
       </section>
-    </main>
+    </VolunteerShell>
   );
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import SessionIntro from "../components/SessionIntro";
 import SessionEndScreen from "../components/SessionEndScreen";
 import SoundRecorder from "../components/SoundRecorder";
 import TurnstileGate from "../components/TurnstileGate";
+import AdminValidationApp from "../components/AdminValidation";
 import {
   getConsentDeclineMessage,
   hasDeclinedConsent,
@@ -190,6 +191,7 @@ function getPhraseStatusClassName(phrase: CategoryPhraseState) {
 }
 
 function App() {
+  const [hashRoute, setHashRoute] = useState<string>(() => window.location.hash);
   const {
     sessionToken,
     participantMetadata,
@@ -212,6 +214,12 @@ function App() {
   const apiUrl = import.meta.env.VITE_API_URL;
   const appName = getVolunteerAppTitle(import.meta.env.VITE_APP_TITLE);
   const turnstileSiteKey = import.meta.env.VITE_TURNSTILE_SITE_KEY || "";
+
+  useEffect(() => {
+    const handleHashChange = () => setHashRoute(window.location.hash);
+    window.addEventListener("hashchange", handleHashChange);
+    return () => window.removeEventListener("hashchange", handleHashChange);
+  }, []);
 
   const metadataComplete = useMemo(
     () => isMetadataComplete(participantMetadata),
@@ -468,6 +476,10 @@ function App() {
   );
 
   useEffect(() => {
+    if (hashRoute.startsWith("#/admin")) {
+      return;
+    }
+
     if (hasBootstrapped.current) {
       return;
     }
@@ -479,7 +491,7 @@ function App() {
     }
 
     void startOrResumeSession(sessionToken, turnstileToken);
-  }, [sessionToken, startOrResumeSession, turnstileSiteKey, turnstileToken]);
+  }, [hashRoute, sessionToken, startOrResumeSession, turnstileSiteKey, turnstileToken]);
 
   const handleTurnstileVerified = useCallback(
     async (token: string) => {
@@ -622,6 +634,10 @@ function App() {
       syncSession,
     ]
   );
+
+  if (hashRoute.startsWith("#/admin")) {
+    return <AdminValidationApp />;
+  }
 
   if (phase === "bootstrapping") {
     return (

--- a/frontend/utils/recordingMime.test.mjs
+++ b/frontend/utils/recordingMime.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildRecordingUploadFile,
+  getActualRecordingMimeType,
+  getAudioFileExtension,
+  selectRecordingMimeType,
+} from "./recordingMime.ts";
+
+function mediaRecorderWithSupport(supportedTypes) {
+  const supported = new Set(supportedTypes);
+  return {
+    isTypeSupported: (mimeType) => supported.has(mimeType),
+  };
+}
+
+test("iPhone/WebKit capability set selects MP4/AAC first", () => {
+  const navigatorLike = {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+    platform: "iPhone",
+    maxTouchPoints: 5,
+  };
+
+  assert.equal(
+    selectRecordingMimeType(
+      mediaRecorderWithSupport(["audio/mp4;codecs=mp4a.40.2", "audio/webm;codecs=opus"]),
+      navigatorLike
+    ),
+    "audio/mp4;codecs=mp4a.40.2"
+  );
+});
+
+test("Android/Chrome capability set selects WebM/Opus first", () => {
+  const navigatorLike = {
+    userAgent:
+      "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Mobile Safari/537.36",
+    platform: "Linux armv8l",
+    maxTouchPoints: 5,
+  };
+
+  assert.equal(
+    selectRecordingMimeType(
+      mediaRecorderWithSupport(["audio/mp4;codecs=mp4a.40.2", "audio/webm;codecs=opus"]),
+      navigatorLike
+    ),
+    "audio/webm;codecs=opus"
+  );
+});
+
+test("MP4 is selected when WebM is unsupported", () => {
+  assert.equal(
+    selectRecordingMimeType(mediaRecorderWithSupport(["audio/mp4"]), {
+      userAgent: "Mozilla/5.0 Chrome/126.0 Safari/537.36",
+      platform: "Win32",
+      maxTouchPoints: 0,
+    }),
+    "audio/mp4"
+  );
+});
+
+test("unsupported candidates and unavailable MediaRecorder fall back to browser default", () => {
+  assert.equal(selectRecordingMimeType(mediaRecorderWithSupport([])), undefined);
+  assert.equal(selectRecordingMimeType(undefined), undefined);
+});
+
+test("actual recorder or chunk MIME type is preferred over fallback", () => {
+  assert.equal(
+    getActualRecordingMimeType("audio/webm;codecs=opus", [], "audio/mp4"),
+    "audio/webm;codecs=opus"
+  );
+  assert.equal(
+    getActualRecordingMimeType("", [new Blob(["x"], { type: "audio/ogg;codecs=opus" })], "audio/mp4"),
+    "audio/ogg;codecs=opus"
+  );
+  assert.equal(getActualRecordingMimeType("", [], "audio/mp4"), "audio/mp4");
+});
+
+test("known MIME types map to matching upload extensions", () => {
+  assert.equal(getAudioFileExtension("audio/webm;codecs=opus"), "webm");
+  assert.equal(getAudioFileExtension("audio/webm"), "webm");
+  assert.equal(getAudioFileExtension("audio/mp4;codecs=mp4a.40.2"), "m4a");
+  assert.equal(getAudioFileExtension("audio/mp4"), "m4a");
+  assert.equal(getAudioFileExtension("audio/ogg;codecs=opus"), "ogg");
+  assert.equal(getAudioFileExtension("audio/wav"), "wav");
+});
+
+test("unknown and empty MIME types use a neutral fallback, not fake WAV", () => {
+  assert.equal(getAudioFileExtension(""), "bin");
+  assert.equal(getAudioFileExtension(undefined), "bin");
+  assert.equal(getAudioFileExtension("application/octet-stream"), "bin");
+});
+
+test("upload file uses original blob bytes, MIME, and matching extension", async () => {
+  const bytes = new Uint8Array([1, 2, 3, 4]);
+  const blob = new Blob([bytes], { type: "audio/webm;codecs=opus" });
+  const file = buildRecordingUploadFile(blob, "task-123");
+
+  assert.equal(file.name, "task-123.webm");
+  assert.equal(file.type, "audio/webm;codecs=opus");
+  assert.equal(file.size, blob.size);
+  assert.deepEqual(new Uint8Array(await file.arrayBuffer()), bytes);
+});
+
+test("upload file does not unconditionally use WAV for unknown blob types", () => {
+  const file = buildRecordingUploadFile(new Blob(["opaque-bytes"]), "task-123");
+
+  assert.equal(file.name, "task-123.bin");
+  assert.equal(file.type, "application/octet-stream");
+});

--- a/frontend/utils/recordingMime.ts
+++ b/frontend/utils/recordingMime.ts
@@ -1,0 +1,95 @@
+type MediaRecorderConstructorLike = {
+  isTypeSupported?: (mimeType: string) => boolean;
+};
+
+type NavigatorLike = {
+  userAgent?: string;
+  platform?: string;
+  maxTouchPoints?: number;
+};
+
+const MP4_AUDIO_TYPES = ["audio/mp4;codecs=mp4a.40.2", "audio/mp4"];
+const WEBM_AUDIO_TYPES = ["audio/webm;codecs=opus", "audio/webm"];
+const FALLBACK_AUDIO_TYPES = ["audio/ogg;codecs=opus", "audio/ogg", "audio/wav"];
+const UNKNOWN_AUDIO_UPLOAD_MIME_TYPE = "application/octet-stream";
+
+function getNavigatorLike(): NavigatorLike | undefined {
+  return typeof navigator === "undefined" ? undefined : navigator;
+}
+
+export function shouldPreferMp4Recording(navigatorLike: NavigatorLike | undefined = getNavigatorLike()) {
+  const userAgent = navigatorLike?.userAgent || "";
+  const platform = navigatorLike?.platform || "";
+  const maxTouchPoints = navigatorLike?.maxTouchPoints || 0;
+  const isiOS =
+    /iPad|iPhone|iPod/i.test(userAgent) || (platform === "MacIntel" && maxTouchPoints > 1);
+  const isSafari = /Safari/i.test(userAgent) && !/Chrome|Chromium|CriOS|FxiOS|Edg/i.test(userAgent);
+
+  return isiOS || isSafari;
+}
+
+export function getRecordingMimeTypeCandidates(
+  navigatorLike: NavigatorLike | undefined = getNavigatorLike()
+) {
+  return shouldPreferMp4Recording(navigatorLike)
+    ? [...MP4_AUDIO_TYPES, ...WEBM_AUDIO_TYPES, ...FALLBACK_AUDIO_TYPES]
+    : [...WEBM_AUDIO_TYPES, ...FALLBACK_AUDIO_TYPES, ...MP4_AUDIO_TYPES];
+}
+
+export function selectRecordingMimeType(
+  mediaRecorderConstructor: MediaRecorderConstructorLike | undefined =
+    typeof MediaRecorder === "undefined" ? undefined : MediaRecorder,
+  navigatorLike: NavigatorLike | undefined = getNavigatorLike()
+) {
+  if (!mediaRecorderConstructor?.isTypeSupported) {
+    return undefined;
+  }
+
+  return getRecordingMimeTypeCandidates(navigatorLike).find((mimeType) =>
+    mediaRecorderConstructor.isTypeSupported?.(mimeType)
+  );
+}
+
+export function getActualRecordingMimeType(
+  recorderMimeType: string | undefined,
+  chunks: Blob[],
+  fallbackMimeType: string | undefined
+) {
+  return (
+    recorderMimeType ||
+    chunks.find((chunk) => chunk.type)?.type ||
+    fallbackMimeType ||
+    ""
+  );
+}
+
+export function getAudioFileExtension(mimeType: string | undefined) {
+  const containerType = (mimeType || "").split(";")[0].trim().toLowerCase();
+
+  switch (containerType) {
+    case "audio/mp4":
+    case "video/mp4":
+      return "m4a";
+    case "audio/webm":
+    case "video/webm":
+      return "webm";
+    case "audio/ogg":
+      return "ogg";
+    case "audio/wav":
+    case "audio/wave":
+    case "audio/x-wav":
+      return "wav";
+    case "audio/aac":
+      return "aac";
+    case "audio/mpeg":
+      return "mp3";
+    default:
+      return "bin";
+  }
+}
+
+export function buildRecordingUploadFile(recordingBlob: Blob, taskId: string) {
+  return new File([recordingBlob], `${taskId}.${getAudioFileExtension(recordingBlob.type)}`, {
+    type: recordingBlob.type || UNKNOWN_AUDIO_UPLOAD_MIME_TYPE,
+  });
+}

--- a/frontend/utils/sessionMetadata.ts
+++ b/frontend/utils/sessionMetadata.ts
@@ -9,7 +9,11 @@ import {
 import { getBrowserTechnicalMetadata } from './technicalMetadata';
 
 const DEFAULT_CONSENT_DECLINE_MESSAGE =
-  'Thank you for your response. This session has been closed and no prompts will be shown.';
+  'Et voi jatkaa osallistumista ilman suostumusta. Voit sulkea tämän sivun. You cannot continue without consent. You may close this page.';
+
+export const CONSENT_VERSION = '1.0';
+export const PRIVACY_NOTICE_VERSION = '1.0';
+export const CONSENT_STORAGE_KEY = 'speechCollectorConsent';
 
 type FormValues = Record<string, string | number | null | undefined>;
 type MetadataObject = Record<string, unknown>;
@@ -31,6 +35,32 @@ function normalizeMetadataValue(value: unknown) {
 function optionalText(value: unknown) {
   const normalized = normalizeMetadataValue(value);
   return normalized || null;
+}
+
+function getLocalStorage() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isValidIsoTimestamp(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0 && Number.isFinite(Date.parse(value));
+}
+
+function hasValidStoredConsent(metadata: MetadataObject) {
+  return (
+    metadata.consent_response === 'yes' &&
+    metadata.consent_version === CONSENT_VERSION &&
+    metadata.privacy_notice_version === PRIVACY_NOTICE_VERSION &&
+    metadata.age_confirmed_18_or_over === true &&
+    isValidIsoTimestamp(metadata.consent_accepted_at)
+  );
 }
 
 export function flattenSessionMetadata(
@@ -57,6 +87,68 @@ export function flattenSessionMetadata(
     audio_hardware: normalizeMetadataValue(environment.audio_hardware ?? root.audio_hardware),
     consent_response: normalizeMetadataValue(root.consent_response),
   };
+}
+
+export function buildConsentSessionMetadata(acceptedAt = new Date().toISOString()) {
+  return {
+    schema_version: 'v1',
+    device_id: getOrCreateDeviceId(),
+    consent_response: 'yes',
+    consent_version: CONSENT_VERSION,
+    privacy_notice_version: PRIVACY_NOTICE_VERSION,
+    consent_accepted_at: acceptedAt,
+    age_confirmed_18_or_over: true,
+    technical: getBrowserTechnicalMetadata(),
+  };
+}
+
+export function getStoredConsentSessionMetadata() {
+  const storage = getLocalStorage();
+  if (!storage) {
+    return null;
+  }
+
+  const storedValue = storage.getItem(CONSENT_STORAGE_KEY);
+  if (!storedValue) {
+    return null;
+  }
+
+  try {
+    const storedConsent = asRecord(JSON.parse(storedValue));
+    if (!hasValidStoredConsent(storedConsent)) {
+      storage.removeItem(CONSENT_STORAGE_KEY);
+      return null;
+    }
+
+    return buildConsentSessionMetadata(String(storedConsent.consent_accepted_at));
+  } catch {
+    storage.removeItem(CONSENT_STORAGE_KEY);
+    return null;
+  }
+}
+
+export function storeConsentSessionMetadata(metadata: Record<string, unknown>) {
+  const storage = getLocalStorage();
+  const consentMetadata = asRecord(metadata);
+
+  if (!storage || !hasValidStoredConsent(consentMetadata)) {
+    return;
+  }
+
+  storage.setItem(
+    CONSENT_STORAGE_KEY,
+    JSON.stringify({
+      consent_response: 'yes',
+      consent_version: CONSENT_VERSION,
+      privacy_notice_version: PRIVACY_NOTICE_VERSION,
+      consent_accepted_at: consentMetadata.consent_accepted_at,
+      age_confirmed_18_or_over: true,
+    })
+  );
+}
+
+export function clearStoredConsentSessionMetadata() {
+  getLocalStorage()?.removeItem(CONSENT_STORAGE_KEY);
 }
 
 function isAllowedSelectValue(field: InfoFormField, value: unknown) {
@@ -102,6 +194,11 @@ export function hasDeclinedConsent(metadata: Record<string, unknown> | null | un
     return false;
   }
 
+  const root = asRecord(metadata);
+  if (root.consent_response === 'no') {
+    return true;
+  }
+
   const values = flattenSessionMetadata(metadata);
 
   return infoFormConfig.some(
@@ -124,15 +221,30 @@ export function getConsentDeclineMessage(metadata: Record<string, unknown> | nul
     : DEFAULT_CONSENT_DECLINE_MESSAGE;
 }
 
-export function buildV1SessionMetadata(values: FormValues) {
+export function buildV1SessionMetadata(
+  values: FormValues,
+  existingMetadata: Record<string, unknown> | null | undefined = {}
+) {
+  const existing = asRecord(existingMetadata);
   const nativeLanguage = normalizeMetadataValue(values.native_language);
   const dialectRegion = normalizeMetadataValue(values.dialect_region);
-  const consentResponse = normalizeMetadataValue(values.consent_response);
+  const consentResponse =
+    normalizeMetadataValue(existing.consent_response) ||
+    normalizeMetadataValue(values.consent_response);
+  const deviceId =
+    normalizeMetadataValue(existing.device_id) ||
+    (consentResponse === 'yes' ? getOrCreateDeviceId() : '');
+  const existingTechnical = asRecord(existing.technical);
 
   return {
     schema_version: 'v1',
-    device_id: consentResponse === 'yes' ? getOrCreateDeviceId() : null,
+    device_id: deviceId || null,
     consent_response: consentResponse,
+    consent_version: normalizeMetadataValue(existing.consent_version) || CONSENT_VERSION,
+    privacy_notice_version:
+      normalizeMetadataValue(existing.privacy_notice_version) || PRIVACY_NOTICE_VERSION,
+    consent_accepted_at: normalizeMetadataValue(existing.consent_accepted_at) || null,
+    age_confirmed_18_or_over: existing.age_confirmed_18_or_over === true,
     demographics: {
       age_group: normalizeMetadataValue(values.age_group),
       gender: normalizeMetadataValue(values.gender),
@@ -147,6 +259,9 @@ export function buildV1SessionMetadata(values: FormValues) {
       noise_level: normalizeMetadataValue(values.noise_level),
       audio_hardware: normalizeMetadataValue(values.audio_hardware),
     },
-    technical: getBrowserTechnicalMetadata(),
+    technical: {
+      ...existingTechnical,
+      ...getBrowserTechnicalMetadata(),
+    },
   };
 }

--- a/infoFormConfig.json
+++ b/infoFormConfig.json
@@ -5,7 +5,6 @@
     "id": "age_group",
     "required": true,
     "options": [
-      { "value": "under_18", "label": "Under 18" },
       { "value": "18-25", "label": "18-25" },
       { "value": "26-35", "label": "26-35" },
       { "value": "36-50", "label": "36-50" },
@@ -112,23 +111,5 @@
         "label": "Not sure / I don't know"
       }
     ]
-  },
-  {
-    "label": "Consent",
-    "type": "consent_markdown_yes_no",
-    "id": "consent_response",
-    "required": true,
-    "markdown": "### Consent to participate\nBy choosing **Yes**, you confirm that:\n\n- these recordings are collected for a speech-classifier project\n- your recordings and session details may be stored, reviewed, and exported for research and model development\n- an anonymous random browser ID is stored in this browser so we can resume an active session and show which phrases this browser has already recorded\n- the browser ID is not a hardware serial number and does not include your name, email, or phone number\n- clearing browser storage removes this ID from this browser, but recordings already submitted remain stored under the previous anonymous ID\n- basic browser, device, and microphone information may be collected automatically to understand recording quality\n- participation is voluntary and you may stop at any time",
-    "options": [
-      {
-        "value": "yes",
-        "label": "Yes, I consent"
-      },
-      {
-        "value": "no",
-        "label": "No, I do not consent"
-      }
-    ],
-    "declineMessage": "Thank you for your response. This session has been closed and no prompts were shown."
   }
 ]

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
     "dev:frontend": "dotenv -e ./.env -- pnpm --filter sound-collector-frontend dev",
     "dev": "concurrently \"pnpm run dev:backend\" \"pnpm run dev:frontend\"",
     "build": "dotenv -e ./.env -- pnpm --filter sound-collector-frontend build",
-    "test:backend": "dotenv -e ./.env -- node --test backend/src/config.test.js backend/src/taskProvider.test.js backend/src/fileStorage.test.js backend/src/index.test.js scripts/aina/pushPrompts.test.js scripts/aina/exportDataset.test.js scripts/aina/exportDatabuilderDataset.test.js",
+    "test:backend": "dotenv -e ./.env -- node --test backend/src/config.test.js backend/src/taskProvider.test.js backend/src/fileStorage.test.js backend/src/admin.test.js backend/src/index.test.js scripts/aina/pushPrompts.test.js scripts/aina/exportDataset.test.js scripts/aina/exportDatabuilderDataset.test.js",
     "serve": "concurrently \"pnpm run dev:backend\" \"pnpm --filter sound-collector-frontend serve\"",
     "aina:seed": "dotenv -e ./.env -- node scripts/aina/pushPrompts.js scripts/aina/short_finnish_prompts.json",
     "aina:export": "dotenv -e ./.env -- node scripts/aina/exportDataset.js",
-    "aina:export:databuilder": "dotenv -e ./.env -- node scripts/aina/exportDatabuilderDataset.js"
+    "aina:export:databuilder": "dotenv -e ./.env -- node scripts/aina/exportDatabuilderDataset.js",
+    "admin:hash-password": "node scripts/aina/hashAdminPassword.js"
   },
   "devDependencies": {
     "concurrently": "^9.0.1",

--- a/scripts/aina/exportDatabuilderDataset.js
+++ b/scripts/aina/exportDatabuilderDataset.js
@@ -5,6 +5,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 
 import {
+  buildConsentGovernanceMetadata,
   configValue,
   createDbClient,
   ensureDirectory,
@@ -256,6 +257,7 @@ export function buildDatabuilderSidecar(row) {
       category: category || null,
       phrase_id: phraseId,
       semantic_label: semanticLabel,
+      consent: buildConsentGovernanceMetadata(sessionMetadata),
     },
     storage: getDatabuilderStorageInfo(row),
   };

--- a/scripts/aina/exportDatabuilderDataset.js
+++ b/scripts/aina/exportDatabuilderDataset.js
@@ -11,9 +11,11 @@ import {
   expireStaleSessions,
   fetchCompletedRows,
   filterRowsForActiveStorage,
+  filterRowsForValidation,
   getActiveStorageType,
   getDurationSec,
   getPhraseId,
+  getRecordingValidationStatus,
   getSemanticLabel,
   pseudonymizeDeviceId,
   pseudonymizeSpeaker,
@@ -23,7 +25,7 @@ import {
   getSoundRecordingsRoot,
   normalizeStorageKey,
 } from '../../backend/src/config.js';
-import { FileStorage } from '../../backend/src/fileStorage.js';
+import { buildMetadataSidecarStorageKey, FileStorage } from '../../backend/src/fileStorage.js';
 
 const DEFAULT_DATABUILDER_OUTPUT_DIR = './exports/short-finnish-responses/v2/databuilder';
 const DEFAULT_DATABUILDER_MANIFEST_VERSION = '20260501001';
@@ -138,11 +140,13 @@ export function getDatabuilderStorageInfo(row) {
   const storageKey = normalizeStorageObjectKey(row.storage_key);
   const objectKey =
     storageType === 'local' ? storageKey : inferRemoteObjectKey(row, recordingMetadata);
+  const metadataObjectKey = objectKey ? buildMetadataSidecarStorageKey(objectKey) : null;
 
   return {
     storage_type: storageType,
     storage_key: storageKey,
     object_key: objectKey || null,
+    metadata_object_key: metadataObjectKey,
     bucket_name: getBucketName(row, recordingMetadata),
   };
 }
@@ -205,6 +209,7 @@ export function buildDatabuilderSidecar(row) {
   const phraseId = getPhraseId(row);
   const semanticLabel = getSemanticLabel(row);
   const submittedAt = normalizeTimestamp(row.submitted_at || recordingMetadata.timestamp);
+  const validation = isPlainObject(recordingMetadata.validation) ? recordingMetadata.validation : {};
 
   if (!normalizedLabel) {
     throw new Error(`Recording ${sampleId} is missing normalized_label.`);
@@ -221,6 +226,12 @@ export function buildDatabuilderSidecar(row) {
     label_source: recordingMetadata.label_source || 'prompt_assumed',
     language,
     category: category || null,
+    validation: {
+      status: getRecordingValidationStatus(row),
+      validated_at: normalizeTimestamp(validation.validated_at),
+      notes: normalizeOptionalString(validation.notes),
+    },
+    original: true,
     augmentation_strategy: null,
     augmentations: [],
     device_id: pseudonymizeDeviceId(row),
@@ -355,6 +366,7 @@ export function buildDatabuilderExportSummary(summary) {
     'Databuilder export summary:',
     `- considered recordings: ${summary.consideredRowCount}`,
     `- exported recordings: ${summary.exportedRowCount}`,
+    `- skipped validation filter: ${summary.skippedValidationCount || 0}`,
     `- skipped legacy/missing processed_audio: ${summary.skippedLegacyProcessedAudioCount}`,
     `- skipped storage mismatch: ${summary.skippedStorageMismatchCount}`,
     `- output directory: ${summary.outputDir}`,
@@ -365,14 +377,16 @@ export async function exportDatabuilderRows(rows, options = {}) {
   const outputDir = path.resolve(options.outputDir || getDatabuilderOutputDir());
   ensureDirectory(outputDir);
 
+  const validationFilter = filterRowsForValidation(rows, options.validationFilter);
   const storageFilter = filterRowsForActiveStorage(
-    rows,
+    validationFilter.exportRows,
     options.activeStorageType || getActiveStorageType()
   );
   const classifierReadyFilter = filterRowsForClassifierReadyAudio(storageFilter.exportRows);
   const summary = {
     consideredRowCount: rows.length,
     exportedRowCount: classifierReadyFilter.exportRows.length,
+    skippedValidationCount: validationFilter.skippedRowCount,
     skippedLegacyProcessedAudioCount: classifierReadyFilter.skippedRowCount,
     skippedStorageMismatchCount: storageFilter.skippedRowCount,
     outputDir,
@@ -415,6 +429,7 @@ export async function exportDatabuilderRows(rows, options = {}) {
     manifest,
     manifestPath,
     samples: writtenSamples,
+    validationFilter,
     storageFilter,
     classifierReadyFilter,
     summary,

--- a/scripts/aina/exportDatabuilderDataset.test.js
+++ b/scripts/aina/exportDatabuilderDataset.test.js
@@ -102,6 +102,11 @@ function makeRow(overrides = {}) {
         channel_count: 1,
         encoding: 'pcm_s16le',
       },
+      validation: {
+        status: 'validated',
+        validated_at: '2026-04-23T10:00:00.000Z',
+        notes: 'checked',
+      },
       storage: {
         object_key: 'session-123/short_finnish_responses_v1_0001_kylla.wav',
         bucket_name: null,
@@ -133,6 +138,12 @@ test('buildDatabuilderSidecar creates root-level databuilder fields', () => {
   assert.equal(sidecar.label_source, 'user_confirmed');
   assert.equal(sidecar.language, 'fi');
   assert.equal(sidecar.category, 'affirmative');
+  assert.deepEqual(sidecar.validation, {
+    status: 'validated',
+    validated_at: '2026-04-23T10:00:00.000Z',
+    notes: 'checked',
+  });
+  assert.equal(sidecar.original, true);
   assert.equal(sidecar.augmentation_strategy, null);
   assert.deepEqual(sidecar.augmentations, []);
   assert.match(sidecar.device_id, /^dev_[a-f0-9]{12}$/);
@@ -150,6 +161,10 @@ test('buildDatabuilderSidecar creates root-level databuilder fields', () => {
   assert.equal(sidecar.collection.phrase_id, 'yes_kylla');
   assert.equal(sidecar.collection.semantic_label, 'yes');
   assert.equal(sidecar.storage.storage_key, 'session-123/short_finnish_responses_v1_0001_kylla.wav');
+  assert.equal(
+    sidecar.storage.metadata_object_key,
+    'session-123/short_finnish_responses_v1_0001_kylla.json'
+  );
   assert.equal(Object.hasOwn(sidecar, 'metadata'), false);
 });
 
@@ -158,6 +173,7 @@ test('required sidecar keys always exist for original recordings', () => {
     makeRow({
       recording_metadata: {
         normalized_label: 'kylla',
+        validation: { status: 'validated' },
       },
       session_metadata: {},
     })
@@ -169,6 +185,10 @@ test('required sidecar keys always exist for original recordings', () => {
   assert.equal(sidecar.augmentation_strategy, null);
   assert.equal(Object.hasOwn(sidecar, 'augmentations'), true);
   assert.deepEqual(sidecar.augmentations, []);
+  assert.equal(Object.hasOwn(sidecar, 'validation'), true);
+  assert.equal(sidecar.validation.status, 'validated');
+  assert.equal(Object.hasOwn(sidecar, 'original'), true);
+  assert.equal(sidecar.original, true);
   assert.equal(Object.hasOwn(sidecar, 'processed_audio'), true);
   assert.equal(sidecar.processed_audio, null);
   assert.equal(Object.hasOwn(sidecar, 'demographics'), true);
@@ -274,6 +294,7 @@ test('aws-s3 export downloads the metadata object key as sample_id.wav', async (
         channel_count: 1,
         encoding: 'pcm_s16le',
       },
+      validation: { status: 'validated' },
       storage: {
         object_key: 'short-finnish-responses/v1/audio/session-123/short_finnish_responses_v1_0001_kylla.wav',
         bucket_name: 'voice-training',
@@ -327,6 +348,66 @@ test('valid processed_audio rows are exported and summarized', async () => {
   assert.equal(result.summary.skippedStorageMismatchCount, 0);
 });
 
+test('databuilder export applies validation filter before processed audio filtering', async () => {
+  const recordingsRoot = makeTempDir();
+  const outputDir = makeTempDir();
+  const validatedRow = makeRow({
+    recording_id: '11111111-1111-4111-8111-111111111111',
+  });
+  const pendingRow = makeRow({
+    recording_id: '22222222-2222-4222-8222-222222222222',
+    recording_metadata: {
+      ...makeRow().recording_metadata,
+      validation: { status: 'pending' },
+    },
+  });
+  writeLocalAudio(recordingsRoot, validatedRow);
+
+  const result = await exportDatabuilderRows([validatedRow, pendingRow], {
+    outputDir,
+    recordingsRoot,
+    activeStorageType: 'local',
+    manifestVersion: 'test-version',
+    log: false,
+  });
+
+  assert.deepEqual(Object.keys(result.manifest.samples), [validatedRow.recording_id]);
+  assert.equal(result.summary.skippedValidationCount, 1);
+  assert.equal(existsSync(path.join(outputDir, `${pendingRow.recording_id}.json`)), false);
+});
+
+test('databuilder not_rejected filter excludes rejected rows only', async () => {
+  const recordingsRoot = makeTempDir();
+  const outputDir = makeTempDir();
+  const pendingRow = makeRow({
+    recording_id: '11111111-1111-4111-8111-111111111111',
+    recording_metadata: {
+      ...makeRow().recording_metadata,
+      validation: { status: 'pending' },
+    },
+  });
+  const rejectedRow = makeRow({
+    recording_id: '22222222-2222-4222-8222-222222222222',
+    recording_metadata: {
+      ...makeRow().recording_metadata,
+      validation: { status: 'rejected' },
+    },
+  });
+  writeLocalAudio(recordingsRoot, pendingRow);
+
+  const result = await exportDatabuilderRows([pendingRow, rejectedRow], {
+    outputDir,
+    recordingsRoot,
+    activeStorageType: 'local',
+    validationFilter: 'not_rejected',
+    manifestVersion: 'test-version',
+    log: false,
+  });
+
+  assert.deepEqual(Object.keys(result.manifest.samples), [pendingRow.recording_id]);
+  assert.equal(result.summary.skippedValidationCount, 1);
+});
+
 test('rows with null or missing processed_audio are skipped by default', async () => {
   const recordingsRoot = makeTempDir();
   const outputDir = makeTempDir();
@@ -338,12 +419,14 @@ test('rows with null or missing processed_audio are skipped by default', async (
     recording_metadata: {
       normalized_label: 'kylla',
       processed_audio: null,
+      validation: { status: 'validated' },
     },
   });
   const missingProcessedAudioRow = makeRow({
     recording_id: '33333333-3333-4333-8333-333333333333',
     recording_metadata: {
       normalized_label: 'kylla',
+      validation: { status: 'validated' },
     },
   });
   writeLocalAudio(recordingsRoot, validRow);
@@ -380,6 +463,7 @@ test('rows with wrong processed_audio values are skipped by default', async () =
         channel_count: 1,
         encoding: 'pcm_s16le',
       },
+      validation: { status: 'validated' },
     },
   });
   const wrongChannelRow = makeRow({
@@ -391,6 +475,7 @@ test('rows with wrong processed_audio values are skipped by default', async () =
         channel_count: 2,
         encoding: 'pcm_s16le',
       },
+      validation: { status: 'validated' },
     },
   });
   const wrongEncodingRow = makeRow({
@@ -402,6 +487,7 @@ test('rows with wrong processed_audio values are skipped by default', async () =
         channel_count: 1,
         encoding: 'opus',
       },
+      validation: { status: 'validated' },
     },
   });
   writeLocalAudio(recordingsRoot, validRow);
@@ -427,6 +513,7 @@ test('databuilder export fails clearly when no classifier-ready rows remain', as
     recording_metadata: {
       normalized_label: 'kylla',
       processed_audio: null,
+      validation: { status: 'validated' },
     },
   });
 

--- a/scripts/aina/exportDatabuilderDataset.test.js
+++ b/scripts/aina/exportDatabuilderDataset.test.js
@@ -59,6 +59,11 @@ function makeRow(overrides = {}) {
     session_metadata: {
       schema_version: 'v1',
       device_id: 'device-123',
+      consent_response: 'yes',
+      consent_version: '1.0',
+      privacy_notice_version: '1.0',
+      consent_accepted_at: '2026-06-03T12:00:00.000Z',
+      age_confirmed_18_or_over: true,
       demographics: {
         age_group: '26-35',
         gender: 'prefer_not_to_say',
@@ -160,6 +165,13 @@ test('buildDatabuilderSidecar creates root-level databuilder fields', () => {
   assert.equal(sidecar.collection.session_id, 'session-123');
   assert.equal(sidecar.collection.phrase_id, 'yes_kylla');
   assert.equal(sidecar.collection.semantic_label, 'yes');
+  assert.deepEqual(sidecar.collection.consent, {
+    consent_response: 'yes',
+    consent_version: '1.0',
+    privacy_notice_version: '1.0',
+    consent_accepted_at: '2026-06-03T12:00:00.000Z',
+    age_confirmed_18_or_over: true,
+  });
   assert.equal(sidecar.storage.storage_key, 'session-123/short_finnish_responses_v1_0001_kylla.wav');
   assert.equal(
     sidecar.storage.metadata_object_key,
@@ -195,6 +207,7 @@ test('required sidecar keys always exist for original recordings', () => {
   assert.equal(Object.hasOwn(sidecar, 'environment'), true);
   assert.equal(Object.hasOwn(sidecar, 'technical'), true);
   assert.equal(Object.hasOwn(sidecar, 'collection'), true);
+  assert.equal(Object.hasOwn(sidecar.collection, 'consent'), true);
   assert.equal(Object.hasOwn(sidecar, 'storage'), true);
   assert.equal(Object.hasOwn(sidecar, 'speaker_id'), true);
   assert.equal(Object.hasOwn(sidecar, 'device_id'), true);

--- a/scripts/aina/exportDataset.js
+++ b/scripts/aina/exportDataset.js
@@ -7,11 +7,13 @@ import { fileURLToPath } from 'url';
 
 import {
   getCollectionAudioPrefix,
+  getDatasetValidationFilter,
   getSessionIdleTimeoutHours,
   getSoundRecordingsRoot,
 } from '../../backend/src/config.js';
 
 const { Client } = pkg;
+const VALIDATION_STATUSES = new Set(['pending', 'validated', 'needs_review', 'rejected']);
 
 export function configValue(name, fallback) {
   return process.env[name] || fallback;
@@ -120,6 +122,69 @@ export function getSemanticLabel(row) {
   return row.recording_metadata?.semantic_label || row.task_metadata?.semantic_label || null;
 }
 
+export function getRecordingValidationStatus(row) {
+  const status = row.recording_metadata?.validation?.status;
+  return VALIDATION_STATUSES.has(status) ? status : 'pending';
+}
+
+export function isRowExportableByValidationFilter(row, validationFilter = getDatasetValidationFilter()) {
+  const status = getRecordingValidationStatus(row);
+
+  if (validationFilter === 'all') {
+    return true;
+  }
+
+  if (validationFilter === 'not_rejected') {
+    return status !== 'rejected';
+  }
+
+  return status === 'validated';
+}
+
+export function filterRowsForValidation(rows, validationFilter = getDatasetValidationFilter()) {
+  const exportRows = [];
+  const skippedCounts = {
+    pending: 0,
+    needs_review: 0,
+    rejected: 0,
+    validated: 0,
+  };
+
+  for (const row of rows) {
+    if (isRowExportableByValidationFilter(row, validationFilter)) {
+      exportRows.push(row);
+      continue;
+    }
+
+    const status = getRecordingValidationStatus(row);
+    skippedCounts[status] = (skippedCounts[status] || 0) + 1;
+  }
+
+  return {
+    validationFilter,
+    exportRows,
+    skippedCounts,
+    skippedRowCount: rows.length - exportRows.length,
+  };
+}
+
+export function buildValidationFilterSummary({ validationFilter, skippedCounts, skippedRowCount }) {
+  if (!skippedRowCount) {
+    return null;
+  }
+
+  const skippedSummary = Object.entries(skippedCounts)
+    .filter(([, count]) => count > 0)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([status, count]) => `${status}=${count}`)
+    .join(', ');
+
+  return (
+    `Skipped ${skippedRowCount} recording(s) due to DATASET_VALIDATION_FILTER=` +
+    `${validationFilter}: ${skippedSummary}.`
+  );
+}
+
 export function buildDatasetMetadata(rows, labels, audioRoot) {
   return {
     dataset_id: configValue('DATASET_ID', 'short_finnish_responses'),
@@ -188,6 +253,11 @@ export function buildSample(row, index, dataset) {
         ...recordingTechnical,
       },
       processed_audio: recordingMetadata.processed_audio || null,
+      validation: {
+        status: getRecordingValidationStatus(row),
+        validated_at: recordingMetadata.validation?.validated_at || null,
+        notes: recordingMetadata.validation?.notes || null,
+      },
       collection: {
         topic_id: row.topic_id,
         task_id: row.task_id,
@@ -334,7 +404,13 @@ export async function exportDataset() {
       fetchLabelVocabulary(client),
     ]);
 
-    const storageFilter = filterRowsForActiveStorage(rows);
+    const validationFilter = filterRowsForValidation(rows);
+    const validationSummary = buildValidationFilterSummary(validationFilter);
+    if (validationSummary) {
+      console.warn(validationSummary);
+    }
+
+    const storageFilter = filterRowsForActiveStorage(validationFilter.exportRows);
     const storageSummary = buildStorageFilterSummary(storageFilter);
     if (storageSummary) {
       console.warn(storageSummary);

--- a/scripts/aina/exportDataset.js
+++ b/scripts/aina/exportDataset.js
@@ -208,6 +208,21 @@ export function buildDatasetMetadata(rows, labels, audioRoot) {
   };
 }
 
+export function buildConsentGovernanceMetadata(sessionMetadata = {}) {
+  return {
+    consent_response: sessionMetadata.consent_response || null,
+    consent_version: sessionMetadata.consent_version || null,
+    privacy_notice_version: sessionMetadata.privacy_notice_version || null,
+    consent_accepted_at: sessionMetadata.consent_accepted_at || null,
+    age_confirmed_18_or_over:
+      sessionMetadata.age_confirmed_18_or_over === true
+        ? true
+        : sessionMetadata.age_confirmed_18_or_over === false
+          ? false
+          : null,
+  };
+}
+
 export function buildSample(row, index, dataset) {
   const sampleId = getSampleId(row, index);
   const recordingMetadata = row.recording_metadata || {};
@@ -268,6 +283,7 @@ export function buildSample(row, index, dataset) {
         category,
         phrase_id: phraseId,
         semantic_label: semanticLabel,
+        consent: buildConsentGovernanceMetadata(sessionMetadata),
       },
       storage: {
         storage_type: row.storage_type,

--- a/scripts/aina/exportDataset.test.js
+++ b/scripts/aina/exportDataset.test.js
@@ -218,6 +218,11 @@ test('buildSample uses recording id and v1 labels in the manifest row', () => {
       session_metadata: {
         schema_version: 'v1',
         device_id: 'device-123',
+        consent_response: 'yes',
+        consent_version: '1.0',
+        privacy_notice_version: '1.0',
+        consent_accepted_at: '2026-06-03T12:00:00.000Z',
+        age_confirmed_18_or_over: true,
         demographics: {
           age_group: '26-35',
           gender: 'prefer_not_to_say',
@@ -295,6 +300,13 @@ test('buildSample uses recording id and v1 labels in the manifest row', () => {
   assert.equal(sample.metadata.collection.session_status, 'completed');
   assert.equal(sample.metadata.collection.phrase_id, 'yes_kylla');
   assert.equal(sample.metadata.collection.semantic_label, 'yes');
+  assert.deepEqual(sample.metadata.collection.consent, {
+    consent_response: 'yes',
+    consent_version: '1.0',
+    privacy_notice_version: '1.0',
+    consent_accepted_at: '2026-06-03T12:00:00.000Z',
+    age_confirmed_18_or_over: true,
+  });
 });
 
 test('buildSample keeps legacy semantic fields nullable', () => {
@@ -326,6 +338,13 @@ test('buildSample keeps legacy semantic fields nullable', () => {
   assert.equal(sample.semantic_label, null);
   assert.equal(sample.metadata.collection.phrase_id, null);
   assert.equal(sample.metadata.collection.semantic_label, null);
+  assert.deepEqual(sample.metadata.collection.consent, {
+    consent_response: null,
+    consent_version: null,
+    privacy_notice_version: null,
+    consent_accepted_at: null,
+    age_confirmed_18_or_over: null,
+  });
 });
 
 test('speaker id is stable for the same device id across sessions', () => {

--- a/scripts/aina/exportDataset.test.js
+++ b/scripts/aina/exportDataset.test.js
@@ -3,10 +3,13 @@ import assert from 'node:assert/strict';
 import path from 'path';
 
 import {
+  buildValidationFilterSummary,
   buildStorageFilterSummary,
   buildSample,
   buildDatasetMetadata,
   filterRowsForActiveStorage,
+  filterRowsForValidation,
+  getRecordingValidationStatus,
   inferAudioRoot,
   pseudonymizeDeviceId,
   pseudonymizeSpeaker,
@@ -137,6 +140,70 @@ test('mixed local and aws-s3 rows export only the active storage_type', () => {
   assert.equal(dataset.audio_root, path.join(getSpeechCollectorRoot(), 'tmp', 'recordings'));
   assert.equal(samples[0].sample_id, 'recording-local');
   assert.equal(samples[0].audio_path, localRow.storage_key);
+});
+
+test('default validation filter exports only validated rows', () => {
+  delete process.env.DATASET_VALIDATION_FILTER;
+  const pendingRow = { recording_id: 'pending', recording_metadata: {} };
+  const needsReviewRow = {
+    recording_id: 'needs-review',
+    recording_metadata: { validation: { status: 'needs_review' } },
+  };
+  const rejectedRow = {
+    recording_id: 'rejected',
+    recording_metadata: { validation: { status: 'rejected' } },
+  };
+  const validatedRow = {
+    recording_id: 'validated',
+    recording_metadata: { validation: { status: 'validated' } },
+  };
+
+  const result = filterRowsForValidation([
+    pendingRow,
+    needsReviewRow,
+    rejectedRow,
+    validatedRow,
+  ]);
+
+  assert.deepEqual(result.exportRows, [validatedRow]);
+  assert.equal(result.validationFilter, 'validated');
+  assert.equal(result.skippedCounts.pending, 1);
+  assert.equal(result.skippedCounts.needs_review, 1);
+  assert.equal(result.skippedCounts.rejected, 1);
+  assert.equal(getRecordingValidationStatus(pendingRow), 'pending');
+});
+
+test('not_rejected validation filter excludes only rejected rows', () => {
+  const rows = [
+    { recording_id: 'pending', recording_metadata: {} },
+    { recording_id: 'needs-review', recording_metadata: { validation: { status: 'needs_review' } } },
+    { recording_id: 'validated', recording_metadata: { validation: { status: 'validated' } } },
+    { recording_id: 'rejected', recording_metadata: { validation: { status: 'rejected' } } },
+  ];
+
+  const result = filterRowsForValidation(rows, 'not_rejected');
+
+  assert.deepEqual(
+    result.exportRows.map((row) => row.recording_id),
+    ['pending', 'needs-review', 'validated']
+  );
+  assert.equal(result.skippedCounts.rejected, 1);
+  assert.equal(
+    buildValidationFilterSummary(result),
+    'Skipped 1 recording(s) due to DATASET_VALIDATION_FILTER=not_rejected: rejected=1.'
+  );
+});
+
+test('all validation filter exports every otherwise eligible row', () => {
+  const rows = [
+    { recording_id: 'pending', recording_metadata: {} },
+    { recording_id: 'rejected', recording_metadata: { validation: { status: 'rejected' } } },
+  ];
+
+  const result = filterRowsForValidation(rows, 'all');
+
+  assert.deepEqual(result.exportRows, rows);
+  assert.equal(buildValidationFilterSummary(result), null);
 });
 
 test('buildSample uses recording id and v1 labels in the manifest row', () => {

--- a/scripts/aina/hashAdminPassword.js
+++ b/scripts/aina/hashAdminPassword.js
@@ -1,0 +1,104 @@
+import { stdin, stderr, stdout, exit } from 'process';
+
+import { createAdminPasswordHash } from '../../backend/src/admin.js';
+
+function printUsage() {
+  stderr.write(
+    [
+      'Usage:',
+      '  pnpm run admin:hash-password',
+      '  pnpm run admin:hash-password -- --stdin',
+      '',
+      'The generated hash is printed to stdout. The plaintext password is never printed.',
+      '',
+    ].join('\n')
+  );
+}
+
+async function readAllStdin() {
+  stdin.setEncoding('utf-8');
+  let value = '';
+
+  for await (const chunk of stdin) {
+    value += chunk;
+  }
+
+  return value.replace(/\r?\n$/, '');
+}
+
+function readHiddenLine(prompt) {
+  return new Promise((resolve, reject) => {
+    if (!stdin.isTTY) {
+      reject(new Error('Interactive password prompt requires a TTY. Use --stdin instead.'));
+      return;
+    }
+
+    stderr.write(prompt);
+    stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding('utf-8');
+    let value = '';
+
+    function cleanup() {
+      stdin.setRawMode(false);
+      stdin.pause();
+      stdin.off('data', onData);
+      stderr.write('\n');
+    }
+
+    function onData(chunk) {
+      for (const char of chunk) {
+        if (char === '\u0003') {
+          cleanup();
+          reject(new Error('Password prompt cancelled.'));
+          return;
+        }
+
+        if (char === '\r' || char === '\n') {
+          cleanup();
+          resolve(value);
+          return;
+        }
+
+        if (char === '\b' || char === '\u007f') {
+          value = value.slice(0, -1);
+          return;
+        }
+
+        value += char;
+      }
+    }
+
+    stdin.on('data', onData);
+  });
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  let password;
+  if (args.includes('--stdin')) {
+    password = await readAllStdin();
+  } else {
+    const first = await readHiddenLine('Admin password: ');
+    const second = await readHiddenLine('Confirm admin password: ');
+    if (first !== second) {
+      throw new Error('Passwords did not match.');
+    }
+    password = first;
+  }
+
+  const hash = await createAdminPasswordHash(password);
+  stdout.write(`${hash}\n`);
+}
+
+try {
+  await main();
+} catch (error) {
+  stderr.write(`${error instanceof Error ? error.message : 'Could not generate hash.'}\n`);
+  exit(1);
+}


### PR DESCRIPTION
﻿## Summary

Fixes iPhone/Safari recording preview playback by preserving the browser-native MediaRecorder MIME/container instead of forcing uploads to `audio/wav`.

- Selects a supported recording MIME type per browser capability.
- Uses MP4/AAC-style `.m4a` uploads for iPhone/Safari when supported.
- Keeps WebM/Opus uploads for Chrome/Android where supported.
- Preserves the real recorder Blob instead of fetching and relabeling the object URL.
- Keeps backend storage/training invariant unchanged: final processed audio remains WAV, 16 kHz, mono, signed 16-bit PCM.

## Validation

- Real-device iPhone 13 Pro Max test passed: record, preview playback, upload, admin playback.
- Original affected volunteer device was iPhone 11, same iOS/Safari media path.
- iPhone diagnostic evidence: `audio/mp4;codecs=mp4a.40.2`, `.m4a`, `canPlayType: probably`, duration ~4s.
- `corepack pnpm run test:backend` passed: 78/78.
- `node --test frontend/utils/recordingMime.test.mjs` passed: 9/9.
- targeted frontend ESLint passed.
- `corepack pnpm --filter sound-collector-frontend build` passed.
- `corepack pnpm --filter sound-collector-frontend lint` passed.
- `git diff --check` passed.

## Safety

No database schema change, no R2/storage contract change, no production deploy, no production env edits.
