### PR TITLE
Fix iOS recording playback MIME handling

### DIFF
--- a/backend/src/fileStorage.test.js
+++ b/backend/src/fileStorage.test.js
@@ -1,7 +1,11 @@
 import fs from 'fs';
 import path from 'path';
+import { execFile } from 'node:child_process';
 import test, { afterEach } from 'node:test';
 import assert from 'node:assert/strict';
+import { promisify } from 'node:util';
+import ffmpegPath from 'ffmpeg-static';
+import ffprobe from 'ffprobe-static';
 
 import { inferAudioRoot } from '../../scripts/aina/exportDataset.js';
 import { getSpeechCollectorRoot, getSoundRecordingsRoot } from './config.js';
@@ -15,6 +19,7 @@ import {
 
 const originalEnv = { ...process.env };
 const cleanupPaths = [];
+const execFileAsync = promisify(execFile);
 
 afterEach(() => {
   for (const key of Object.keys(process.env)) {
@@ -41,6 +46,52 @@ test('buildRecordingStorageKey uses a unique session/task/recording layout', () 
   );
 });
 
+async function generateTinyAudioFixture(outputPath, outputOptions) {
+  try {
+    await execFileAsync(ffmpegPath, [
+      '-hide_banner',
+      '-loglevel',
+      'error',
+      '-f',
+      'lavfi',
+      '-i',
+      'sine=frequency=440:duration=0.25',
+      ...outputOptions,
+      '-y',
+      outputPath,
+    ]);
+  } catch (error) {
+    const stderr = typeof error?.stderr === 'string' ? error.stderr.trim() : '';
+    throw new Error(stderr || error.message);
+  }
+}
+
+async function probeAudioFile(inputPath) {
+  const { stdout } = await execFileAsync(ffprobe.path, [
+    '-v',
+    'error',
+    '-select_streams',
+    'a:0',
+    '-show_entries',
+    'stream=codec_name,sample_rate,channels',
+    '-of',
+    'json',
+    inputPath,
+  ]);
+
+  return JSON.parse(stdout).streams?.[0] || {};
+}
+
+async function assertReencodedFixture(inputPath) {
+  const storage = new FileStorage('local');
+  await storage.reencodeFile(inputPath);
+
+  const metadata = await probeAudioFile(inputPath);
+  assert.equal(metadata.codec_name, 'pcm_s16le');
+  assert.equal(metadata.sample_rate, '16000');
+  assert.equal(metadata.channels, 1);
+}
+
 test('buildMetadataSidecarStorageKey replaces wav extension with json', () => {
   assert.equal(
     buildMetadataSidecarStorageKey('session-123/task-456/recording-789.wav'),
@@ -59,6 +110,38 @@ test('processed audio ffmpeg options enforce 16 kHz mono PCM WAV', () => {
     channel_count: 1,
     encoding: 'pcm_s16le',
   });
+});
+
+test('reencodeFile normalizes WebM Opus input to 16 kHz mono PCM audio', async () => {
+  const appRoot = getSpeechCollectorRoot();
+  const testParent = path.join(appRoot, 'tmp');
+  fs.mkdirSync(testParent, { recursive: true });
+
+  const tempRoot = fs.mkdtempSync(path.join(testParent, 'webm-reencode-root-'));
+  cleanupPaths.push(tempRoot);
+
+  const inputPath = path.join(tempRoot, 'browser-webm-bytes-in-wav-temp-file.wav');
+  process.env.STORAGE = 'local';
+  process.env.SOUND_RECORDINGS_PATH = path.relative(appRoot, path.join(tempRoot, 'recordings'));
+
+  await generateTinyAudioFixture(inputPath, ['-c:a', 'libopus', '-f', 'webm']);
+  await assertReencodedFixture(inputPath);
+});
+
+test('reencodeFile normalizes MP4 AAC input to 16 kHz mono PCM audio', async () => {
+  const appRoot = getSpeechCollectorRoot();
+  const testParent = path.join(appRoot, 'tmp');
+  fs.mkdirSync(testParent, { recursive: true });
+
+  const tempRoot = fs.mkdtempSync(path.join(testParent, 'mp4-reencode-root-'));
+  cleanupPaths.push(tempRoot);
+
+  const inputPath = path.join(tempRoot, 'browser-mp4-bytes-in-wav-temp-file.wav');
+  process.env.STORAGE = 'local';
+  process.env.SOUND_RECORDINGS_PATH = path.relative(appRoot, path.join(tempRoot, 'recordings'));
+
+  await generateTinyAudioFixture(inputPath, ['-c:a', 'aac', '-f', 'mp4']);
+  await assertReencodedFixture(inputPath);
 });
 
 test('relative SOUND_RECORDINGS_PATH resolves from the speech-collector root in backend and exporter', () => {

--- a/backend/src/index.test.js
+++ b/backend/src/index.test.js
@@ -60,8 +60,10 @@ function createProvider(overrides = {}) {
         categories: [],
       };
     },
-    async submitRecording(_sessionToken, _taskId, recordingDetails) {
+    async submitRecording(sessionToken, taskId, recordingDetails) {
       this.submitRecordingCalls += 1;
+      this.lastSubmitSessionToken = sessionToken;
+      this.lastSubmitTaskId = taskId;
       this.lastRecordingDetails = recordingDetails;
       return { success: true, sessionStatus: 'active' };
     },
@@ -72,8 +74,9 @@ function createProvider(overrides = {}) {
 function createFileStorage(overrides = {}) {
   return {
     saveRecordingCalls: 0,
-    async saveRecording(_file, options) {
+    async saveRecording(file, options) {
       this.saveRecordingCalls += 1;
+      this.lastFile = file;
       this.lastSaveOptions = options;
       const storageKey = `${options.sessionId}/${options.taskId}/${options.recordingId}.wav`;
       return {
@@ -108,7 +111,12 @@ async function withServer(app, run) {
   }
 }
 
-function createUploadForm({ metadata = undefined, fileBytes = 'wav-data' } = {}) {
+function createUploadForm({
+  metadata = undefined,
+  fileBytes = 'wav-data',
+  fileType = 'audio/wav',
+  filename = 'task-123.wav',
+} = {}) {
   const form = new FormData();
   form.set('sessionToken', 'session-token');
   form.set('taskId', 'task-123');
@@ -116,7 +124,7 @@ function createUploadForm({ metadata = undefined, fileBytes = 'wav-data' } = {})
     form.set('metadata', metadata);
   }
 
-  form.set('file', new Blob([fileBytes], { type: 'audio/wav' }), 'task-123.wav');
+  form.set('file', new Blob([fileBytes], { type: fileType }), filename);
   return form;
 }
 
@@ -351,9 +359,18 @@ test('session metadata guard rejection prevents storage and DB submit', async ()
     const response = await fetch(`${baseUrl}/api/upload-sound`, {
       method: 'POST',
       body: createUploadForm({
+        fileType: 'audio/webm;codecs=opus',
+        filename: 'task-123.webm',
         metadata: JSON.stringify({
-          literal_transcript: null,
-          label_source: 'prompt_assumed',
+          literal_transcript: 'kyl',
+          label_source: 'user_confirmed',
+          technical: {
+            sample_rate_hz: 48000,
+            channel_count: 1,
+            media_stream_settings: {
+              echoCancellation: true,
+            },
+          },
         }),
       }),
     });
@@ -381,9 +398,18 @@ test('upload continues past upload target when session metadata is valid', async
     const response = await fetch(`${baseUrl}/api/upload-sound`, {
       method: 'POST',
       body: createUploadForm({
+        fileType: 'audio/webm;codecs=opus',
+        filename: 'task-123.webm',
         metadata: JSON.stringify({
-          literal_transcript: null,
-          label_source: 'prompt_assumed',
+          literal_transcript: 'kyl',
+          label_source: 'user_confirmed',
+          technical: {
+            sample_rate_hz: 48000,
+            channel_count: 1,
+            media_stream_settings: {
+              echoCancellation: true,
+            },
+          },
         }),
       }),
     });
@@ -394,6 +420,12 @@ test('upload continues past upload target when session metadata is valid', async
     assert.equal(provider.getUploadTargetCalls, 1);
     assert.equal(fileStorage.saveRecordingCalls, 1);
     assert.equal(provider.submitRecordingCalls, 1);
+    assert.equal(provider.lastSubmitSessionToken, 'session-token');
+    assert.equal(provider.lastSubmitTaskId, 'task-123');
+    assert.equal(fileStorage.lastSaveOptions.sessionId, 'session-123');
+    assert.equal(fileStorage.lastSaveOptions.taskId, 'task-123');
+    assert.equal(fileStorage.lastFile.originalname, 'task-123.webm');
+    assert.equal(fileStorage.lastFile.mimetype, 'audio/webm');
     assert.match(fileStorage.lastSaveOptions.recordingId, /^[0-9a-f-]{36}$/);
     assert.equal(provider.lastRecordingDetails.recordingId, fileStorage.lastSaveOptions.recordingId);
     assert.equal(
@@ -402,6 +434,15 @@ test('upload continues past upload target when session metadata is valid', async
     );
     assert.equal(provider.lastRecordingDetails.metadata.phrase_id, 'yes_kylla');
     assert.equal(provider.lastRecordingDetails.metadata.semantic_label, 'yes');
+    assert.equal(provider.lastRecordingDetails.metadata.literal_transcript, 'kyl');
+    assert.equal(provider.lastRecordingDetails.metadata.label_source, 'user_confirmed');
+    assert.deepEqual(provider.lastRecordingDetails.metadata.technical, {
+      sample_rate_hz: 48000,
+      channel_count: 1,
+      media_stream_settings: {
+        echoCancellation: true,
+      },
+    });
     assert.deepEqual(provider.lastRecordingDetails.metadata.processed_audio, {
       sample_rate_hz: 16000,
       channel_count: 1,

--- a/frontend/components/SoundRecorder.tsx
+++ b/frontend/components/SoundRecorder.tsx
@@ -1,14 +1,29 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useReactMediaRecorder } from "react-media-recorder";
 
+import {
+  buildRecordingUploadFile,
+  getActualRecordingMimeType,
+  getAudioFileExtension,
+  selectRecordingMimeType,
+} from "../utils/recordingMime";
+import type { SessionState, SessionStatus } from "../types/session";
 import { getAudioTrackTechnicalMetadata } from "../utils/technicalMetadata";
 import "./SoundRecorder.css";
+
+interface UploadSoundResult {
+  success?: boolean;
+  message?: string;
+  session?: SessionState;
+  sessionStatus?: SessionStatus;
+  [key: string]: unknown;
+}
 
 interface SoundRecorderProps {
   sessionToken: string | null;
   taskId: string;
   promptedWord: string;
-  onUploadComplete: (result: any) => Promise<void> | void;
+  onUploadComplete: (result: UploadSoundResult) => Promise<void> | void;
   onNextTask?: () => Promise<void> | void;
   nextActionLabel?: string;
 }
@@ -28,6 +43,33 @@ const SoundRecorder = ({
   onNextTask,
   nextActionLabel = "Next prompt",
 }: SoundRecorderProps) => {
+  const selectedRecordingMimeType = useMemo(() => selectRecordingMimeType(), []);
+  const mediaDebugEnabled = useMemo(() => {
+    if (!import.meta.env.DEV || typeof window === "undefined") {
+      return false;
+    }
+
+    return new URLSearchParams(window.location.search).get("mediaDebug") === "1";
+  }, []);
+  const mediaRecorderOptions = useMemo<MediaRecorderOptions | undefined>(
+    () =>
+      selectedRecordingMimeType
+        ? {
+            mimeType: selectedRecordingMimeType,
+          }
+        : undefined,
+    [selectedRecordingMimeType]
+  );
+  const blobPropertyBag = useMemo<BlobPropertyBag>(() => ({}), []);
+  const [recordingBlob, setRecordingBlob] = useState<Blob | null>(null);
+  const [playbackMessage, setPlaybackMessage] = useState<string>("");
+  const logMediaDebug = (event: string, payload: Record<string, unknown>) => {
+    if (!mediaDebugEnabled) {
+      return;
+    }
+
+    console.info("[mediaDebug]", event, payload);
+  };
   const {
     error: recorderError,
     status,
@@ -39,6 +81,21 @@ const SoundRecorder = ({
   } = useReactMediaRecorder({
     audio: true,
     video: false,
+    mediaRecorderOptions,
+    blobPropertyBag,
+    onStop: (_blobUrl, blob) => {
+      const actualMimeType = getActualRecordingMimeType(blob.type, [], selectedRecordingMimeType);
+      const typedBlob =
+        actualMimeType && blob.type !== actualMimeType ? new Blob([blob], { type: actualMimeType }) : blob;
+
+      logMediaDebug("recording-stopped", {
+        selectedMimeType: selectedRecordingMimeType || null,
+        actualBlobMimeType: typedBlob.type || null,
+        blobSize: typedBlob.size,
+        extension: getAudioFileExtension(typedBlob.type),
+      });
+      setRecordingBlob(typedBlob);
+    },
   });
   const [taskDone, setTaskDone] = useState<boolean>(false);
   const [soundUploading, setSoundUploading] = useState<boolean>(false);
@@ -57,6 +114,8 @@ const SoundRecorder = ({
     stopRecordingRef.current = stopRecording;
   }, [clearBlobUrl, stopRecording]);
 
+  useEffect(() => () => clearBlobUrlRef.current(), []);
+
   useEffect(() => {
     setTaskDone(false);
     setSoundUploading(false);
@@ -65,6 +124,8 @@ const SoundRecorder = ({
     setElapsedSeconds(0);
     setTranscriptMode("same");
     setLiteralTranscript("");
+    setRecordingBlob(null);
+    setPlaybackMessage("");
     clearBlobUrlRef.current();
   }, [taskId]);
 
@@ -101,6 +162,8 @@ const SoundRecorder = ({
 
   const handleStartRecording = () => {
     clearBlobUrl();
+    setRecordingBlob(null);
+    setPlaybackMessage("");
     setTaskDone(false);
     setUploadFailed(false);
     setUploadMessage("");
@@ -123,12 +186,12 @@ const SoundRecorder = ({
     };
   };
 
-  const uploadSound = async () => {
+  const uploadSound = async (): Promise<UploadSoundResult> => {
     if (!sessionToken) {
       throw new Error("A session token is required before uploading.");
     }
 
-    if (!mediaBlobUrl) {
+    if (!recordingBlob || recordingBlob.size === 0) {
       throw new Error("Record audio before uploading.");
     }
 
@@ -137,8 +200,7 @@ const SoundRecorder = ({
     formData.append("taskId", taskId);
     formData.append("metadata", JSON.stringify(buildUploadMetadata()));
 
-    const blob = await fetch(mediaBlobUrl).then((response) => response.blob());
-    const file = new File([blob], `${taskId}.wav`, { type: "audio/wav" });
+    const file = buildRecordingUploadFile(recordingBlob, taskId);
     formData.append("file", file);
 
     const response = await fetch(`${apiUrl}/api/upload-sound`, {
@@ -146,7 +208,7 @@ const SoundRecorder = ({
       body: formData,
     });
 
-    const data = await response.json();
+    const data = (await response.json()) as UploadSoundResult;
     if (!data.success) {
       throw new Error(data.message || "Could not upload the recording.");
     }
@@ -159,7 +221,50 @@ const SoundRecorder = ({
       <div className="recorder-preview">
         {mediaBlobUrl ? (
           <>
-            <audio src={mediaBlobUrl} controls />
+            <audio
+              key={mediaBlobUrl}
+              controls
+              preload="metadata"
+              onCanPlay={() => setPlaybackMessage("")}
+              onLoadedMetadata={(event) => {
+                setPlaybackMessage("");
+                logMediaDebug("audio-loadedmetadata", {
+                  blobMimeType: recordingBlob?.type || null,
+                  canPlayType: recordingBlob?.type
+                    ? event.currentTarget.canPlayType(recordingBlob.type)
+                    : "",
+                  duration: event.currentTarget.duration,
+                });
+              }}
+              onStalled={() => {
+                logMediaDebug("audio-stalled", {
+                  blobMimeType: recordingBlob?.type || null,
+                  blobSize: recordingBlob?.size ?? null,
+                });
+                setPlaybackMessage("Playback is still loading. If it does not start, try re-recording.");
+              }}
+              onError={(event) => {
+                const audioError = event.currentTarget.error;
+                logMediaDebug("audio-error", {
+                  blobMimeType: recordingBlob?.type || null,
+                  canPlayType: recordingBlob?.type
+                    ? event.currentTarget.canPlayType(recordingBlob.type)
+                    : "",
+                  errorCode: audioError?.code ?? null,
+                  errorMessage: audioError?.message || null,
+                });
+                setPlaybackMessage(
+                  audioError
+                    ? `Playback could not load on this device. Error code: ${audioError.code}.`
+                    : "Playback could not load on this device. Try re-recording before upload."
+                );
+              }}
+            >
+              <source src={mediaBlobUrl} type={recordingBlob?.type || undefined} />
+            </audio>
+            {playbackMessage && (
+              <p className="app-inline-message app-inline-message--error">{playbackMessage}</p>
+            )}
             <div className="recorder-transcript">
               <span>What did you actually say?</span>
               <div className="recorder-transcript__options">
@@ -243,6 +348,8 @@ const SoundRecorder = ({
               setUploadMessage("");
               const result = await uploadSound();
               setTaskDone(Boolean(onNextTask) && result.sessionStatus !== "completed");
+              setRecordingBlob(null);
+              setPlaybackMessage("");
               clearBlobUrlRef.current();
               setUploadMessage("Recording saved.");
               await onUploadComplete(result);
@@ -255,7 +362,7 @@ const SoundRecorder = ({
               setSoundUploading(false);
             }
           }}
-          disabled={status !== "stopped" || !mediaBlobUrl || soundUploading}
+          disabled={status !== "stopped" || !recordingBlob || recordingBlob.size === 0 || soundUploading}
         >
           {soundUploading ? "Uploading..." : "Upload"}
         </button>

--- a/frontend/utils/recordingMime.test.mjs
+++ b/frontend/utils/recordingMime.test.mjs
@@ -1,0 +1,111 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildRecordingUploadFile,
+  getActualRecordingMimeType,
+  getAudioFileExtension,
+  selectRecordingMimeType,
+} from "./recordingMime.ts";
+
+function mediaRecorderWithSupport(supportedTypes) {
+  const supported = new Set(supportedTypes);
+  return {
+    isTypeSupported: (mimeType) => supported.has(mimeType),
+  };
+}
+
+test("iPhone/WebKit capability set selects MP4/AAC first", () => {
+  const navigatorLike = {
+    userAgent:
+      "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1",
+    platform: "iPhone",
+    maxTouchPoints: 5,
+  };
+
+  assert.equal(
+    selectRecordingMimeType(
+      mediaRecorderWithSupport(["audio/mp4;codecs=mp4a.40.2", "audio/webm;codecs=opus"]),
+      navigatorLike
+    ),
+    "audio/mp4;codecs=mp4a.40.2"
+  );
+});
+
+test("Android/Chrome capability set selects WebM/Opus first", () => {
+  const navigatorLike = {
+    userAgent:
+      "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Mobile Safari/537.36",
+    platform: "Linux armv8l",
+    maxTouchPoints: 5,
+  };
+
+  assert.equal(
+    selectRecordingMimeType(
+      mediaRecorderWithSupport(["audio/mp4;codecs=mp4a.40.2", "audio/webm;codecs=opus"]),
+      navigatorLike
+    ),
+    "audio/webm;codecs=opus"
+  );
+});
+
+test("MP4 is selected when WebM is unsupported", () => {
+  assert.equal(
+    selectRecordingMimeType(mediaRecorderWithSupport(["audio/mp4"]), {
+      userAgent: "Mozilla/5.0 Chrome/126.0 Safari/537.36",
+      platform: "Win32",
+      maxTouchPoints: 0,
+    }),
+    "audio/mp4"
+  );
+});
+
+test("unsupported candidates and unavailable MediaRecorder fall back to browser default", () => {
+  assert.equal(selectRecordingMimeType(mediaRecorderWithSupport([])), undefined);
+  assert.equal(selectRecordingMimeType(undefined), undefined);
+});
+
+test("actual recorder or chunk MIME type is preferred over fallback", () => {
+  assert.equal(
+    getActualRecordingMimeType("audio/webm;codecs=opus", [], "audio/mp4"),
+    "audio/webm;codecs=opus"
+  );
+  assert.equal(
+    getActualRecordingMimeType("", [new Blob(["x"], { type: "audio/ogg;codecs=opus" })], "audio/mp4"),
+    "audio/ogg;codecs=opus"
+  );
+  assert.equal(getActualRecordingMimeType("", [], "audio/mp4"), "audio/mp4");
+});
+
+test("known MIME types map to matching upload extensions", () => {
+  assert.equal(getAudioFileExtension("audio/webm;codecs=opus"), "webm");
+  assert.equal(getAudioFileExtension("audio/webm"), "webm");
+  assert.equal(getAudioFileExtension("audio/mp4;codecs=mp4a.40.2"), "m4a");
+  assert.equal(getAudioFileExtension("audio/mp4"), "m4a");
+  assert.equal(getAudioFileExtension("audio/ogg;codecs=opus"), "ogg");
+  assert.equal(getAudioFileExtension("audio/wav"), "wav");
+});
+
+test("unknown and empty MIME types use a neutral fallback, not fake WAV", () => {
+  assert.equal(getAudioFileExtension(""), "bin");
+  assert.equal(getAudioFileExtension(undefined), "bin");
+  assert.equal(getAudioFileExtension("application/octet-stream"), "bin");
+});
+
+test("upload file uses original blob bytes, MIME, and matching extension", async () => {
+  const bytes = new Uint8Array([1, 2, 3, 4]);
+  const blob = new Blob([bytes], { type: "audio/webm;codecs=opus" });
+  const file = buildRecordingUploadFile(blob, "task-123");
+
+  assert.equal(file.name, "task-123.webm");
+  assert.equal(file.type, "audio/webm;codecs=opus");
+  assert.equal(file.size, blob.size);
+  assert.deepEqual(new Uint8Array(await file.arrayBuffer()), bytes);
+});
+
+test("upload file does not unconditionally use WAV for unknown blob types", () => {
+  const file = buildRecordingUploadFile(new Blob(["opaque-bytes"]), "task-123");
+
+  assert.equal(file.name, "task-123.bin");
+  assert.equal(file.type, "application/octet-stream");
+});

--- a/frontend/utils/recordingMime.ts
+++ b/frontend/utils/recordingMime.ts
@@ -1,0 +1,95 @@
+type MediaRecorderConstructorLike = {
+  isTypeSupported?: (mimeType: string) => boolean;
+};
+
+type NavigatorLike = {
+  userAgent?: string;
+  platform?: string;
+  maxTouchPoints?: number;
+};
+
+const MP4_AUDIO_TYPES = ["audio/mp4;codecs=mp4a.40.2", "audio/mp4"];
+const WEBM_AUDIO_TYPES = ["audio/webm;codecs=opus", "audio/webm"];
+const FALLBACK_AUDIO_TYPES = ["audio/ogg;codecs=opus", "audio/ogg", "audio/wav"];
+const UNKNOWN_AUDIO_UPLOAD_MIME_TYPE = "application/octet-stream";
+
+function getNavigatorLike(): NavigatorLike | undefined {
+  return typeof navigator === "undefined" ? undefined : navigator;
+}
+
+export function shouldPreferMp4Recording(navigatorLike: NavigatorLike | undefined = getNavigatorLike()) {
+  const userAgent = navigatorLike?.userAgent || "";
+  const platform = navigatorLike?.platform || "";
+  const maxTouchPoints = navigatorLike?.maxTouchPoints || 0;
+  const isiOS =
+    /iPad|iPhone|iPod/i.test(userAgent) || (platform === "MacIntel" && maxTouchPoints > 1);
+  const isSafari = /Safari/i.test(userAgent) && !/Chrome|Chromium|CriOS|FxiOS|Edg/i.test(userAgent);
+
+  return isiOS || isSafari;
+}
+
+export function getRecordingMimeTypeCandidates(
+  navigatorLike: NavigatorLike | undefined = getNavigatorLike()
+) {
+  return shouldPreferMp4Recording(navigatorLike)
+    ? [...MP4_AUDIO_TYPES, ...WEBM_AUDIO_TYPES, ...FALLBACK_AUDIO_TYPES]
+    : [...WEBM_AUDIO_TYPES, ...FALLBACK_AUDIO_TYPES, ...MP4_AUDIO_TYPES];
+}
+
+export function selectRecordingMimeType(
+  mediaRecorderConstructor: MediaRecorderConstructorLike | undefined =
+    typeof MediaRecorder === "undefined" ? undefined : MediaRecorder,
+  navigatorLike: NavigatorLike | undefined = getNavigatorLike()
+) {
+  if (!mediaRecorderConstructor?.isTypeSupported) {
+    return undefined;
+  }
+
+  return getRecordingMimeTypeCandidates(navigatorLike).find((mimeType) =>
+    mediaRecorderConstructor.isTypeSupported?.(mimeType)
+  );
+}
+
+export function getActualRecordingMimeType(
+  recorderMimeType: string | undefined,
+  chunks: Blob[],
+  fallbackMimeType: string | undefined
+) {
+  return (
+    recorderMimeType ||
+    chunks.find((chunk) => chunk.type)?.type ||
+    fallbackMimeType ||
+    ""
+  );
+}
+
+export function getAudioFileExtension(mimeType: string | undefined) {
+  const containerType = (mimeType || "").split(";")[0].trim().toLowerCase();
+
+  switch (containerType) {
+    case "audio/mp4":
+    case "video/mp4":
+      return "m4a";
+    case "audio/webm":
+    case "video/webm":
+      return "webm";
+    case "audio/ogg":
+      return "ogg";
+    case "audio/wav":
+    case "audio/wave":
+    case "audio/x-wav":
+      return "wav";
+    case "audio/aac":
+      return "aac";
+    case "audio/mpeg":
+      return "mp3";
+    default:
+      return "bin";
+  }
+}
+
+export function buildRecordingUploadFile(recordingBlob: Blob, taskId: string) {
+  return new File([recordingBlob], `${taskId}.${getAudioFileExtension(recordingBlob.type)}`, {
+    type: recordingBlob.type || UNKNOWN_AUDIO_UPLOAD_MIME_TYPE,
+  });
+}


### PR DESCRIPTION
﻿## Summary

Fixes iPhone/Safari recording preview playback by preserving the browser-native MediaRecorder MIME/container instead of forcing uploads to `audio/wav`.

- Selects a supported recording MIME type per browser capability.
- Uses MP4/AAC-style `.m4a` uploads for iPhone/Safari when supported.
- Keeps WebM/Opus uploads for Chrome/Android where supported.
- Preserves the real recorder Blob instead of fetching and relabeling the object URL.
- Keeps backend storage/training invariant unchanged: final processed audio remains WAV, 16 kHz, mono, signed 16-bit PCM.

## Validation

- Real-device iPhone 13 Pro Max test passed: record, preview playback, upload, admin playback.
- Original affected volunteer device was iPhone 11, same iOS/Safari media path.
- iPhone diagnostic evidence: `audio/mp4;codecs=mp4a.40.2`, `.m4a`, `canPlayType: probably`, duration ~4s.
- `corepack pnpm run test:backend` passed: 78/78.
- `node --test frontend/utils/recordingMime.test.mjs` passed: 9/9.
- targeted frontend ESLint passed.
- `corepack pnpm --filter sound-collector-frontend build` passed.
- `corepack pnpm --filter sound-collector-frontend lint` passed.
- `git diff --check` passed.

## Safety

No database schema change, no R2/storage contract change, no production deploy, no production env edits.
